### PR TITLE
Remove warning from recommendation confirmation email

### DIFF
--- a/src/shared/i18n/de/mail.json
+++ b/src/shared/i18n/de/mail.json
@@ -273,7 +273,6 @@
             "title": "DFX-Empfehlung bestätigen",
             "salutation": "Du hast eine ausstehende DFX-Empfehlung",
             "message": "Kannst du {name} ({mail}) für die Nutzug von DFX bestätigen und für ihn bürgen?",
-            "warning": "Bestätige nur Personen die du wirklich persönlich kennst und für die du bürgen kannst. Wenn die Person in einen Betrugsfall involviert ist kannst auch du eine Kontosperrung bekommen, wenn du diese Person bestätigt und für sie gebürgt hast.",
             "button": "Du kannst ganz einfach den nachfolgenden Button anklicken, um die Einladung zu bestätigen oder abzulehnen:<br>[url:Klick hier]",
             "link": "Oder du benutzt den nachfolgenden Link:<br>[url:{urlText}]"
         }

--- a/src/shared/i18n/en/mail.json
+++ b/src/shared/i18n/en/mail.json
@@ -273,7 +273,6 @@
             "title": "Confirm DFX recommendation",
             "salutation": "You have a pending DFX recommendation",
             "message": "Can you confirm {name} ({mail}) for the use of DFX and vouch for him?",
-            "warning": "Only confirm people you really know personally and for whom you can vouch. If the person is involved in a case of fraud, you could also have your account blocked if you confirmed and vouched for this person.",
             "button": "You can simply click on the button below to accept or decline the invitation:<br>[url:Click here]",
             "link": "Or you can use the following link:<br>[url:{urlText}]"
         }

--- a/src/shared/i18n/es/mail.json
+++ b/src/shared/i18n/es/mail.json
@@ -273,7 +273,6 @@
             "title": "Confirmar recomendación DFX",
             "salutation": "Tienes una recomendación DFX pendiente",
             "message": "¿Puede confirmar {name} ({mail}) para el uso de DFX y responder por él?",
-            "warning": "Solo confirma a personas que conozcas personalmente y por las que puedas responder. Si la persona está involucrada en un caso de fraude, también podrían bloquear tu cuenta si la has confirmado y respondido por ella.",
             "button": "Solo tienes que hacer clic en el botón de abajo para aceptar o rechazar la invitación:<br>[url:haga clic aquí]",
             "link": "O puede utilizar el siguiente enlace:<br>[url:{urlText}]"
         }

--- a/src/shared/i18n/fr/mail.json
+++ b/src/shared/i18n/fr/mail.json
@@ -273,7 +273,6 @@
             "title": "Confirmer la recommandation DFX",
             "salutation": "Vous avez une recommandation DFX en attente",
             "message": "Pouvez-vous confirmer {name} ({mail}) pour l'utilisation de DFX et vous porter garant pour lui ?",
-            "warning": "Ne confirmez que les personnes que vous connaissez vraiment personnellement et pour lesquelles vous pouvez vous porter garant. Si cette personne est impliquée dans une affaire de fraude, votre compte pourrait également être bloqué si vous l'avez confirmée et si vous vous êtes porté garant pour elle.",
             "button": "Il vous suffit de cliquer sur le bouton ci-dessous pour accepter ou refuser l'invitation:<br>[url:cliquez ici]",
             "link": "Ou vous pouvez utiliser le lien suivant:<br>[url:{urlText}]"
         }

--- a/src/shared/i18n/it/mail.json
+++ b/src/shared/i18n/it/mail.json
@@ -273,7 +273,6 @@
             "title": "Conferma raccomandazione DFX",
             "salutation": "Hai una raccomandazione DFX in sospeso",
             "message": "Puoi confermare {name} ({mail}) per l'uso di DFX e garantire per lui?",
-            "warning": "Conferma solo le persone che conosci personalmente e per le quali puoi garantire. Se la persona è coinvolta in un caso di frode, anche il tuo account potrebbe essere bloccato se hai confermato e garantito per questa persona.",
             "button": "È sufficiente cliccare sul pulsante sottostante per accettare o rifiutare l'invito:<br>[url:clicca qui]",
             "link": "Oppure puoi utilizzare il seguente link:<br>[url:{urlText}]"
         }

--- a/src/shared/i18n/pt/mail.json
+++ b/src/shared/i18n/pt/mail.json
@@ -273,7 +273,6 @@
             "title": "Confirm DFX recommendation",
             "salutation": "You have a pending DFX recommendation",
             "message": "Can you confirm {name} ({mail}) for the use of DFX and vouch for him?",
-            "warning": "Only confirm people you really know personally and for whom you can vouch. If the person is involved in a case of fraud, you could also have your account blocked if you confirmed and vouched for this person.",
             "button": "You can simply click on the button below to accept or decline the invitation:<br>[url:Click here]",
             "link": "Or you can use the following link:<br>[url:{urlText}]"
         }

--- a/src/subdomains/generic/user/models/recommendation/recommendation.service.ts
+++ b/src/subdomains/generic/user/models/recommendation/recommendation.service.ts
@@ -304,8 +304,6 @@ export class RecommendationService {
                 key: `${MailTranslationKey.RECOMMENDATION_CONFIRMATION}.message`,
                 params: { name: entity.recommended.completeName, mail: entity.recommended.mail },
               },
-              { key: MailKey.SPACE, params: { value: '5' } },
-              { key: `${MailTranslationKey.RECOMMENDATION_CONFIRMATION}.warning` },
               { key: MailKey.SPACE, params: { value: '4' } },
               {
                 key: `${MailTranslationKey.RECOMMENDATION_CONFIRMATION}.button`,


### PR DESCRIPTION
## Summary
- Remove warning text from recommendation confirmation email
- Remove warning from all i18n mail translations (DE, EN, FR, IT, ES, PT)
- Clean up unused spacing in email template

## Test plan
- [ ] Verify recommendation confirmation emails are sent without warning text