### PR TITLE
Add Yapeal Transaction Enrichment API integration

### DIFF
--- a/src/integration/bank/dto/yapeal.dto.ts
+++ b/src/integration/bank/dto/yapeal.dto.ts
@@ -218,3 +218,22 @@ export interface YapealSubscription {
     callbackPath?: string;
   };
 }
+
+// --- Transaction Enrichment DTOs --- //
+
+export interface YapealTransactionDetails {
+  uid: string;
+  counterpartName?: string;
+  counterpartMyPicture?: string;
+  ultimateCreditorName?: string;
+  ultimateCreditorAddress?: string;
+  ultimateCreditorAddressLines?: string[];
+  ultimateDebitorName?: string;
+  ultimateDebitorAddress?: string;
+  ultimateDebitorAddressLines?: string[];
+  creditor?: {
+    name?: string;
+    iban?: string;
+    bic?: string;
+  };
+}

--- a/src/integration/bank/services/yapeal.service.ts
+++ b/src/integration/bank/services/yapeal.service.ts
@@ -17,6 +17,7 @@ import {
   YapealSubscription,
   YapealSubscriptionFormat,
   YapealSubscriptionRequest,
+  YapealTransactionDetails,
 } from '../dto/yapeal.dto';
 import { Iso20022Service, Pain001Payment } from './iso20022.service';
 
@@ -144,6 +145,17 @@ export class YapealService {
 
   async deleteTransactionSubscription(iban: string): Promise<void> {
     await this.callApi<void>(`b2b/v2/account/subscription?iban=${iban}`, 'DELETE', undefined, true);
+  }
+
+  // --- TRANSACTION ENRICHMENT METHODS --- //
+
+  async getTransactionDetails(transactionUid: string): Promise<YapealTransactionDetails | undefined> {
+    try {
+      return await this.callApi<YapealTransactionDetails>(`b2b/v2/transactions/${transactionUid}`, 'GET', undefined, true);
+    } catch (e) {
+      // Transaction not found or enrichment not available
+      return undefined;
+    }
   }
 
   // --- HELPER METHODS --- //

--- a/src/subdomains/supporting/bank-tx/bank-tx/services/bank-transaction-handler.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/services/bank-transaction-handler.service.ts
@@ -1,8 +1,9 @@
 import { ConflictException, Injectable, OnModuleInit } from '@nestjs/common';
+import { YapealService } from 'src/integration/bank/services/yapeal.service';
 import { YapealWebhookService } from 'src/integration/bank/services/yapeal-webhook.service';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { SpecialExternalAccountService } from 'src/subdomains/supporting/payment/services/special-external-account.service';
-import { BankTx } from '../entities/bank-tx.entity';
+import { BankTx, BankTxIndicator } from '../entities/bank-tx.entity';
 import { BankTxService } from './bank-tx.service';
 
 export interface BankTransactionEvent {
@@ -16,6 +17,7 @@ export class BankTransactionHandler implements OnModuleInit {
 
   constructor(
     private readonly yapealWebhookService: YapealWebhookService,
+    private readonly yapealService: YapealService,
     private readonly bankTxService: BankTxService,
     private readonly specialAccountService: SpecialExternalAccountService,
   ) {}
@@ -27,6 +29,10 @@ export class BankTransactionHandler implements OnModuleInit {
   private async handleTransaction(event: BankTransactionEvent): Promise<void> {
     try {
       const multiAccounts = await this.specialAccountService.getMultiAccounts();
+
+      // Enrich with transaction details from Yapeal Transaction Enrichment API
+      await this.enrichTransactionDetails(event.bankTxData);
+
       await this.bankTxService.create(event.bankTxData, multiAccounts);
     } catch (e) {
       if (e instanceof ConflictException) {
@@ -34,6 +40,40 @@ export class BankTransactionHandler implements OnModuleInit {
       }
 
       this.logger.error('Failed to handle bank webhook transaction:', e);
+    }
+  }
+
+  private async enrichTransactionDetails(bankTxData: Partial<BankTx>): Promise<void> {
+    if (!bankTxData.accountServiceRef) return;
+
+    try {
+      const details = await this.yapealService.getTransactionDetails(bankTxData.accountServiceRef);
+      if (!details) return;
+
+      // For CREDIT transactions (incoming), ultimateCreditorName is the recipient name entered by sender
+      // For DEBIT transactions (outgoing), ultimateDebitorName is the sender name
+      const isCredit = bankTxData.creditDebitIndicator === BankTxIndicator.CREDIT;
+
+      const ultimateName = isCredit ? details.ultimateCreditorName : details.ultimateDebitorName;
+      const ultimateAddress = isCredit ? details.ultimateCreditorAddress : details.ultimateDebitorAddress;
+      const ultimateAddressLines = isCredit ? details.ultimateCreditorAddressLines : details.ultimateDebitorAddressLines;
+
+      if (ultimateName && !bankTxData.ultimateName) {
+        bankTxData.ultimateName = ultimateName;
+      }
+
+      if (ultimateAddress && !bankTxData.ultimateAddressLine1) {
+        bankTxData.ultimateAddressLine1 = ultimateAddress;
+      }
+
+      if (ultimateAddressLines?.length && !bankTxData.ultimateAddressLine1) {
+        bankTxData.ultimateAddressLine1 = ultimateAddressLines[0];
+        if (ultimateAddressLines.length > 1) {
+          bankTxData.ultimateAddressLine2 = ultimateAddressLines.slice(1).join(', ');
+        }
+      }
+    } catch (e) {
+      this.logger.warn(`Failed to enrich transaction details for ${bankTxData.accountServiceRef}:`, e);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Implementiert die Yapeal Transaction Enrichment API (`GET /b2b/v2/transactions/{uid}`)
- Bei eingehenden Transaktionen (CREDIT) auf VirtualIbans wird der vom Absender eingegebene Empfängername (`ultimateCreditorName`) extrahiert
- Bei ausgehenden Transaktionen (DEBIT) wird der Absendername (`ultimateDebitorName`) extrahiert
- Die enrichierten Daten werden in den bestehenden `ultimateName`-Feldern der BankTx gespeichert

## Änderungen
1. **yapeal.dto.ts**: Neues `YapealTransactionDetails` Interface für die API-Response
2. **yapeal.service.ts**: Neue `getTransactionDetails()` Methode
3. **bank-transaction-handler.service.ts**: Anreicherungslogik beim Webhook-Empfang

## Hintergrund
Bei eingehenden Zahlungen auf VirtualIbans fehlt oft der vom Absender eingegebene Empfängername im camt.054 Webhook. Die Transaction Enrichment API liefert diesen Namen als `ultimateCreditorName`.

## Test plan
- [ ] Eingehende Transaktion auf VirtualIban empfangen
- [ ] Prüfen ob `ultimateName` in BankTx befüllt wird
- [ ] Prüfen dass existierende `ultimateName`-Werte nicht überschrieben werden