### PR TITLE
Fix invoice sender for virtual IBAN transactions

### DIFF
--- a/src/subdomains/supporting/payment/services/swiss-qr.service.ts
+++ b/src/subdomains/supporting/payment/services/swiss-qr.service.ts
@@ -155,12 +155,13 @@ export class SwissQRService {
         pdf.path(dfxLogoText).fill('#072440');
         pdf.restore();
 
-        // Creditor address
+        // Sender address (always DFX AG)
+        const sender = this.dfxCreditor();
         pdf.fontSize(12);
         pdf.fillColor('black');
         pdf.font('Helvetica');
         pdf.text(
-          `${billData.creditor.name}\n${billData.creditor.address} ${billData.creditor.buildingNumber}\n${billData.creditor.zip} ${billData.creditor.city}`,
+          `${sender.name}\n${sender.address} ${sender.buildingNumber}\n${sender.zip} ${sender.city}`,
           mm2pt(20),
           mm2pt(35),
           {


### PR DESCRIPTION
## Summary
- Fix invoice PDF showing customer as sender instead of DFX AG for virtual IBAN transactions
- Always use DFX AG address as letter sender (top left), regardless of IBAN type

## Problem
When generating invoice PDFs for users with virtual IBANs (personal IBANs), the customer's name and address were incorrectly shown as the invoice sender (top left) instead of DFX AG.

This happened because the sender address was using `billData.creditor`, which varies based on the IBAN type.

## Solution
Always use `dfxCreditor()` (DFX AG, Bahnhofstrasse 7, 6300 Zug) for the PDF letter sender address.

Note: The QR code creditor remains unchanged (`billData.creditor`) - this only affects the visual sender address in the letter header.