### PR TITLE
[DEV-4492] Fix null pointer exception in ipLog userData

### DIFF
--- a/src/shared/models/ip-log/ip-log.service.ts
+++ b/src/shared/models/ip-log/ip-log.service.ts
@@ -28,7 +28,7 @@ export class IpLogService {
       url,
       address,
       user,
-      userData: userData ?? user.userData,
+      userData: userData ?? user?.userData,
       walletType,
     });
 


### PR DESCRIPTION
## Summary
Fixes a null pointer exception in the authentication flow introduced by DEV-4492. The code attempted to access `user.userData` when `user` could be null (e.g., during new registrations or in LOC environment).

## Changes
- Added optional chaining operator (`user?.userData`) in `ip-log.service.ts:31` to prevent null pointer exceptions

## Test plan
- [ ] Test login with existing user
- [ ] Test login in LOC environment
- [ ] Test new user registration