### PR TITLE
Add houseNumber column to fiat_output table

### DIFF
--- a/migration/1765904905464-FiatOutputHouseNumber.js
+++ b/migration/1765904905464-FiatOutputHouseNumber.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class FiatOutputHouseNumber1765904905464 {
+    name = 'FiatOutputHouseNumber1765904905464'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "fiat_output" ADD "houseNumber" nvarchar(256)`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "fiat_output" DROP COLUMN "houseNumber"`);
+    }
+}

--- a/src/integration/bank/services/iso20022.service.ts
+++ b/src/integration/bank/services/iso20022.service.ts
@@ -45,6 +45,7 @@ export interface CamtTransaction {
 export interface Party {
   name: string;
   address?: string;
+  houseNumber?: string;
   zip?: string;
   city?: string;
   country: string;
@@ -370,6 +371,7 @@ export class Iso20022Service {
                   Nm: payment.creditor.name,
                   PstlAdr: {
                     ...(payment.creditor.address && { StrtNm: payment.creditor.address }),
+                    ...(payment.creditor.houseNumber && { BldgNb: payment.creditor.houseNumber }),
                     ...(payment.creditor.zip && { PstCd: payment.creditor.zip }),
                     ...(payment.creditor.city && { TwnNm: payment.creditor.city }),
                     Ctry: payment.creditor.country,

--- a/src/subdomains/supporting/fiat-output/dto/create-fiat-output.dto.ts
+++ b/src/subdomains/supporting/fiat-output/dto/create-fiat-output.dto.ts
@@ -45,6 +45,10 @@ export class CreateFiatOutputDto {
 
   @IsOptional()
   @IsString()
+  houseNumber?: string;
+
+  @IsOptional()
+  @IsString()
   city?: string;
 
   @IsOptional()

--- a/src/subdomains/supporting/fiat-output/dto/update-fiat-output.dto.ts
+++ b/src/subdomains/supporting/fiat-output/dto/update-fiat-output.dto.ts
@@ -58,6 +58,10 @@ export class UpdateFiatOutputDto {
 
   @IsOptional()
   @IsString()
+  houseNumber?: string;
+
+  @IsOptional()
+  @IsString()
   zip?: string;
 
   @IsOptional()

--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -336,6 +336,7 @@ export class FiatOutputJobService {
           creditor: {
             name: entity.name,
             address: entity.address,
+            houseNumber: entity.houseNumber,
             zip: entity.zip,
             city: entity.city,
             country: entity.country,

--- a/src/subdomains/supporting/fiat-output/fiat-output.entity.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output.entity.ts
@@ -85,6 +85,9 @@ export class FiatOutput extends IEntity {
   address?: string;
 
   @Column({ length: 256, nullable: true })
+  houseNumber?: string;
+
+  @Column({ length: 256, nullable: true })
   zip?: string;
 
   @Column({ length: 256, nullable: true })


### PR DESCRIPTION
## Summary
- Add houseNumber field to FiatOutput entity for separate house number storage
- Add BldgNb to Pain001 JSON generation for Yapeal payments
- Update DTOs and Party interface accordingly

## Changes
- `fiat-output.entity.ts`: New `houseNumber` column
- `iso20022.service.ts`: Party interface + Pain001 JSON with `BldgNb`
- `create-fiat-output.dto.ts` / `update-fiat-output.dto.ts`: Add `houseNumber`
- `fiat-output-job.service.ts`: Pass `houseNumber` to Yapeal creditor
- Migration: Add `houseNumber` column to `fiat_output` table

## Test plan
- [x] Build passes
- [x] Unit tests pass (8/8)
- [ ] Manual test: Create FiatOutput with houseNumber via API
- [ ] Manual test: Verify Yapeal payment includes BldgNb