### PR TITLE
Set bankFixed fee to 1 for Bank type fees

### DIFF
--- a/migration/1765453028539-SetBankFixedFee.js
+++ b/migration/1765453028539-SetBankFixedFee.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class SetBankFixedFee1765453028539 {
+    name = 'SetBankFixedFee1765453028539'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`UPDATE "fee" SET "fixed" = 1 WHERE "type" = 'Bank'`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`UPDATE "fee" SET "fixed" = 0 WHERE "type" = 'Bank'`);
+    }
+}


### PR DESCRIPTION
## Summary
Migration to set `fee.fixed = 1` for all Bank type fee entries.

## Related
Companion PR to #2619 (Remove currency conversion for bankFixed fee)

## Migration
Sets `fixed = 1` for all fees where `type = 'Bank'`