### PR TITLE
feat(recall): make userId optional to allow unassigned recall entries

### DIFF
--- a/migration/1756201286864-RecallUserOptional.js
+++ b/migration/1756201286864-RecallUserOptional.js
@@ -1,0 +1,33 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class RecallUserOptional1756201286864 {
+    name = 'RecallUserOptional1756201286864'
+
+    async up(queryRunner) {
+        // Drop the foreign key constraint first
+        await queryRunner.query(`ALTER TABLE "recall" DROP CONSTRAINT "FK_9d9db094ddf6a60b57431f39e85"`);
+
+        // Make userId column nullable in SQL Server
+        await queryRunner.query(`ALTER TABLE "recall" ALTER COLUMN "userId" int NULL`);
+
+        // Re-add the foreign key constraint with the column now nullable
+        await queryRunner.query(`ALTER TABLE "recall" ADD CONSTRAINT "FK_9d9db094ddf6a60b57431f39e85" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    async down(queryRunner) {
+        // Drop the foreign key constraint
+        await queryRunner.query(`ALTER TABLE "recall" DROP CONSTRAINT "FK_9d9db094ddf6a60b57431f39e85"`);
+
+        // Make userId column NOT NULL again
+        await queryRunner.query(`ALTER TABLE "recall" ALTER COLUMN "userId" int NOT NULL`);
+
+        // Re-add the foreign key constraint with NOT NULL
+        await queryRunner.query(`ALTER TABLE "recall" ADD CONSTRAINT "FK_9d9db094ddf6a60b57431f39e85" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+}

--- a/src/subdomains/supporting/recall/recall.dto.ts
+++ b/src/subdomains/supporting/recall/recall.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsNumber, IsString, ValidateIf } from 'class-validator';
+import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateIf } from 'class-validator';
 
 export class RecallDto {
   @IsNotEmpty()
@@ -15,9 +15,9 @@ export class RecallDto {
   @IsInt()
   sequence: number;
 
-  @IsNotEmpty()
+  @IsOptional()
   @IsInt()
-  userId: number;
+  userId?: number;
 
   @IsNotEmpty()
   @IsString()

--- a/src/subdomains/supporting/recall/recall.entity.ts
+++ b/src/subdomains/supporting/recall/recall.entity.ts
@@ -16,7 +16,7 @@ export class Recall extends IEntity {
   @Column({ type: 'int' })
   sequence: number;
 
-  @ManyToOne(() => User, { nullable: false })
+  @ManyToOne(() => User, { nullable: true })
   user: User;
 
   @Column({ length: 'MAX' })

--- a/src/subdomains/supporting/recall/recall.service.ts
+++ b/src/subdomains/supporting/recall/recall.service.ts
@@ -12,7 +12,7 @@ export class RecallService {
       ...dto,
       bankTx: { id: dto.bankTxId },
       checkoutTx: { id: dto.checkoutTxId },
-      user: { id: dto.userId },
+      user: dto.userId ? { id: dto.userId } : null,
     });
 
     return this.repo.save(entity);


### PR DESCRIPTION
## Summary
- Made userId field optional in Recall entities to support recall entries that are not yet assigned to specific users
- This allows creating recall entries that can be assigned to users later in the process

## Changes
- **RecallDto**: Updated userId field to be optional with proper validation
- **Recall Entity**: Changed user relationship to nullable
- **RecallService**: Added handling for optional userId
- **Database Migration**: Created migration to make userId column nullable

## Test plan
- [ ] Verify existing recall entries with userId still work
- [ ] Test creating new recall entries without userId  
- [ ] Test creating new recall entries with userId
- [ ] Verify migration runs successfully on database