### PR TITLE
[FIX] Add ZANO to PaymentLinkBlockchain configuration

### DIFF
--- a/src/integration/blockchain/shared/enums/blockchain.enum.ts
+++ b/src/integration/blockchain/shared/enums/blockchain.enum.ts
@@ -48,6 +48,7 @@ export const PaymentLinkBlockchain = {
   POLYGON: Blockchain.POLYGON,
   GNOSIS: Blockchain.GNOSIS,
   BITCOIN: Blockchain.BITCOIN,
+  ZANO: Blockchain.ZANO,
   BINANCE_PAY: Blockchain.BINANCE_PAY,
   KUCOIN_PAY: Blockchain.KUCOIN_PAY,
   SOLANA: Blockchain.SOLANA,


### PR DESCRIPTION
## Summary
- Added ZANO to the PaymentLinkBlockchain configuration to enable it as a payment method for payment links

## Problem
ZANO was not available as a payment option when accessing LNURLP endpoints (e.g., https://api.dfx.swiss/v1/lnurlp/pl_b9583c), even though the blockchain integration for ZANO exists in the codebase.

## Solution
Added `ZANO: Blockchain.ZANO` to the `PaymentLinkBlockchain` constant in `blockchain.enum.ts`, which allows ZANO to be configured as a valid payment method for payment links.

## Test plan
- [ ] Verify ZANO appears as an available payment method in LNURLP endpoints
- [ ] Test ZANO payment activation through payment links
- [ ] Ensure existing payment methods continue to work