### PR TITLE
Remove currency conversion for bankFixed fee

### DIFF
--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -721,7 +721,7 @@ export class TransactionHelper implements OnModuleInit {
       fee: {
         min: this.convertFee(fee.min, price, from),
         fixed: this.convertFee(fee.fixed, price, from),
-        bankFixed: this.convertFee(fee.bankFixed, price, from),
+        bankFixed: fee.bankFixed, // no conversion - 1 CHF/EUR/USD = 1 unit
         network: this.convertFee(fee.network, price, from),
         networkStart: fee.networkStart != null ? this.convertFee(fee.networkStart, price, from) : undefined,
       },
@@ -739,7 +739,7 @@ export class TransactionHelper implements OnModuleInit {
       fee: {
         min: this.convertFee(fee.min, price, to),
         fixed: this.convertFee(fee.fixed, price, to),
-        bankFixed: this.convertFee(fee.bankFixed, price, to),
+        bankFixed: fee.bankFixed, // no conversion - 1 CHF/EUR/USD = 1 unit
         network: this.convertFee(fee.network, price, to),
         networkStart: fee.networkStart != null ? this.convertFee(fee.networkStart, price, to) : undefined,
       },


### PR DESCRIPTION
## Summary
- Remove currency conversion for `bankFixed` fee in transaction-helper
- bankFixed now stays at 1 unit regardless of transaction currency (1 CHF/EUR/USD)

## Changes
- `getSourceSpecs`: Skip conversion for bankFixed
- `getTargetSpecs`: Skip conversion for bankFixed

## Database
Set `fixed = 1` for Bank fee entries (`type = 'Bank'`) to apply 1 unit per transaction.