### PR TITLE
Fix missing country in Organization sync

### DIFF
--- a/src/subdomains/generic/user/models/organization/organization.service.ts
+++ b/src/subdomains/generic/user/models/organization/organization.service.ts
@@ -23,9 +23,12 @@ export class OrganizationService {
 
   @DfxCron(CronExpression.EVERY_MINUTE, { process: Process.ORGANIZATION_SYNC, timeout: 1800 })
   async syncOrganization() {
-    const entities = await this.userDataRepo.findBy({
-      organization: { id: IsNull() },
-      accountType: In([AccountType.ORGANIZATION, AccountType.SOLE_PROPRIETORSHIP]),
+    const entities = await this.userDataRepo.find({
+      where: {
+        organization: { id: IsNull() },
+        accountType: In([AccountType.ORGANIZATION, AccountType.SOLE_PROPRIETORSHIP]),
+      },
+      relations: { organizationCountry: true },
     });
 
     for (const entity of entities) {


### PR DESCRIPTION
## Problem

Das "Land" (Country) Feld in der Zahlungsinformation ist leer für Organization Accounts mit Personal IBAN.

**Beispiel:**
- Organisation: BBL Logistik GmbH
- `userData.organizationCountryId: 55` (Germany) - deprecated Feld, hat Wert
- `Organization.countryId: null` - neues Feld, ist leer!

## Root Cause

Der `syncOrganization` Cron-Job in `organization.service.ts` verwendet `findBy()`:

```typescript
const entities = await this.userDataRepo.findBy({
  organization: { id: IsNull() },
  accountType: In([AccountType.ORGANIZATION, AccountType.SOLE_PROPRIETORSHIP]),
});
```

**Problem:** `findBy()` lädt KEINE eager relations!

Daher ist `entity.organizationCountry` = `undefined`, und die Organization wird erstellt mit:
```typescript
country: entity.organizationCountry,  // undefined!
```

## Fix

`findBy()` → `find()` mit expliziten Relations:

```typescript
const entities = await this.userDataRepo.find({
  where: { ... },
  relations: { organizationCountry: true },
});
```

## Hinweis: Bestehende Daten

Dieser Fix verhindert das Problem für **neue** Organizations. 
Bestehende Organizations mit `countryId = null` müssen separat korrigiert werden (DB-Update oder Migration).

**SQL für manuelle Korrektur:**
```sql
UPDATE organization o
SET country_id = ud.organization_country_id
FROM user_data ud
WHERE ud.organization_id = o.id
  AND o.country_id IS NULL
  AND ud.organization_country_id IS NOT NULL;
```