### PR TITLE
fix(kyc): use residence country instead of document country for IP mismatch check

### DIFF
--- a/src/subdomains/generic/kyc/dto/sum-sub.dto.ts
+++ b/src/subdomains/generic/kyc/dto/sum-sub.dto.ts
@@ -65,7 +65,6 @@ export interface SumSubDataResult {
     lastName?: string;
     lastNameEn?: string;
     country?: string;
-    addresses?: { country?: string }[];
   };
   email?: string;
   phone?: string;

--- a/src/subdomains/generic/kyc/entities/kyc-step.entity.ts
+++ b/src/subdomains/generic/kyc/entities/kyc-step.entity.ts
@@ -371,7 +371,7 @@ export class KycStep extends IEntity {
         kycType: identResultData.webhook.levelName,
         success: identResultData.webhook.reviewResult?.reviewAnswer === ReviewAnswer.GREEN,
         ipCountry: identResultData.data.ipCountry,
-        country: identResultData.data.fixedInfo?.country ?? identResultData.data.fixedInfo?.addresses?.[0]?.country,
+        country: identResultData.data.fixedInfo?.country,
       };
     } else if (this.isManual) {
       const identResultData = this.getResult<ManualIdentResult>();


### PR DESCRIPTION
## Summary
- CountryIpCountryMismatch prüft nun das Wohnort-Land (fixedInfo.country) statt das Dokument-Land (info.country)
- Behebt false-positive Fehler bei Nutzern die in einem anderen Land wohnen als ihr Dokument ausgestellt wurde

## Changes
- `sum-sub.dto.ts`: fixedInfo Typdefinition hinzugefügt
- `kyc-step.entity.ts`: country in resultData verwendet nun fixedInfo.country mit Fallback auf addresses[0].country