### PR TITLE
Fix: Temporarily require KYC for all purchases

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -117,11 +117,11 @@ export class Configuration {
   ];
 
   tradingLimits = {
-    monthlyDefaultWoKyc: 1000, // CHF
+    monthlyDefaultWoKyc: 0, // CHF - TEMPORARY: KYC required for all purchases
     weeklyAmlRule: 25000, // CHF
     monthlyDefault: 500000, // CHF
     yearlyDefault: 1000000000, // CHF
-    yearlyWithoutKyc: 50000, // CHF
+    yearlyWithoutKyc: 0, // CHF - TEMPORARY: KYC required for all purchases
     cardDefault: 4000, // CHF
   };
 


### PR DESCRIPTION
## Summary
⚠️ **TEMPORARY MEASURE** - Requires KYC verification for ALL purchases

## Changes
- Set `monthlyDefaultWoKyc` to 0 CHF (was 1000 CHF) 
- Set `yearlyWithoutKyc` to 0 CHF (was 50000 CHF)

## Impact
- **BREAKING CHANGE**: All users must complete KYC Level 50 before making any purchase
- Users without KYC will receive `KYC_LEVEL_TOO_LOW` error
- No purchases possible without verified identity

## Rollback
To revert this temporary measure, simply restore the original values:
- `monthlyDefaultWoKyc: 1000`
- `yearlyWithoutKyc: 50000`

## Testing
- Verify that purchases without KYC are blocked
- Confirm that users with KYC Level 50 can still purchase normally
- Check that appropriate error messages are shown to users without KYC

## Note
This is a provisional security measure. Should be reverted once the underlying issue is resolved.