### PR TITLE
[DEV-4347] Präzisierung der Phone-Verifikations-Regel

### DIFF
--- a/src/subdomains/core/aml/services/aml-helper.service.ts
+++ b/src/subdomains/core/aml/services/aml-helper.service.ts
@@ -82,6 +82,8 @@ export class AmlHelperService {
         errors.push(AmlError.VIDEO_IDENT_MISSING);
     }
     if (
+      entity instanceof BuyCrypto &&
+      (entity.bankTx || entity.checkoutTx) &&
       !entity.userData.phoneCallCheckDate &&
       entity.userData.phone &&
       entity.userData.birthday &&


### PR DESCRIPTION
## Ziel

Diese Änderung präzisiert die Anwendung der Telefonverifikations-Regel für User über 55 Jahre.

## Änderungen

Die phoneCallCheckDate-Verifikation wird **nur noch** bei folgenden Transaktionstypen angewendet:
- **BuyCrypto mit BankTx** (Banküberweisung → Crypto)
- **BuyCrypto mit CheckoutTx** (Kreditkarte → Crypto)

**Ausgeschlossen** sind nun:
- BuyCrypto mit CryptoInput (Crypto → Crypto Swaps)
- BuyFiat (Crypto → Fiat Verkäufe)

## Hintergrund

Die ursprüngliche Implementierung hätte die Regel auf alle Transaktionstypen angewendet. Diese Präzisierung stellt sicher, dass nur Fiat-zu-Crypto Käufe (über Bank oder Kreditkarte) von der verschärften Verifikation betroffen sind.

## Impact

- Betrifft nur Personal Accounts über 55 Jahre
- Gilt nur für nicht-aktive User
- Reduziert die Anzahl der betroffenen Transaktionen erheblich
- Crypto-zu-Crypto Swaps und Verkäufe bleiben unverändert

## Testing

- [ ] Verifiziert, dass BuyCrypto mit BankTx die Regel triggert
- [ ] Verifiziert, dass BuyCrypto mit CheckoutTx die Regel triggert  
- [ ] Verifiziert, dass BuyCrypto mit CryptoInput die Regel NICHT triggert
- [ ] Verifiziert, dass BuyFiat die Regel NICHT triggert