### PR TITLE
feat(gs): Add CADMIN role and column restriction for GS database access

### DIFF
--- a/src/shared/auth/role.guard.ts
+++ b/src/shared/auth/role.guard.ts
@@ -4,14 +4,14 @@ import { UserRole } from 'src/shared/auth/user-role.enum';
 class RoleGuardClass implements CanActivate {
   // additional allowed roles
   private readonly additionalRoles = {
-    [UserRole.ACCOUNT]: [UserRole.USER, UserRole.CUSTODY, UserRole.VIP, UserRole.BETA, UserRole.ADMIN, UserRole.CADMIN],
-    [UserRole.USER]: [UserRole.VIP, UserRole.BETA, UserRole.ADMIN, UserRole.CADMIN, UserRole.CUSTODY],
-    [UserRole.VIP]: [UserRole.ADMIN, UserRole.CADMIN],
-    [UserRole.BETA]: [UserRole.ADMIN, UserRole.CADMIN],
-    [UserRole.SUPPORT]: [UserRole.COMPLIANCE, UserRole.ADMIN, UserRole.CADMIN],
-    [UserRole.COMPLIANCE]: [UserRole.ADMIN, UserRole.CADMIN],
-    [UserRole.BANKING_BOT]: [UserRole.ADMIN, UserRole.CADMIN],
-    [UserRole.ADMIN]: [UserRole.CADMIN],
+    [UserRole.ACCOUNT]: [UserRole.USER, UserRole.CUSTODY, UserRole.VIP, UserRole.BETA, UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    [UserRole.USER]: [UserRole.VIP, UserRole.BETA, UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.CUSTODY],
+    [UserRole.VIP]: [UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    [UserRole.BETA]: [UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    [UserRole.SUPPORT]: [UserRole.COMPLIANCE, UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    [UserRole.COMPLIANCE]: [UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    [UserRole.BANKING_BOT]: [UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    [UserRole.ADMIN]: [UserRole.SUPER_ADMIN],
   };
 
   constructor(private readonly entryRole: UserRole) {}

--- a/src/shared/auth/user-role.enum.ts
+++ b/src/shared/auth/user-role.enum.ts
@@ -5,7 +5,7 @@ export enum UserRole {
   VIP = 'VIP',
   BETA = 'Beta',
   ADMIN = 'Admin',
-  CADMIN = 'Cadmin',
+  SUPER_ADMIN = 'SuperAdmin',
   SUPPORT = 'Support',
   COMPLIANCE = 'Compliance',
   CUSTODY = 'Custody',

--- a/src/subdomains/generic/gs/gs-column-exclusion.config.ts
+++ b/src/subdomains/generic/gs/gs-column-exclusion.config.ts
@@ -1,8 +1,0 @@
-// Configuration: Columns to exclude from GS database access per table
-// These columns will show the restricted marker for all roles except CADMIN
-
-export const GsRestrictedMarker = '[RESTRICTED]';
-
-export const GsExcludedColumns: Record<string, string[]> = {
-  asset: ['ikna'],
-};


### PR DESCRIPTION
## Summary

- Adds new `CADMIN` role with highest privileges (above ADMIN)
- Implements configurable column exclusion for GS database endpoints
- Non-CADMIN roles see `[RESTRICTED]` for excluded columns
- Column visibility is preserved (keys remain, only values are masked)

## Changes

| File | Change |
|------|--------|
| `user-role.enum.ts` | Add `CADMIN` role |
| `role.guard.ts` | Add CADMIN to role hierarchy |
| `gs-column-exclusion.config.ts` | New config for excluded columns |
| `gs.controller.ts` | Pass JWT role to service methods |
| `gs.service.ts` | Add `maskExcludedColumns()` method |

## Configuration

Excluded columns can be configured in `gs-column-exclusion.config.ts`:

```typescript
export const GsExcludedColumns: Record<string, string[]> = {
  asset: ['ikna'],
  // Add more tables as needed
};
```

## Test plan

- [ ] Verify ADMIN role sees `[RESTRICTED]` for `ikna` column in `asset` table
- [ ] Verify CADMIN role sees actual value for `ikna` column
- [ ] Verify other columns are unaffected