### PR TITLE
Fix: Load users relation in RealUnit registration

### DIFF
--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -190,7 +190,7 @@ export class RealUnitService {
 
     // get and validate user
     const userData = await this.userService
-      .getUserByAddress(dto.walletAddress, { userData: { kycSteps: true } })
+      .getUserByAddress(dto.walletAddress, { userData: { kycSteps: true, users: true } })
       .then((u) => u?.userData);
 
     if (!userData) throw new NotFoundException('User not found');


### PR DESCRIPTION
## Summary
- Add `users` relation when fetching userData in RealUnit registration
- Fixes `userData.users is not iterable` error

## Problem
`updatePersonalData` iterates over `userData.users` for Sift account updates, but the RealUnit registration endpoint didn't load this relation.

## Solution
Added `users: true` to the relation query when fetching userData.

## Test plan
- [ ] Test RealUnit registration with new user account