### PR TITLE
Fix: Prioritize BankReleaseDateMissing over PhoneVerificationNeeded

### DIFF
--- a/src/subdomains/core/aml/enums/aml-error.enum.ts
+++ b/src/subdomains/core/aml/enums/aml-error.enum.ts
@@ -260,7 +260,7 @@ export const AmlErrorResult: {
     amlReason: AmlReason.MANUAL_CHECK_PHONE,
   },
   [AmlError.BANK_RELEASE_DATE_MISSING]: {
-    type: AmlErrorType.SINGLE,
+    type: AmlErrorType.CRUCIAL,
     amlCheck: CheckStatus.PENDING,
     amlReason: AmlReason.BANK_RELEASE_PENDING,
   },

--- a/src/subdomains/core/aml/services/aml-helper.service.ts
+++ b/src/subdomains/core/aml/services/aml-helper.service.ts
@@ -520,7 +520,12 @@ export class AmlHelperService {
     // Crucial error aml
     const crucialErrorResults = amlResults.filter((r) => r.type === AmlErrorType.CRUCIAL);
     if (crucialErrorResults.length) {
+      // Prioritize BANK_RELEASE_DATE_MISSING over other crucial errors
+      const bankReleaseMissingResult = crucialErrorResults.find(
+        (c) => c.amlError === AmlError.BANK_RELEASE_DATE_MISSING,
+      );
       const crucialErrorResult =
+        bankReleaseMissingResult ??
         crucialErrorResults.find((c) => c.amlCheck === CheckStatus.FAIL) ??
         crucialErrorResults.find((c) => c.amlCheck === CheckStatus.PENDING) ??
         crucialErrorResults.find((c) => c.amlCheck === CheckStatus.GSHEET) ??


### PR DESCRIPTION
## Summary
- Adjusted AML error priority logic to correctly handle transactions with both PhoneVerificationNeeded and BankReleaseDateMissing errors
- These transactions will now be flagged with `amlReason = BankReleasePending` instead of `ManualCheckPhone`

## Changes
- Changed `BANK_RELEASE_DATE_MISSING` error type from `SINGLE` to `CRUCIAL` for proper priority handling
- Added explicit priority logic in `AmlHelperService` to prioritize `BANK_RELEASE_DATE_MISSING` when multiple crucial errors occur

## Impact
- Transactions with comment "PhoneVerificationNeeded;BankReleaseDateMissing" will now correctly show `amlReason = BankReleasePending`
- Both errors are still tracked in the comment field for complete visibility

## Testing
- Manual verification of the priority logic needed
- Existing transactions may need review to ensure correct processing

## Notes
- This change ensures the most critical issue (missing bank release date) is properly flagged for handling
- The phone verification requirement is still captured in the comment for follow-up