### PR TITLE
Fixed access modifier for feeAsset, didn't work for pool pair at runtime

### DIFF
--- a/src/subdomains/supporting/dex/services/dex.service.ts
+++ b/src/subdomains/supporting/dex/services/dex.service.ts
@@ -202,7 +202,8 @@ export class DexService {
         console.info(
           `Liquidity purchase is ready. Order ID: ${order.id}. Context: ${order.context}. Correlation ID: ${order.correlationId}`,
         );
-      } catch {
+      } catch (e) {
+        console.error(`Error while trying to add purchase data to liquidity order. Order ID: ${order.id}`, e);
         continue;
       }
     }

--- a/src/subdomains/supporting/dex/strategies/check-liquidity/impl/base/check-liquidity.strategy.ts
+++ b/src/subdomains/supporting/dex/strategies/check-liquidity/impl/base/check-liquidity.strategy.ts
@@ -2,10 +2,10 @@ import { Asset } from 'src/shared/models/asset/asset.entity';
 import { CheckLiquidityResult, LiquidityRequest } from '../../../../interfaces';
 
 export abstract class CheckLiquidityStrategy {
-  #feeAsset: Asset;
+  private _feeAsset: Asset;
 
   async feeAsset(): Promise<Asset> {
-    return this.#feeAsset ?? this.getFeeAsset();
+    return (this._feeAsset ??= await this.getFeeAsset());
   }
 
   abstract checkLiquidity(request: LiquidityRequest): Promise<CheckLiquidityResult>;

--- a/src/subdomains/supporting/dex/strategies/purchase-liquidity/impl/base/purchase-liquidity.strategy.ts
+++ b/src/subdomains/supporting/dex/strategies/purchase-liquidity/impl/base/purchase-liquidity.strategy.ts
@@ -8,12 +8,12 @@ import { PriceSlippageException } from '../../../../exceptions/price-slippage.ex
 import { LiquidityRequest } from '../../../../interfaces';
 
 export abstract class PurchaseLiquidityStrategy {
-  #feeAsset: Asset;
+  private _feeAsset: Asset;
 
   constructor(protected readonly notificationService: NotificationService) {}
 
   async feeAsset(): Promise<Asset> {
-    return this.#feeAsset ?? this.getFeeAsset();
+    return (this._feeAsset ??= await this.getFeeAsset());
   }
 
   abstract purchaseLiquidity(request: LiquidityRequest): Promise<void>;

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/payout.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/payout.strategy.ts
@@ -3,10 +3,10 @@ import { Asset } from 'src/shared/models/asset/asset.entity';
 import { PayoutOrder } from '../../../../entities/payout-order.entity';
 
 export abstract class PayoutStrategy {
-  #feeAsset: Asset;
+  private _feeAsset: Asset;
 
   async feeAsset(): Promise<Asset> {
-    return this.#feeAsset ?? (await this.getFeeAsset());
+    return (this._feeAsset ??= await this.getFeeAsset());
   }
 
   abstract doPayout(orders: PayoutOrder[]): Promise<void>;

--- a/src/subdomains/supporting/payout/strategies/prepare/impl/base/prepare.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/prepare/impl/base/prepare.strategy.ts
@@ -3,10 +3,10 @@ import { Asset } from 'src/shared/models/asset/asset.entity';
 import { PayoutOrder } from '../../../../entities/payout-order.entity';
 
 export abstract class PrepareStrategy {
-  #feeAsset: Asset;
+  private _feeAsset: Asset;
 
   async feeAsset(): Promise<Asset> {
-    return this.#feeAsset ?? (await this.getFeeAsset());
+    return (this._feeAsset ??= await this.getFeeAsset());
   }
 
   abstract preparePayout(order: PayoutOrder): Promise<void>;


### PR DESCRIPTION
* NOTASK - fixed access modifier for feeAsset, didn't work for pool pairs at runtime

* NOTASK - shorter syntax for fee asset

### Release Checklist

#### Pre-Release

- [x] Check migrations
  - No database related infos (sqldb-xxx)
  - Impact on GS (new/removed columns)
- [x] Check for linter errors (in PR)
- [x] Test basic user operations
  - Login/logout
  - Registration
  - Update user data
  - Create/delete payment routes

#### Post-Release

- Test basic user operations
- Monitor application insights log
