### PR TITLE
Add address fields to YAPEAL payments and fix status handling

### DIFF
--- a/src/integration/bank/services/iso20022.service.ts
+++ b/src/integration/bank/services/iso20022.service.ts
@@ -19,6 +19,9 @@ export interface Party {
   iban: string;
   bic?: string;
   country?: string;
+  address?: string;
+  zip?: string;
+  city?: string;
 }
 
 export interface Pain001Payment {
@@ -147,6 +150,9 @@ export class Iso20022Service {
                 Cdtr: {
                   Nm: payment.creditor.name,
                   PstlAdr: {
+                    ...(payment.creditor.address && { StrtNm: payment.creditor.address }),
+                    ...(payment.creditor.zip && { PstCd: payment.creditor.zip }),
+                    ...(payment.creditor.city && { TwnNm: payment.creditor.city }),
                     Ctry: payment.creditor.country,
                   },
                 },

--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -306,12 +306,15 @@ export class FiatOutputJobService {
             iban: entity.iban,
             bic: entity.bic,
             country: entity.country,
+            address: entity.address,
+            zip: entity.zip,
+            city: entity.city,
           },
           remittanceInfo: entity.remittanceInfo,
         };
 
         await this.yapealService.sendPayment(payment);
-        await this.fiatOutputRepo.update(entity.id, { yapealMsgId: msgId });
+        await this.fiatOutputRepo.update(entity.id, { yapealMsgId: msgId, isTransmittedDate: new Date() });
       } catch (e) {
         this.logger.error(`Failed to transmit YAPEAL payment for fiat output ${entity.id}:`, e);
       }
@@ -325,7 +328,7 @@ export class FiatOutputJobService {
     const entities = await this.fiatOutputRepo.find({
       where: {
         yapealMsgId: Not(IsNull()),
-        isTransmittedDate: IsNull(),
+        isConfirmedDate: IsNull(),
         isComplete: false,
       },
     });
@@ -336,7 +339,6 @@ export class FiatOutputJobService {
 
         if (status.status === YapealPaymentStatus.SUCCESS) {
           await this.fiatOutputRepo.update(entity.id, {
-            isTransmittedDate: new Date(),
             isConfirmedDate: new Date(),
             isApprovedDate: new Date(),
           });


### PR DESCRIPTION
## Summary
- Add address, zip, city to Pain001Payment creditor data for YAPEAL payments
- Set isTransmittedDate immediately after successful sendPayment (not only on SUCCESS status)
- Check isConfirmedDate instead of isTransmittedDate in status check job

## Test plan
- [ ] Verify YAPEAL payments include address fields in Pain001 JSON
- [ ] Verify isTransmittedDate is set after sendPayment call
- [ ] Verify isConfirmedDate/isApprovedDate are set on SUCCESS status