### PR TITLE
[SUPPORT] Add Buy.deposit.address to support search endpoint

### DIFF
--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -18,9 +18,9 @@ export class SupportService {
     private readonly userService: UserService,
     private readonly buyService: BuyService,
     private readonly sellService: SellService,
+    private readonly swapService: SwapService,
     private readonly buyCryptoService: BuyCryptoService,
     private readonly buyFiatService: BuyFiatService,
-    private readonly swapService: SwapService,
     private readonly payInService: PayInService,
   ) {}
 
@@ -47,6 +47,7 @@ export class SupportService {
     if (Config.formats.address.test(key)) {
       return Promise.all([
         this.userService.getUserByKey('address', key, true),
+        this.buyService.getBuyByKey('deposit.address', key, true),
         this.sellService.getSellByKey('deposit.address', key, true),
         this.swapService.getSwapByKey('deposit.address', key, true),
       ]).then((s) => s.find((s) => s)?.userData);


### PR DESCRIPTION
## Problem

Der Support-Endpoint `GET /support?key={search}` wurde im Commit ac3ff007 eingeführt, um Compliance-Mitarbeitern die Suche nach UserData anhand verschiedener Identifikatoren zu ermöglichen. Bei der Suche nach Wallet-Adressen gab es jedoch eine wichtige Lücke:

Der Endpoint durchsuchte nur:
- `User.address` (Auszahlungsadressen)
- `Sell.deposit.address` (Sell-Route Deposit-Adressen)
- `Swap.deposit.address` (Swap-Route Deposit-Adressen)

**Fehlend waren:**
- `Buy.deposit.address` (Buy-Route Deposit-Adressen)

Dies bedeutete, dass wenn ein Kunde eine Buy-Route erstellt hatte und nach seiner Deposit-Adresse gesucht wurde, die UserData nicht gefunden werden konnte. Dies ist problematisch für Compliance-Fälle, Support-Anfragen und AML-Untersuchungen, bei denen schnell ermittelt werden muss, zu welchem Kunden eine bestimmte Blockchain-Adresse gehört.

## Lösung

Diese Änderung erweitert die Adress-Suche im Support-Endpoint um `Buy.deposit.address`:

```typescript
if (Config.formats.address.test(key)) {
  return Promise.all([
    this.userService.getUserByKey('address', key, true),
    this.buyService.getBuyByKey('deposit.address', key, true),  // ✅ NEU
    this.sellService.getSellByKey('deposit.address', key, true),
    this.swapService.getSwapByKey('deposit.address', key, true),
  ]).then((s) => s.find((s) => s)?.userData);
}
```

Die Implementierung folgt dem bestehenden Pattern:
- Verwendet die bereits vorhandene Methode `getBuyByKey()` im BuyService
- Nutzt den `onlyDefaultRelation = true` Parameter für optimale Performance
- Sucht parallel zu den anderen Routen und gibt die erste gefundene UserData zurück

## Warum ist diese Änderung wichtig?

1. **Vollständigkeit**: Buy-Routen sind ein zentraler Teil der DFX-Services. Ohne diese Suche fehlt ein wichtiges Puzzle-Stück bei der Identifizierung von Kunden.

2. **Compliance & AML**: Bei Compliance-Checks müssen wir schnell ermitteln können, zu welchem Kunden eine Blockchain-Adresse gehört - unabhängig davon, ob es eine Buy-, Sell- oder Swap-Route ist.

3. **Support-Effizienz**: Support-Mitarbeiter können nun zuverlässig nach allen Deposit-Adressen suchen, ohne zu wissen, welcher Route-Typ verwendet wurde.

4. **Konsistenz**: Die Implementierung ist jetzt konsistent - alle Route-Typen mit Deposit-Adressen (Buy, Sell, Swap) werden durchsucht.

## Technische Details

- Keine Breaking Changes
- Keine neuen Dependencies
- Performance-optimiert durch `onlyDefaultRelation = true`
- Folgt dem bestehenden Code-Pattern
- TypeScript kompiliert ohne Fehler

## Test Plan

Der Endpoint sollte getestet werden mit:
- ✅ Buy.deposit.address (neu)
- ✅ Sell.deposit.address (existing)
- ✅ Swap.deposit.address (existing)
- ✅ User.address (existing)
- ✅ Nicht-existierende Adressen sollten 404 zurückgeben