### PR TITLE
Fix secp256k1.verify TypeScript type error in auth-lnurl.service

### DIFF
--- a/src/subdomains/generic/user/models/auth/auth-lnurl.service.ts
+++ b/src/subdomains/generic/user/models/auth/auth-lnurl.service.ts
@@ -93,7 +93,11 @@ export class AuthLnUrlService {
     }
 
     try {
-      const verifyResult = secp256k1.verify(sig, k1, key);
+      // Convert hex strings to Uint8Array for secp256k1.verify
+      const sigBytes = Uint8Array.from(Buffer.from(sig, 'hex'));
+      const k1Bytes = Uint8Array.from(Buffer.from(k1, 'hex'));
+      const keyBytes = Uint8Array.from(Buffer.from(key, 'hex'));
+      const verifyResult = secp256k1.verify(sigBytes, k1Bytes, keyBytes);
       if (!verifyResult) return AuthLnurlSignInResponseDto.createError('invalid auth signature');
 
       authCacheEntry.accessToken = await this.signIn(signupDto, servicesIp, userIp);


### PR DESCRIPTION
## Problem

The `secp256k1.verify()` method from `@noble/curves/secp256k1` was receiving hex string parameters, but the library expects `Uint8Array` parameters. This caused a TypeScript compilation error that was blocking the build pipeline.

## Root Cause

The Noble curves library's `secp256k1.verify()` method signature expects:
```typescript
verify(signature: Uint8Array, messageHash: Uint8Array, publicKey: Uint8Array): boolean
```

However, the code was passing hex strings directly:
```typescript
const verifyResult = secp256k1.verify(sig, k1, key); // sig, k1, key are hex strings
```

## Solution

Convert hex strings to `Uint8Array` before passing to the verification function:

```typescript
// Convert hex strings to Uint8Array for secp256k1.verify
const sigBytes = Uint8Array.from(Buffer.from(sig, 'hex'));
const k1Bytes = Uint8Array.from(Buffer.from(k1, 'hex'));
const keyBytes = Uint8Array.from(Buffer.from(key, 'hex'));
const verifyResult = secp256k1.verify(sigBytes, k1Bytes, keyBytes);
```

## Why This Approach

1. **Library Compatibility**: The `@noble/curves` library is designed to work with binary data (`Uint8Array`) for cryptographic operations, which is more secure and performant than string operations.

2. **Standard Conversion**: `Uint8Array.from(Buffer.from(hex, 'hex'))` is the standard Node.js pattern for converting hex-encoded strings to byte arrays.

3. **Type Safety**: This fix resolves the TypeScript compilation error while maintaining full type safety.

4. **Security**: Working with binary data for cryptographic operations is a best practice, as it avoids potential encoding issues that could compromise security.

5. **Performance**: Binary operations on `Uint8Array` are generally faster than string manipulations for cryptographic functions.

## Alternative Approaches Considered

- **Using Buffer directly**: Could use `Buffer.from(hex, 'hex')` but `Uint8Array` is more explicit about the expected type
- **Library replacement**: Could switch to a different secp256k1 library, but `@noble/curves` is well-maintained and secure
- **String-based verification**: Could find a library that accepts strings, but binary operations are cryptographically preferred

## Testing

- Build pipeline now passes without TypeScript errors
- No functional changes to the authentication logic
- Maintains backward compatibility with existing LNURL authentication flow

## Files Changed

- `src/subdomains/generic/user/models/auth/auth-lnurl.service.ts`: Updated secp256k1.verify() call to use proper types