### PR TITLE
[NO-TASK] Fix: Track all exchange order IDs to prevent partial fill loss

### DIFF
--- a/migration/1766132637328-LmPreviousCorrelationIds.js
+++ b/migration/1766132637328-LmPreviousCorrelationIds.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class LmPreviousCorrelationIds1766132637328 {
+    name = 'LmPreviousCorrelationIds1766132637328'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "liquidity_management_order" ADD "previousCorrelationIds" nvarchar(MAX)`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "liquidity_management_order" DROP COLUMN "previousCorrelationIds"`);
+    }
+}

--- a/src/subdomains/core/liquidity-management/entities/liquidity-management-order.entity.ts
+++ b/src/subdomains/core/liquidity-management/entities/liquidity-management-order.entity.ts
@@ -95,18 +95,8 @@ export class LiquidityManagementOrder extends IEntity {
   //*** PUBLIC API ***//
 
   get allCorrelationIds(): string[] {
-    const ids: string[] = [];
-
-    if (this.previousCorrelationIds) {
-      ids.push(...this.previousCorrelationIds.split(','));
-    }
-
-    if (this.correlationId) {
-      ids.push(this.correlationId);
-    }
-
-    // Remove duplicates and empty strings
-    return [...new Set(ids)].filter((id) => id.length > 0);
+    const ids = [this.correlationId, this.previousCorrelationIds?.split(',')].flat();
+    return [...new Set(ids)].filter((id) => id);
   }
 
   inProgress(correlationId: string): this {
@@ -117,12 +107,7 @@ export class LiquidityManagementOrder extends IEntity {
   }
 
   updateCorrelationId(newCorrelationId: string): this {
-    if (this.correlationId) {
-      this.previousCorrelationIds = this.previousCorrelationIds
-        ? `${this.previousCorrelationIds},${this.correlationId}`
-        : this.correlationId;
-    }
-
+    this.previousCorrelationIds = this.allCorrelationIds.join(',');
     this.correlationId = newCorrelationId;
 
     return this;


### PR DESCRIPTION
## Summary

- **Bug**: When a trade's price changes during execution, the exchange (e.g., Binance) cancels the original order and creates a new one with a different ID
- **Issue**: The `correlationId` was simply overwritten, causing any partial fills from the original order to be lost in tracking
- **Impact**: Example from 2025-12-18: Order `54136578194` (6.68 BTC / ~$680k) was partially filled, then replaced by `54136603111` (32.85 BTC). Only 32.85 BTC was tracked instead of the actual 39.53 BTC

## Changes

### Entity (`liquidity-management-order.entity.ts`)

1. **New field `previousCorrelationIds`**
   - Stores comma-separated list of all previous order IDs
   
2. **New method `updateCorrelationId()`** 
   - Preserves the old correlationId before updating to the new one
   
3. **New getter `allCorrelationIds`**
   - Returns deduplicated array of all order IDs (previous + current)

### Adapter (`ccxt-exchange.adapter.ts`)

4. **New method `aggregateTradeAmounts()`**
   - Uses `Promise.allSettled()` for graceful handling of individual fetch failures
   - Uses `trade.filled` instead of `trade.amount` (critical: `amount` is order size, `filled` is actual filled quantity)
   - Adds logging for multi-order aggregation scenarios
   - Throws `OrderFailedException` only if ALL fetches fail

5. **Updated `checkBuyCompletion()` and `checkSellCompletion()`**
   - Now use the new `aggregateTradeAmounts()` method

## Test plan

- [ ] Deploy to test environment
- [ ] Trigger a liquidity order that experiences a price change during execution
- [ ] Verify that `previousCorrelationIds` is populated when correlationId changes
- [ ] Verify that `inputAmount` and `outputAmount` include fills from all orders
- [ ] Verify logging output shows aggregation details