### PR TITLE
Fix EIP-712 primaryType for RealUnit registration

### DIFF
--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -322,7 +322,7 @@ export class RealUnitService {
     };
 
     const types = {
-      RealUnitUserRegistration: [
+      RealUnitUser: [
         { name: 'email', type: 'string' },
         { name: 'name', type: 'string' },
         { name: 'type', type: 'string' },


### PR DESCRIPTION
## Summary
- Change EIP-712 types key from `RealUnitUserRegistration` to `RealUnitUser` to match Aktionariat's expected schema

## Context
Aktionariat's API expects the primaryType to be `RealUnitUser`, not `RealUnitUserRegistration`. This mismatch caused signature verification to fail.

## Test plan
- [ ] Test RealUnit registration with valid signature