### PR TITLE
[DEV-4432] Extend support endpoint response with user details

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -2,6 +2,10 @@ import { IsNotEmpty } from 'class-validator';
 
 export class UserDataSupportInfo {
   userDataId: number;
+  kycStatus: string;
+  accountType?: string;
+  mail?: string;
+  verifiedName?: string;
 }
 
 export class UserDataSupportQuery {

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -60,6 +60,12 @@ export class SupportService {
   }
 
   private toDto(userData: UserData): UserDataSupportInfo {
-    return { userDataId: userData.id };
+    return {
+      userDataId: userData.id,
+      kycStatus: userData.kycStatus,
+      accountType: userData.accountType,
+      mail: userData.mail,
+      verifiedName: userData.verifiedName,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Add additional user data fields to support endpoint response
- Provides compliance users with more context when searching

## Changes
- Extended `UserDataSupportInfo` DTO with: `kycStatus`, `accountType`, `mail`, `verifiedName`
- Updated `toDto()` method in `SupportService` to map all new fields

## Response Example
```json
[
  {
    "userDataId": 123,
    "kycStatus": "Completed",
    "accountType": "Personal",
    "mail": "user@example.com",
    "verifiedName": "John Doe"
  }
]
```

## Test plan
- Test support endpoint with various search criteria
- Verify all fields are returned correctly
- Test with multiple UserData results (e.g., email search, IP search)