### PR TITLE
Route VIP users to Yapeal bank for buy orders

### DIFF
--- a/src/subdomains/core/buy-crypto/routes/buy/buy.service.ts
+++ b/src/subdomains/core/buy-crypto/routes/buy/buy.service.ts
@@ -275,6 +275,7 @@ export class BuyService {
       currency: dto.currency.name,
       paymentMethod: dto.paymentMethod,
       userData: user.userData,
+      user: user,
     });
 
     const buyDto: BuyPaymentInfoDto = {


### PR DESCRIPTION
## Summary
- VIP users (role = VIP) are now routed to Yapeal bank for EUR/CHF buy orders
- Falls back to normal bank selection if Yapeal not available for the currency (e.g. USD)
- Non-VIP users continue with existing bank selection logic

## Changes
- Extended `BankSelectorInput` interface with optional `user` field
- Added VIP check as first priority in `getBank()` method
- Added `getVipBank()` helper that bypasses the `receive` flag check

## Test plan
- [ ] Verify VIP user gets Yapeal IBAN for EUR buy order
- [ ] Verify VIP user gets Yapeal IBAN for CHF buy order
- [ ] Verify VIP user gets Bank Frick for USD buy order (fallback)
- [ ] Verify non-VIP user gets normal bank selection