### PR TITLE
[NOTASK] Set recommendation expiration to 30 days for both types

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -238,7 +238,7 @@ export class Configuration {
   };
 
   recommendation = {
-    recommenderExpiration: 7, // days
+    recommenderExpiration: 30, // days
     confirmationExpiration: 30, // days
     maxRecommendationPerMail: 3,
   };


### PR DESCRIPTION
## Summary
- Unified the expiration period for INVITATION and REQUEST recommendations to 30 days
- Previously INVITATION had 7 days and REQUEST had 30 days

## Test plan
- [ ] Verify new INVITATION recommendations get 30 day expiration
- [ ] Verify REQUEST recommendations still get 30 day expiration