### PR TITLE
Add default bank details for RealUnit

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -877,11 +877,11 @@ export class Configuration {
     realunit: {
       graphUrl: process.env.REALUNIT_GRAPH_URL,
       bank: {
-        recipient: process.env.REALUNIT_BANK_RECIPIENT,
-        address: process.env.REALUNIT_BANK_ADDRESS,
-        iban: process.env.REALUNIT_BANK_IBAN,
-        bic: process.env.REALUNIT_BANK_BIC,
-        name: process.env.REALUNIT_BANK_NAME,
+        recipient: process.env.REALUNIT_BANK_RECIPIENT ?? 'RealUnit Schweiz AG',
+        address: process.env.REALUNIT_BANK_ADDRESS ?? 'Schochenmühlestrasse 6, 6340 Baar, Switzerland',
+        iban: process.env.REALUNIT_BANK_IBAN ?? 'CH22 0830 7000 5609 4630 9',
+        bic: process.env.REALUNIT_BANK_BIC ?? 'HYPLCH22XXX',
+        name: process.env.REALUNIT_BANK_NAME ?? 'Hypothekarbank Lenzburg',
       },
     },
     ebel2x: {


### PR DESCRIPTION
## Summary
- Add fallback values for `REALUNIT_BANK_*` environment variables
- Ensures `/realunit/bank` endpoint returns valid data even when env is not configured

## Changes
Default values added to `config.ts`:
- `REALUNIT_BANK_RECIPIENT`: RealUnit Schweiz AG
- `REALUNIT_BANK_ADDRESS`: Schochenmühlestrasse 6, 6340 Baar, Switzerland
- `REALUNIT_BANK_IBAN`: CH22 0830 7000 5609 4630 9
- `REALUNIT_BANK_BIC`: HYPLCH22XXX
- `REALUNIT_BANK_NAME`: Hypothekarbank Lenzburg