### PR TITLE
Skip TradeApprovalDateMissing check for wallets with autoTradeApproval

### DIFF
--- a/src/subdomains/core/aml/services/aml-helper.service.ts
+++ b/src/subdomains/core/aml/services/aml-helper.service.ts
@@ -51,7 +51,11 @@ export class AmlHelperService {
     )
       return errors;
 
-    if (!DisabledProcess(Process.TRADE_APPROVAL_DATE) && !entity.userData.tradeApprovalDate)
+    if (
+      !DisabledProcess(Process.TRADE_APPROVAL_DATE) &&
+      !entity.userData.tradeApprovalDate &&
+      !entity.wallet.autoTradeApproval
+    )
       errors.push(AmlError.TRADE_APPROVAL_DATE_MISSING);
     if (entity.inputReferenceAmount < minVolume * 0.9) errors.push(AmlError.MIN_VOLUME_NOT_REACHED);
     if (entity.user.isBlocked) errors.push(AmlError.USER_BLOCKED);

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -825,7 +825,12 @@ export class TransactionHelper implements OnModuleInit {
     )
       return;
 
-    if (!DisabledProcess(Process.TRADE_APPROVAL_DATE) && user?.userData && !user.userData.tradeApprovalDate)
+    if (
+      !DisabledProcess(Process.TRADE_APPROVAL_DATE) &&
+      user?.userData &&
+      !user.userData.tradeApprovalDate &&
+      !user.wallet.autoTradeApproval
+    )
       return QuoteError.TRADING_NOT_ALLOWED;
 
     if (isSell && ibanCountry && !to.isIbanCountryAllowed(ibanCountry)) return QuoteError.IBAN_CURRENCY_MISMATCH;


### PR DESCRIPTION
## Summary
- Users from wallets with `autoTradeApproval=true` (e.g. CakeWallet) no longer receive `TradeApprovalDateMissing` error
- Previously, if a user was created via a different wallet and later used CakeWallet, they could still be blocked due to missing `tradeApprovalDate`
- Now the check considers `wallet.autoTradeApproval` in addition to `userData.tradeApprovalDate`

## Changes
- `aml-helper.service.ts`: Added `!entity.wallet.autoTradeApproval` condition to AML error check
- `transaction-helper.ts`: Added `!user.wallet.autoTradeApproval` condition to quote error check

## Test plan
- [ ] Verify user with CakeWallet and no `tradeApprovalDate` can get quotes
- [ ] Verify user with CakeWallet and no `tradeApprovalDate` can complete BuyCrypto without `TradeApprovalDateMissing`
- [ ] Verify user without `autoTradeApproval` wallet still requires `tradeApprovalDate`