### PR TITLE
Extend YAPEAL integration with payments and balance

### DIFF
--- a/src/integration/bank/dto/yapeal.dto.ts
+++ b/src/integration/bank/dto/yapeal.dto.ts
@@ -26,6 +26,15 @@ export interface VibanListResponse {
 
 // --- Account/Balance DTOs --- //
 
+export enum YapealAccountStatus {
+  ACTIVE = 'active',
+  CANCELLED = 'cancelled',
+  CANCELLING = 'cancelling',
+  LOCKED = 'locked',
+  NEW = 'new',
+  RETIRED = 'retired',
+}
+
 export interface YapealAmount {
   factor: number;
   value: number;
@@ -46,7 +55,7 @@ export interface YapealAccount {
   currency: string;
   iban: string;
   name: string;
-  status: 'active' | 'cancelled' | 'cancelling' | 'locked' | 'new' | 'retired';
+  status: YapealAccountStatus;
 }
 
 export interface YapealAccountsResponse {
@@ -128,7 +137,11 @@ export interface YapealPain001Request {
 
 // --- Payment Status DTOs --- //
 
-export type YapealPaymentStatus = 'SUCCESS' | 'CREATED' | 'NOCONTENT';
+export enum YapealPaymentStatus {
+  SUCCESS = 'SUCCESS',
+  CREATED = 'CREATED',
+  NOCONTENT = 'NOCONTENT',
+}
 
 export interface YapealPaymentStatusResponse {
   fileContent?: string; // base64 encoded pain.002 XML

--- a/src/integration/bank/services/iso20022.service.ts
+++ b/src/integration/bank/services/iso20022.service.ts
@@ -22,12 +22,13 @@ export interface Party {
 }
 
 export interface Pain001Payment {
+  messageId: string;
+  endToEndId: string;
   amount: number;
   currency: 'CHF' | 'EUR';
   debtor: Party;
   creditor: Party;
   remittanceInfo?: string;
-  endToEndId?: string;
   executionDate?: Date;
 }
 
@@ -106,10 +107,68 @@ export class Iso20022Service {
   }
 
   // --- PAIN.001 GENERATION --- //
+
+  static createPain001Json(payment: Pain001Payment): any {
+    return {
+      CstmrCdtTrfInitn: {
+        GrpHdr: {
+          MsgId: payment.messageId,
+          NbOfTxs: '1',
+          CtrlSum: payment.amount,
+          InitgPty: {
+            Nm: payment.debtor.name,
+          },
+        },
+        PmtInf: [
+          {
+            Dbtr: {
+              Nm: payment.debtor.name,
+              PstlAdr: {
+                Ctry: payment.debtor.country,
+              },
+            },
+            DbtrAcct: {
+              Id: {
+                IBAN: payment.debtor.iban,
+              },
+              Ccy: payment.currency,
+            },
+            CdtTrfTxInf: [
+              {
+                PmtId: {
+                  EndToEndId: payment.endToEndId,
+                },
+                Amt: {
+                  InstdAmt: {
+                    Ccy: payment.currency,
+                    value: payment.amount,
+                  },
+                },
+                Cdtr: {
+                  Nm: payment.creditor.name,
+                  PstlAdr: {
+                    Ctry: payment.creditor.country,
+                  },
+                },
+                CdtrAcct: {
+                  Id: {
+                    IBAN: payment.creditor.iban,
+                  },
+                },
+                ...(payment.remittanceInfo && {
+                  RmtInf: {
+                    Ustrd: payment.remittanceInfo,
+                  },
+                }),
+              },
+            ],
+          },
+        ],
+      },
+    };
+  }
+
   static createPain001Xml(payment: Pain001Payment): string {
-    const messageId = Util.createUniqueId('MSG');
-    const paymentId = Util.createUniqueId('PMT');
-    const endToEndId = payment.endToEndId || Util.createUniqueId('E2E');
     const creationDateTime = new Date().toISOString();
     const executionDate = Util.isoDate(payment.executionDate || new Date());
     const amount = payment.amount.toFixed(2);
@@ -118,7 +177,7 @@ export class Iso20022Service {
 <Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <CstmrCdtTrfInitn>
     <GrpHdr>
-      <MsgId>${messageId}</MsgId>
+      <MsgId>${payment.messageId}</MsgId>
       <CreDtTm>${creationDateTime}</CreDtTm>
       <NbOfTxs>1</NbOfTxs>
       <CtrlSum>${amount}</CtrlSum>
@@ -127,7 +186,7 @@ export class Iso20022Service {
       </InitgPty>
     </GrpHdr>
     <PmtInf>
-      <PmtInfId>${paymentId}</PmtInfId>
+      <PmtInfId>${payment.messageId}</PmtInfId>
       <PmtMtd>TRF</PmtMtd>
       <BtchBookg>false</BtchBookg>
       <NbOfTxs>1</NbOfTxs>
@@ -154,7 +213,7 @@ export class Iso20022Service {
       <ChrgBr>SLEV</ChrgBr>
       <CdtTrfTxInf>
         <PmtId>
-          <EndToEndId>${endToEndId}</EndToEndId>
+          <EndToEndId>${payment.endToEndId}</EndToEndId>
         </PmtId>
         <Amt>
           <InstdAmt Ccy="${payment.currency}">${amount}</InstdAmt>

--- a/src/integration/bank/services/yapeal-webhook.service.ts
+++ b/src/integration/bank/services/yapeal-webhook.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { Subject } from 'rxjs';
+import { BankTxIndicator } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
 import {
   YapealTransactionStatus,
   YapealTransactionType,
   YapealWebhookPayloadDto,
   YapealWebhookTransactionDto,
 } from '../dto/yapeal-webhook.dto';
-import { BankTxIndicator } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
 
 export interface YapealTransactionEvent {
   accountIban: string;
@@ -35,13 +35,7 @@ export class YapealWebhookService {
   processWebhook(payload: YapealWebhookPayloadDto): void {
     const { data } = payload;
 
-    // Only process BOOKED transactions (both CREDIT and DEBIT)
     if (data.status !== YapealTransactionStatus.BOOKED) {
-      return;
-    }
-
-    // Process both CREDIT and DEBIT transactions
-    if (data.type !== YapealTransactionType.CREDIT && data.type !== YapealTransactionType.DEBIT) {
       return;
     }
 
@@ -58,8 +52,7 @@ export class YapealWebhookService {
       valueDate: data.valueDate ? new Date(data.valueDate) : undefined,
       amount: Math.abs(data.amount),
       currency: data.currency,
-      creditDebitIndicator:
-        data.type === YapealTransactionType.CREDIT ? BankTxIndicator.CREDIT : BankTxIndicator.DEBIT,
+      creditDebitIndicator: data.type === YapealTransactionType.CREDIT ? BankTxIndicator.CREDIT : BankTxIndicator.DEBIT,
       name: data.counterpartyName,
       iban: data.counterpartyIban,
       accountIban: data.iban,

--- a/src/integration/bank/services/yapeal.service.ts
+++ b/src/integration/bank/services/yapeal.service.ts
@@ -2,18 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { Method } from 'axios';
 import { Config } from 'src/config/config';
 import { HttpService } from 'src/shared/services/http.service';
-import { Util } from 'src/shared/utils/util';
-import { Pain001Payment } from './iso20022.service';
 import {
   VibanListResponse,
   VibanProposalResponse,
   VibanReserveRequest,
   VibanReserveResponse,
   YapealAccountsResponse,
-  YapealPain001Request,
+  YapealAccountStatus,
   YapealPaymentStatus,
   YapealPaymentStatusResponse,
 } from '../dto/yapeal.dto';
+import { Iso20022Service, Pain001Payment } from './iso20022.service';
 
 export interface YapealBalanceInfo {
   iban: string;
@@ -42,47 +41,6 @@ export class YapealService {
     return this.callApi<VibanListResponse>(`b2b/v2/cash-accounts/${accountUid}/vibans`, 'GET');
   }
 
-  // --- ACCOUNT/BALANCE METHODS --- //
-
-  async getAccounts(): Promise<YapealAccountsResponse> {
-    const { partnershipUid } = Config.bank.yapeal;
-    return this.callApi<YapealAccountsResponse>(`b2b/v2/agent/${partnershipUid}/accounts`, 'GET');
-  }
-
-  async getBalance(iban?: string): Promise<YapealBalanceInfo | undefined> {
-    const response = await this.getAccounts();
-    const targetIban = iban ?? Config.bank.yapeal.baseAccountIban;
-
-    const account = response.accounts.find((a) => a.iban === targetIban && a.status === 'active');
-    if (!account) return undefined;
-
-    return {
-      iban: account.iban,
-      currency: account.currency,
-      availableBalance: this.convertYapealAmount(account.balances.available.amount),
-      totalBalance: this.convertYapealAmount(account.balances.total.amount),
-    };
-  }
-
-  // --- PAYMENT METHODS --- //
-
-  async sendPayment(payment: Pain001Payment): Promise<{ msgId: string; status: YapealPaymentStatus }> {
-    const msgId = Util.createUniqueId('MSG');
-    const request = this.buildPain001Request(payment, msgId);
-
-    await this.callApi<unknown>('b2b/instant-payment-orders/by-pain', 'POST', request, true);
-
-    const { status } = await this.getPaymentStatus(msgId);
-
-    return { msgId, status };
-  }
-
-  async getPaymentStatus(msgId: string): Promise<YapealPaymentStatusResponse> {
-    return this.callApi<YapealPaymentStatusResponse>(`b2b/instant-payment-order/${msgId}/state`, 'GET');
-  }
-
-  // --- HELPER METHODS --- //
-
   private async getVibanProposal(): Promise<VibanProposalResponse> {
     const { partnershipUid } = Config.bank.yapeal;
     return this.callApi<VibanProposalResponse>(`b2b/v2/partnerships/${partnershipUid}/viban/proposal`, 'GET');
@@ -103,67 +61,43 @@ export class YapealService {
     );
   }
 
-  private buildPain001Request(payment: Pain001Payment, msgId: string): YapealPain001Request {
-    const endToEndId = payment.endToEndId || Util.createUniqueId('E2E');
+  // --- ACCOUNT/BALANCE METHODS --- //
 
-    return {
-      CstmrCdtTrfInitn: {
-        GrpHdr: {
-          MsgId: msgId,
-          NbOfTxs: '1',
-          CtrlSum: payment.amount,
-          InitgPty: {
-            Nm: payment.debtor.name,
-          },
-        },
-        PmtInf: [
-          {
-            Dbtr: {
-              Nm: payment.debtor.name,
-              PstlAdr: {
-                Ctry: payment.debtor.country,
-              },
-            },
-            DbtrAcct: {
-              Id: {
-                IBAN: payment.debtor.iban,
-              },
-              Ccy: payment.currency,
-            },
-            CdtTrfTxInf: [
-              {
-                PmtId: {
-                  EndToEndId: endToEndId,
-                },
-                Amt: {
-                  InstdAmt: {
-                    Ccy: payment.currency,
-                    value: payment.amount,
-                  },
-                },
-                Cdtr: {
-                  Nm: payment.creditor.name,
-                  PstlAdr: {
-                    Ctry: payment.creditor.country,
-                  },
-                },
-                CdtrAcct: {
-                  Id: {
-                    IBAN: payment.creditor.iban,
-                  },
-                },
-                ...(payment.remittanceInfo && {
-                  RmtInf: {
-                    Ustrd: payment.remittanceInfo,
-                  },
-                }),
-              },
-            ],
-          },
-        ],
-      },
-    };
+  async getBalances(): Promise<YapealBalanceInfo[]> {
+    const response = await this.getAccounts();
+
+    return response.accounts
+      .filter((account) => account.status === YapealAccountStatus.ACTIVE)
+      .map((account) => ({
+        iban: account.iban,
+        currency: account.currency,
+        availableBalance: this.convertYapealAmount(account.balances.available.amount),
+        totalBalance: this.convertYapealAmount(account.balances.total.amount),
+      }));
   }
+
+  private async getAccounts(): Promise<YapealAccountsResponse> {
+    const { partnershipUid } = Config.bank.yapeal;
+    return this.callApi<YapealAccountsResponse>(`b2b/v2/agent/${partnershipUid}/accounts`, 'GET');
+  }
+
+  // --- PAYMENT METHODS --- //
+
+  async sendPayment(payment: Pain001Payment): Promise<{ msgId: string; status: YapealPaymentStatus }> {
+    const request = Iso20022Service.createPain001Json(payment);
+
+    await this.callApi<unknown>('b2b/instant-payment-orders/by-pain', 'POST', request, true);
+
+    const { status } = await this.getPaymentStatus(payment.messageId);
+
+    return { msgId: payment.messageId, status };
+  }
+
+  async getPaymentStatus(msgId: string): Promise<YapealPaymentStatusResponse> {
+    return this.callApi<YapealPaymentStatusResponse>(`b2b/instant-payment-order/${msgId}/state`, 'GET');
+  }
+
+  // --- HELPER METHODS --- //
 
   private convertYapealAmount(amount: { factor: number; value: number }): number {
     // YAPEAL returns amount as value * 10^(-factor)

--- a/src/subdomains/core/liquidity-management/adapters/balances/bank.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/bank.adapter.ts
@@ -63,9 +63,11 @@ export class BankAdapter implements LiquidityBalanceIntegration {
           break;
 
         case IbanBankName.YAPEAL:
-          const yapealBalance = await this.yapealService.getBalance();
-          if (yapealBalance) {
-            assets.forEach((asset) => balances.push(LiquidityBalance.create(asset, yapealBalance.availableBalance)));
+          const yapealBalances = await this.yapealService.getBalances();
+
+          for (const balance of yapealBalances) {
+            const matchingAssets = assets.filter((asset) => asset.dexName === balance.currency);
+            matchingAssets.forEach((asset) => balances.push(LiquidityBalance.create(asset, balance.availableBalance)));
           }
 
           break;

--- a/src/subdomains/core/monitoring/observers/bank.observer.ts
+++ b/src/subdomains/core/monitoring/observers/bank.observer.ts
@@ -86,21 +86,22 @@ export class BankObserver extends MetricObserver<BankData[]> {
   }
 
   private async getYapeal(): Promise<BankData[]> {
-    const balanceInfo = await this.yapealService.getBalance();
-    if (!balanceInfo) return [];
+    const yapealBalances = await this.yapealService.getBalances();
 
-    const yapealBank = await this.bankService.getBankInternal(IbanBankName.YAPEAL, balanceInfo.currency);
-    const dbBalance = await this.getDbBalance(yapealBank.iban, balanceInfo.currency);
+    const yapealBankData = [];
+    for (const balance of yapealBalances) {
+      const dbBalance = await this.getDbBalance(balance.iban, balance.currency);
 
-    return [
-      {
+      yapealBankData.push({
         name: 'Yapeal',
-        currency: balanceInfo.currency,
-        balance: balanceInfo.availableBalance,
+        currency: balance.currency,
+        balance: balance.availableBalance,
         dbBalance: Util.round(dbBalance, 2),
-        difference: balanceInfo.availableBalance - Util.round(dbBalance, 2),
-      },
-    ];
+        difference: balance.availableBalance - Util.round(dbBalance, 2),
+      });
+    }
+
+    return yapealBankData;
   }
 
   private async getDbBalance(iban: string, currency: string): Promise<number> {


### PR DESCRIPTION
## Summary

- Add instant payment functionality via YAPEAL Pain.001 JSON API
- Add account balance retrieval for liquidity management
- Add payment status tracking
- Enable DEBIT transaction processing in webhook handler

## Changes

### New Methods in `YapealService`
- `sendPayment(payment)` - Send instant payments via Pain.001 JSON format
- `getPaymentStatus(msgId)` - Track payment order status (SUCCESS/CREATED/NOCONTENT)
- `getAccounts()` - Retrieve all accounts with balances
- `getBalance(iban?)` - Convenience method for single account balance

### Webhook Enhancement
- Now processes both CREDIT and DEBIT transactions (previously only CREDIT)
- Added `Math.abs()` for amount handling on DEBIT transactions

### New DTOs
- Account/Balance response types (`YapealAccountsResponse`, `YapealAccount`, etc.)
- Pain.001 JSON request types (`YapealPain001Request`, etc.)
- Payment status response type (`YapealPaymentStatusResponse`)

## Test plan

- [ ] Verify balance retrieval works with YAPEAL test environment
- [ ] Test instant payment flow end-to-end
- [ ] Confirm DEBIT webhooks are processed correctly