### PR TITLE
Allow LM rule updates during processing

### DIFF
--- a/src/subdomains/core/liquidity-management/services/liquidity-management-rule.service.ts
+++ b/src/subdomains/core/liquidity-management/services/liquidity-management-rule.service.ts
@@ -56,9 +56,6 @@ export class LiquidityManagementRuleService {
     const existingRule = await this.ruleRepo.findOneBy({ id });
 
     if (!existingRule) throw new NotFoundException(`Rule ${id} was not found.`);
-    if (existingRule.status === LiquidityManagementRuleStatus.PROCESSING) {
-      throw new BadRequestException('Rule is currently processing and cannot be updated');
-    }
 
     await this.ruleRepo.update(existingRule.id, dto);
   }


### PR DESCRIPTION
## Summary

Entfernt die Einschränkung, die das Aktualisieren von Liquidity Management Rules während des `PROCESSING`-Status verhinderte.

## Begründung

### Bisheriges Verhalten
Wenn eine LM-Rule im Status `PROCESSING` war, wurde bei einem Update-Versuch folgender Fehler zurückgegeben:
```
{"statusCode":400,"message":"Rule is currently processing and cannot be updated","error":"Bad Request"}
```

### Warum der Check nicht notwendig ist

1. **Pipeline-Werte sind bereits fixiert**: Wenn eine Pipeline gestartet wird, werden `minAmount` und `maxAmount` zum Startzeitpunkt erfasst und in der Pipeline-Entity gespeichert (`LiquidityManagementPipeline.create(rule, result)`). Eine nachträgliche Änderung der Rule-Thresholds (`minimal`, `optimal`, `maximal`, `limit`) hat keinen Einfluss auf die laufende Pipeline.

2. **Keine Race Conditions**: Die Pipeline arbeitet unabhängig von den Rule-Thresholds. Sie führt die bereits berechneten Orders aus, ohne die Rule-Werte erneut abzufragen.

3. **Legitime Use Cases werden blockiert**: 
   - User bemerkt einen Fehler in den Thresholds während die Pipeline läuft
   - Marktbedingungen ändern sich und erfordern Anpassungen
   - Vorbereitung der nächsten Iteration während die aktuelle noch läuft

4. **Nächste Iteration nutzt neue Werte**: Nach Abschluss der Pipeline (Status wechselt zu `ACTIVE` oder `PAUSED`) werden bei der nächsten Balance-Prüfung sowieso die aktualisierten Threshold-Werte verwendet.

### Betroffene Felder im Update-DTO
- `minimal` - Unterer Schwellenwert
- `optimal` - Zielwert
- `maximal` - Oberer Schwellenwert  
- `limit` - Limit
- `reactivationTime` - Reaktivierungszeit nach Pause

Keines dieser Felder beeinflusst eine bereits laufende Pipeline.