### PR TITLE
[SUPPORT] Add kycHash search to support endpoint

### DIFF
--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -36,6 +36,16 @@ export class SupportService {
   private async getUserDatasByKey(key: string): Promise<UserData[]> {
     if (key.includes('@')) return this.userDataService.getUsersByMail(key, false);
 
+    // Check for kycHash (UUID format: 8-4-4-4-12)
+    if (/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(key)) {
+      try {
+        const userData = await this.userDataService.getByKycHashOrThrow(key);
+        return [userData];
+      } catch {
+        return [];
+      }
+    }
+
     const uniqueUserData = await this.getUniqueUserDataByKey(key);
     return uniqueUserData ? [uniqueUserData] : [];
   }


### PR DESCRIPTION
## Problem

Der Support-Endpoint `GET /support?key={search}` ermöglicht es Compliance-Mitarbeitern, UserData anhand verschiedener Identifikatoren zu suchen. Bisher waren folgende Suchkriterien unterstützt:
- E-Mail-Adressen
- Bank Usage (DFXB-XXXX-XXXX-XXXX)
- Wallet-Adressen (Bitcoin, Ethereum, etc.)
- Transaction IDs

Es fehlte jedoch die Möglichkeit, direkt nach dem **kycHash** zu suchen. Der kycHash ist ein eindeutiger UUID-Identifier, der jedem UserData-Objekt zugewiesen wird und in verschiedenen Kontexten verwendet wird:
- In KYC-URLs für Kunden: `https://services.dfx.swiss/kyc?code={kycHash}`
- Für Video-Ident-Links
- In internen Logs und Prozessen

Für Compliance- und Support-Zwecke ist es wichtig, schnell von einem kycHash zur entsprechenden UserData zu gelangen, ohne manuell in der Datenbank suchen zu müssen.

## Lösung

Diese Änderung erweitert den Support-Endpoint um die automatische Erkennung und Suche nach kycHash:

```typescript
// Check for kycHash (UUID format: 8-4-4-4-12)
if (/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(key)) {
  try {
    const userData = await this.userDataService.getByKycHashOrThrow(key);
    return [userData];
  } catch {
    return [];
  }
}
```

### Funktionsweise

1. **Automatische Format-Erkennung**: Der Endpoint erkennt automatisch das UUID-Format (z.B. `038DB441-6C1B-F011-8B3D-6045BD8B791C`)
2. **Case-Insensitive**: Die Suche funktioniert sowohl mit Groß- als auch Kleinbuchstaben
3. **Sichere Fehlerbehandlung**: Wenn kein UserData mit diesem kycHash existiert, wird ein leeres Array zurückgegeben (404)
4. **Merge-Behandlung**: Die verwendete Methode `getByKycHashOrThrow` behandelt automatisch gemergete Accounts korrekt

### UUID-Format

Der kycHash folgt dem Standard-UUID-Format:
- 8 Hexadezimal-Zeichen
- 4 Hexadezimal-Zeichen
- 4 Hexadezimal-Zeichen
- 4 Hexadezimal-Zeichen
- 12 Hexadezimal-Zeichen

Beispiel: `038DB441-6C1B-F011-8B3D-6045BD8B791C`

## Warum ist diese Änderung wichtig?

1. **Compliance-Effizienz**: Compliance-Mitarbeiter können jetzt direkt von KYC-URLs oder Logs zur UserData navigieren
2. **Support-Geschwindigkeit**: Schnellere Bearbeitung von Support-Anfragen, wenn der Kunde seine KYC-URL bereitstellt
3. **Vollständigkeit**: Alle wichtigen Identifier sind nun durchsuchbar (E-Mail, Adressen, TxIDs, BankUsage, kycHash)
4. **Konsistenz**: Die Implementierung folgt dem bestehenden Pattern und verwendet vorhandene Service-Methoden

## Technische Details

- Keine Breaking Changes
- Keine neuen Dependencies
- Verwendet bestehende Methode `UserDataService.getByKycHashOrThrow()`
- Regex ist optimiert für Performance
- TypeScript kompiliert ohne Fehler
- Sichere Error-Handling mit try-catch

## Test Plan

Der Endpoint sollte getestet werden mit:
- ✅ Gültigem kycHash (sollte UserData zurückgeben)
- ✅ Ungültigem kycHash (sollte 404 zurückgeben)
- ✅ kycHash in Kleinbuchstaben (sollte funktionieren)
- ✅ kycHash in Großbuchstaben (sollte funktionieren)
- ✅ Gemergtem Account (sollte Master-Account zurückgeben)
- ✅ Kein UUID-Format (sollte andere Suchkriterien prüfen)

## Beispiel-Verwendung

```bash
# Suche nach kycHash
GET /support?key=038DB441-6C1B-F011-8B3D-6045BD8B791C

# Response
[
  {
    "userDataId": 12345
  }
]
```