### PR TITLE
Fix: Require KYC for all purchases (temporary)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -117,7 +117,7 @@ export class Configuration {
   ];
 
   tradingLimits = {
-    monthlyDefaultWoKyc: 1000, // CHF
+    monthlyDefaultWoKyc: 0, // CHF - TEMPORARY: KYC required for all purchases
     weeklyAmlRule: 25000, // CHF
     monthlyDefault: 500000, // CHF
     yearlyDefault: 1000000000, // CHF


### PR DESCRIPTION
## Summary
Temporary measure to require KYC for all purchases by setting the monthly limit without KYC to 0.

## Change
- Set `monthlyDefaultWoKyc` to 0 CHF (was 1000 CHF)

## Impact  
- All purchases now require KYC verification
- Users will hit the monthly limit immediately and get `KYC_LEVEL_TOO_LOW` error

## Rollback
To revert: Set `monthlyDefaultWoKyc` back to 1000