### PR TITLE
feat(realunit): Add sellPrice endpoint for Brokerbot

### DIFF
--- a/src/integration/blockchain/realunit/realunit-blockchain.service.ts
+++ b/src/integration/blockchain/realunit/realunit-blockchain.service.ts
@@ -6,6 +6,7 @@ import {
   BrokerbotBuyPriceDto,
   BrokerbotInfoDto,
   BrokerbotPriceDto,
+  BrokerbotSellPriceDto,
   BrokerbotSharesDto,
 } from 'src/integration/realunit/dto/realunit.dto';
 import { Blockchain } from '../shared/enums/blockchain.enum';
@@ -22,6 +23,7 @@ const ZCHF_ADDRESS = '0xb58e61c3098d85632df34eecfb899a1ed80921cb';
 const BROKERBOT_ABI = [
   'function getPrice() public view returns (uint256)',
   'function getBuyPrice(uint256 shares) public view returns (uint256)',
+  'function getSellPrice(uint256 shares) public view returns (uint256)',
   'function getShares(uint256 money) public view returns (uint256)',
   'function settings() public view returns (uint256)',
 ];
@@ -80,6 +82,21 @@ export class RealUnitBlockchainService implements OnModuleInit {
       shares,
       totalPrice: EvmUtil.fromWeiAmount(totalPriceRaw).toString(),
       totalPriceRaw: totalPriceRaw.toString(),
+      pricePerShare: EvmUtil.fromWeiAmount(pricePerShareRaw).toString(),
+    };
+  }
+
+  async getBrokerbotSellPrice(shares: number): Promise<BrokerbotSellPriceDto> {
+    const contract = this.getBrokerbotContract();
+    const [totalProceedsRaw, pricePerShareRaw] = await Promise.all([
+      contract.getSellPrice(shares),
+      contract.getPrice(),
+    ]);
+
+    return {
+      shares,
+      totalProceeds: EvmUtil.fromWeiAmount(totalProceedsRaw).toString(),
+      totalProceedsRaw: totalProceedsRaw.toString(),
       pricePerShare: EvmUtil.fromWeiAmount(pricePerShareRaw).toString(),
     };
   }

--- a/src/integration/realunit/controllers/realunit.controller.ts
+++ b/src/integration/realunit/controllers/realunit.controller.ts
@@ -9,6 +9,7 @@ import {
   BrokerbotBuyPriceDto,
   BrokerbotInfoDto,
   BrokerbotPriceDto,
+  BrokerbotSellPriceDto,
   BrokerbotSharesDto,
   HistoricalPriceDto,
   HistoricalPriceQueryDto,
@@ -122,6 +123,17 @@ export class RealUnitController {
   @ApiOkResponse({ type: BrokerbotBuyPriceDto })
   async getBrokerbotBuyPrice(@Query('shares') shares: number): Promise<BrokerbotBuyPriceDto> {
     return this.realunitService.getBrokerbotBuyPrice(Number(shares));
+  }
+
+  @Get('brokerbot/sellPrice')
+  @ApiOperation({
+    summary: 'Get sell price for shares',
+    description: 'Calculates the total proceeds from selling a specific number of REALU shares',
+  })
+  @ApiQuery({ name: 'shares', type: Number, description: 'Number of shares to sell' })
+  @ApiOkResponse({ type: BrokerbotSellPriceDto })
+  async getBrokerbotSellPrice(@Query('shares') shares: number): Promise<BrokerbotSellPriceDto> {
+    return this.realunitService.getBrokerbotSellPrice(Number(shares));
   }
 
   @Get('brokerbot/shares')

--- a/src/integration/realunit/dto/realunit.dto.ts
+++ b/src/integration/realunit/dto/realunit.dto.ts
@@ -263,6 +263,20 @@ export class BrokerbotBuyPriceDto {
   pricePerShare: string;
 }
 
+export class BrokerbotSellPriceDto {
+  @ApiProperty({ description: 'Number of shares to sell' })
+  shares: number;
+
+  @ApiProperty({ description: 'Total proceeds in CHF (18 decimals formatted)' })
+  totalProceeds: string;
+
+  @ApiProperty({ description: 'Raw total proceeds in wei' })
+  totalProceedsRaw: string;
+
+  @ApiProperty({ description: 'Current price per share in CHF' })
+  pricePerShare: string;
+}
+
 export class BrokerbotSharesDto {
   @ApiProperty({ description: 'Amount in CHF' })
   amount: string;

--- a/src/integration/realunit/realunit.service.ts
+++ b/src/integration/realunit/realunit.service.ts
@@ -28,6 +28,7 @@ import {
   BrokerbotBuyPriceDto,
   BrokerbotInfoDto,
   BrokerbotPriceDto,
+  BrokerbotSellPriceDto,
   BrokerbotSharesDto,
   HistoricalPriceDto,
   HoldersDto,
@@ -131,6 +132,10 @@ export class RealUnitService {
 
   async getBrokerbotBuyPrice(shares: number): Promise<BrokerbotBuyPriceDto> {
     return this.blockchainService.getBrokerbotBuyPrice(shares);
+  }
+
+  async getBrokerbotSellPrice(shares: number): Promise<BrokerbotSellPriceDto> {
+    return this.blockchainService.getBrokerbotSellPrice(shares);
   }
 
   async getBrokerbotShares(amountChf: string): Promise<BrokerbotSharesDto> {


### PR DESCRIPTION
## Summary

Add `GET /realunit/brokerbot/sellPrice` endpoint to calculate proceeds from selling REALU shares. This mirrors the existing `buyPrice` endpoint for symmetry.

## Changes

- Add `getSellPrice` to Brokerbot contract ABI
- Add `BrokerbotSellPriceDto` response type
- Add `getBrokerbotSellPrice` method in blockchain service
- Add wrapper in `RealUnitService`
- Add controller endpoint

## New Endpoint

| Endpoint | Description |
|----------|-------------|
| `GET /brokerbot/sellPrice?shares=N` | Calculate proceeds from selling N shares |

## Test Plan

- [ ] Verify endpoint returns correct sell price from Brokerbot contract
- [ ] Compare sell price vs buy price (sell should be <= buy due to spread)
- [ ] Test with various share amounts