### PR TITLE
[DEV-XXXX] Support endpoint kycHash search - consistent implementation

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -177,6 +177,7 @@ export class Configuration {
     key: new RegExp(`^(${this.allKeyFormat})$`),
     ref: /^(\w{1,3}-\w{1,3})$/,
     bankUsage: /[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}/,
+    kycHash: /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i,
   };
 
   database: TypeOrmModuleOptions = {

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -41,6 +41,8 @@ export class SupportService {
   }
 
   private async getUniqueUserDataByKey(key: string): Promise<UserData> {
+    if (Config.formats.kycHash.test(key)) return this.userDataService.getUserDataByKey('kycHash', key);
+
     if (Config.formats.bankUsage.test(key))
       return this.buyService.getBuyByKey('bankUsage', key, true).then((b) => b?.userData);
 


### PR DESCRIPTION
## Summary

This PR adds support for searching UserData by kycHash through the compliance support endpoint with a **consistent implementation** that follows existing code patterns.

## Background

This supersedes PR #2503 which had an inconsistent implementation. The initial kycHash search implementation had three inconsistencies:

1. **Pattern location**: Used inline regex instead of `Config.formats` pattern
2. **Method structure**: Check was in `getUserDatasByKey()` instead of `getUniqueUserDataByKey()`  
3. **Error handling**: Used try-catch instead of returning null like other searches

## Changes

### 1. Added kycHash pattern to Config.formats
- Location: `src/config/config.ts`
- Pattern: `/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i`
- Format: UUID (8-4-4-4-12 hexadecimal digits, case-insensitive)
- Example: `038DB441-6C1B-F011-8B3D-6045BD8B791C`

### 2. Added kycHash check to getUniqueUserDataByKey()
- Location: `src/subdomains/generic/support/support.service.ts`
- Uses: `UserDataService.getUserDataByKey('kycHash', key)`
- Placed at the beginning of the method (before bankUsage check)
- Returns null on failure (consistent with other searches)

## Implementation Pattern

The implementation now follows the same pattern as `bankUsage`:

```typescript
if (Config.formats.kycHash.test(key)) 
  return this.userDataService.getUserDataByKey('kycHash', key);
```

This ensures:
- ✅ Validation patterns centralized in `Config.formats`
- ✅ Unique identifier checks in `getUniqueUserDataByKey()`
- ✅ Consistent error handling (returns null, no try-catch needed)

## Testing

The kycHash search can be tested via:
- Endpoint: `GET /support?key={kycHash}`
- Auth: Requires COMPLIANCE role
- Format: UUID format (e.g., `038DB441-6C1B-F011-8B3D-6045BD8B791C`)

## Notes

- kycHash is a unique UUID identifier for UserData (indexed in database)
- The `getUserDataByKey` method in UserDataService already handles merged accounts
- This implementation replaces the inconsistent one from PR #2503