### PR TITLE
Fix Aktionariat payload to exclude kycData field

### DIFF
--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -1,5 +1,4 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { plainToInstance } from 'class-transformer';
 import { verifyTypedData } from 'ethers/lib/utils';
 import { request } from 'graphql-request';
 import { Config, GetConfig } from 'src/config/config';
@@ -398,8 +397,25 @@ export class RealUnitService {
     const { api } = Config.blockchain.realunit;
 
     try {
-      // forward Aktionariat fields
-      const payload = plainToInstance(AktionariatRegistrationDto, dto);
+      // forward only Aktionariat fields (exclude kycData to avoid signature verification issues)
+      const payload: AktionariatRegistrationDto = {
+        email: dto.email,
+        name: dto.name,
+        type: dto.type,
+        phoneNumber: dto.phoneNumber,
+        birthday: dto.birthday,
+        nationality: dto.nationality,
+        addressStreet: dto.addressStreet,
+        addressPostalCode: dto.addressPostalCode,
+        addressCity: dto.addressCity,
+        addressCountry: dto.addressCountry,
+        swissTaxResidence: dto.swissTaxResidence,
+        registrationDate: dto.registrationDate,
+        walletAddress: dto.walletAddress,
+        signature: dto.signature,
+        lang: dto.lang,
+        countryAndTINs: dto.countryAndTINs,
+      };
 
       await this.http.post(`${api.url}/registerUser`, payload, {
         headers: { 'x-api-key': api.key },


### PR DESCRIPTION
## Problem
`plainToInstance(AktionariatRegistrationDto, dto)` copied ALL properties from the source object, including `kycData`. This caused Aktionariat's signature verification to fail with "Invalid signature" error because the extra field polluted the verification process.

## Solution
Replace `plainToInstance` with explicit field mapping to send only the required Aktionariat fields:
- email, name, type, phoneNumber, birthday, nationality
- addressStreet, addressPostalCode, addressCity, addressCountry
- swissTaxResidence, registrationDate, walletAddress
- signature, lang, countryAndTINs

## Changes
- Explicit payload construction instead of `plainToInstance`
- Removed unused `plainToInstance` import