### PR TITLE
[DEV-XXXX] Support endpoint user.ref search

### DIFF
--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -44,6 +44,8 @@ export class SupportService {
     if (Config.formats.bankUsage.test(key))
       return this.buyService.getBuyByKey('bankUsage', key, true).then((b) => b?.userData);
 
+    if (Config.formats.ref.test(key)) return this.userService.getUserByKey('ref', key, true).then((u) => u?.userData);
+
     if (Config.formats.address.test(key)) {
       return Promise.all([
         this.userService.getUserByKey('address', key, true),


### PR DESCRIPTION
## Summary

This PR adds support for searching UserData by user.ref through the compliance support endpoint.

## Background

The support endpoint allows compliance team members to search for UserData by various identifiers. This PR extends the search capability to include user.ref codes (referral codes).

## Changes

### Added user.ref check to getUniqueUserDataByKey()
- Location: `src/subdomains/generic/support/support.service.ts:47`
- Uses: `UserService.getUserByKey('ref', key, true).then((u) => u?.userData)`
- Validation: Uses existing `Config.formats.ref` pattern
- Format: `\w{1,3}-\w{1,3}` (e.g., `173-870`)

## Implementation Details

The implementation follows the existing pattern:

```typescript
if (Config.formats.ref.test(key)) 
  return this.userService.getUserByKey('ref', key, true).then((u) => u?.userData);
```

Key aspects:
- ✅ Uses existing `Config.formats.ref` pattern (no new pattern needed)
- ✅ Placed in `getUniqueUserDataByKey()` method (consistent location)
- ✅ Uses `getUserByKey` with `onlyDefaultRelation=true` (optimized query)
- ✅ Returns `user?.userData` (consistent return type)
- ✅ Returns null on failure (consistent error handling)

## Database Schema

The `user.ref` field:
- Table: `user`
- Column: `ref` (VARCHAR(256), nullable)
- Index: Unique index where `ref IS NOT NULL`
- Example values: `173-870`, `019-957`, `160-195`

## Testing

The user.ref search can be tested via:
- Endpoint: `GET /support?key={user.ref}`
- Auth: Requires COMPLIANCE role
- Format: 1-3 word characters, hyphen, 1-3 word characters (e.g., `173-870`)

## Related Changes

This PR is part of a series to enhance the support endpoint:
- PR #2502: Added Buy.deposit.address search
- PR #2504: Added kycHash search (consistent implementation)
- **This PR**: Added user.ref search