### PR TITLE
Add KYC level check for personal IBAN creation

### DIFF
--- a/src/subdomains/core/buy-crypto/routes/buy/buy.controller.ts
+++ b/src/subdomains/core/buy-crypto/routes/buy/buy.controller.ts
@@ -22,7 +22,7 @@ import { AssetDtoMapper } from 'src/shared/models/asset/dto/asset-dto.mapper';
 import { FiatService } from 'src/shared/models/fiat/fiat.service';
 import { PaymentInfoService } from 'src/shared/services/payment-info.service';
 import { Util } from 'src/shared/utils/util';
-import { RiskStatus, UserDataStatus } from 'src/subdomains/generic/user/models/user-data/user-data.enum';
+import { KycLevel, RiskStatus, UserDataStatus } from 'src/subdomains/generic/user/models/user-data/user-data.enum';
 import { UserStatus } from 'src/subdomains/generic/user/models/user/user.enum';
 import { UserService } from 'src/subdomains/generic/user/models/user/user.service';
 import { IbanBankName } from 'src/subdomains/supporting/bank/bank/dto/bank.dto';
@@ -260,6 +260,10 @@ export class BuyController {
   @ApiOkResponse({ type: VirtualIbanDto })
   async createPersonalIban(@GetJwt() jwt: JwtPayload, @Body() dto: CreateVirtualIbanDto): Promise<VirtualIbanDto> {
     const user = await this.userService.getUser(jwt.user, { userData: true });
+
+    if (user.userData.kycLevel < KycLevel.LEVEL_50)
+      throw new BadRequestException('KYC level 50 or higher required for personal IBAN');
+
     const virtualIban = await this.virtualIbanService.createForUser(user.userData, dto.currency);
 
     return {


### PR DESCRIPTION
## Summary
- Require KYC level 50 or higher to create personal IBAN
- Return 400 BadRequestException with clear error message

## Test plan
- [ ] Test personal IBAN creation with user < KYC level 50 (should return 400)
- [ ] Test personal IBAN creation with user >= KYC level 50 (should succeed)