### PR TITLE
Update custody balance error message

### DIFF
--- a/src/subdomains/core/custody/services/custody-order.service.ts
+++ b/src/subdomains/core/custody/services/custody-order.service.ts
@@ -262,6 +262,7 @@ export class CustodyOrderService {
 
   private checkBalance(asset: Asset, amount: number, custodyBalances: CustodyBalance[]): void {
     const assetBalance = custodyBalances.find((a) => a.asset.id === asset.id);
-    if (!assetBalance || assetBalance.balance < amount) throw new BadRequestException('Not enough balance');
+    if (!assetBalance || assetBalance.balance < amount)
+      throw new BadRequestException('This transaction can only be created manually by support');
   }
 }


### PR DESCRIPTION
## Summary
- Change error message from 'Not enough balance' to 'This transaction can only be created manually by support'
- Provides clearer guidance for users when custody balance check fails

## Test plan
- [ ] Verify error message displays correctly when balance check fails