### PR TITLE
Add ISO 20022 Bank Transaction Code (BkTxCd) support

### DIFF
--- a/src/integration/bank/services/yapeal-webhook.service.ts
+++ b/src/integration/bank/services/yapeal-webhook.service.ts
@@ -44,6 +44,9 @@ export class YapealWebhookService {
           bic: transaction.bic,
           remittanceInfo: transaction.remittanceInfo,
           endToEndId: transaction.endToEndId,
+          txDomainCode: transaction.txDomainCode,
+          txFamilyCode: transaction.txFamilyCode,
+          txSubFamilyCode: transaction.txSubFamilyCode,
           txRaw: JSON.stringify(payload),
         },
       });

--- a/src/integration/bank/services/yapeal.service.ts
+++ b/src/integration/bank/services/yapeal.service.ts
@@ -91,11 +91,18 @@ export class YapealService {
     return this.callApi<string>(`b2b/accounts/${iban}/camt-053-statement?${params.toString()}`, 'GET', undefined, true);
   }
 
-  async getTransactionAddressDetails(
+  async getTransactionEnrichmentData(
     accountIban: string,
     accountServiceRef: string,
     bookingDate: Date,
-  ): Promise<{ addressLine1?: string; addressLine2?: string; country?: string } | undefined> {
+  ): Promise<{
+    addressLine1?: string;
+    addressLine2?: string;
+    country?: string;
+    txDomainCode?: string;
+    txFamilyCode?: string;
+    txSubFamilyCode?: string;
+  } | undefined> {
     try {
       const statement = await this.getAccountStatement(accountIban, bookingDate, bookingDate);
       const transactions = Iso20022Service.parseCamt053Xml(statement, accountIban);
@@ -107,6 +114,9 @@ export class YapealService {
         addressLine1: matchingTx.addressLine1,
         addressLine2: matchingTx.addressLine2,
         country: matchingTx.country,
+        txDomainCode: matchingTx.txDomainCode,
+        txFamilyCode: matchingTx.txFamilyCode,
+        txSubFamilyCode: matchingTx.txSubFamilyCode,
       };
     } catch {
       return undefined;

--- a/src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity.ts
@@ -207,6 +207,16 @@ export class BankTx extends IEntity {
   @Column({ length: 'MAX', nullable: true })
   txRaw?: string;
 
+  // ISO 20022 Bank Transaction Code (BkTxCd)
+  @Column({ length: 256, nullable: true })
+  txDomainCode?: string; // e.g. PMNT (Payment)
+
+  @Column({ length: 256, nullable: true })
+  txFamilyCode?: string; // e.g. RCDT (Received Credit), ICDT (Issued Credit), DMCT (Domestic Credit)
+
+  @Column({ length: 256, nullable: true })
+  txSubFamilyCode?: string; // e.g. AUTT (Automated), STDO (Standing Order), SALA (Salary)
+
   // routing id for american banks
   @Column({ length: 256, nullable: true })
   aba?: string;


### PR DESCRIPTION
## Summary

- Add `txDomainCode`, `txFamilyCode`, `txSubFamilyCode` to BankTx entity
- Parse BkTxCd from camt.054 JSON and camt.053 XML
- Enrich webhook transactions with correct BkTxCd from camt.053

## Problem

YAPEAL Webhook liefert falsche BkTxCd Codes:
- Webhook: `CCRD/CDWL` (Credit Card / Card Withdrawal)
- camt.053: `RCDT/AUTT` (Received Credit / Automated) ✅

## BkTxCd Codes Referenz

| Code | Bedeutung |
|------|-----------|
| RCDT | Received Credit Transfer (eingehende Überweisung) |
| ICDT | Issued Credit Transfer (ausgehende Zahlung) |
| DMCT | Domestic Credit Transfer |
| STDO | Standing Order (Dauerauftrag) |
| SALA | Salary Payment (Gehaltszahlung) |
| FEES | Fees and charges (Gebühren) |
| AUTT | Automated Transaction |

## Test plan

- [ ] Verifizieren dass BkTxCd aus camt.053 korrekt geparsed wird
- [ ] Prüfen dass Webhook-Daten mit korrekten Codes überschrieben werden