### PR TITLE
Add bank account details to refund endpoint

### DIFF
--- a/src/subdomains/core/history/dto/refund-data.dto.ts
+++ b/src/subdomains/core/history/dto/refund-data.dto.ts
@@ -14,28 +14,7 @@ export class RefundFeeDto {
   dfx: number;
 }
 
-export class RefundDataDto {
-  @ApiProperty({ description: 'Expiry date of the refund data' })
-  expiryDate: Date;
-
-  @ApiProperty({ type: RefundFeeDto, description: 'Refund fees' })
-  fee: RefundFeeDto;
-
-  @ApiProperty()
-  inputAmount: number;
-
-  @ApiProperty({ oneOf: [{ $ref: getSchemaPath(AssetDto) }, { $ref: getSchemaPath(FiatDto) }] })
-  inputAsset: ActiveDto;
-
-  @ApiProperty()
-  refundAmount: number;
-
-  @ApiProperty({ oneOf: [{ $ref: getSchemaPath(AssetDto) }, { $ref: getSchemaPath(FiatDto) }] })
-  refundAsset: ActiveDto;
-
-  @ApiPropertyOptional({ description: 'IBAN for bank tx or blockchain address for crypto tx' })
-  refundTarget?: string;
-
+export class RefundBankDetailsDto {
   @ApiPropertyOptional({ description: 'Account holder name' })
   name?: string;
 
@@ -59,4 +38,30 @@ export class RefundDataDto {
 
   @ApiPropertyOptional({ description: 'BIC/SWIFT code' })
   bic?: string;
+}
+
+export class RefundDataDto {
+  @ApiProperty({ description: 'Expiry date of the refund data' })
+  expiryDate: Date;
+
+  @ApiProperty({ type: RefundFeeDto, description: 'Refund fees' })
+  fee: RefundFeeDto;
+
+  @ApiProperty()
+  inputAmount: number;
+
+  @ApiProperty({ oneOf: [{ $ref: getSchemaPath(AssetDto) }, { $ref: getSchemaPath(FiatDto) }] })
+  inputAsset: ActiveDto;
+
+  @ApiProperty()
+  refundAmount: number;
+
+  @ApiProperty({ oneOf: [{ $ref: getSchemaPath(AssetDto) }, { $ref: getSchemaPath(FiatDto) }] })
+  refundAsset: ActiveDto;
+
+  @ApiPropertyOptional({ description: 'IBAN for bank tx or blockchain address for crypto tx' })
+  refundTarget?: string;
+
+  @ApiPropertyOptional({ type: RefundBankDetailsDto, description: 'Bank details' })
+  bankDetails?: RefundBankDetailsDto;
 }

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -449,12 +449,16 @@ export class TransactionHelper implements OnModuleInit {
       },
       refundAsset,
       refundTarget,
-      name: bankTx?.name,
-      address: bankTx?.addressLine1,
-      city: bankTx?.addressLine2,
-      country: bankTx?.country,
-      iban: bankTx?.iban,
-      bic: bankTx?.bic,
+      bankDetails: bankTx
+        ? {
+            name: bankTx?.name,
+            address: bankTx?.addressLine1,
+            city: bankTx?.addressLine2,
+            country: bankTx?.country,
+            iban: bankTx?.iban,
+            bic: bankTx?.bic,
+          }
+        : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary
- Extend `RefundDataDto` with bank account fields: name, address, houseNumber, zip, city, country, iban, bic
- Extract bank details from `BankTx` entity in `getRefundData` method
- Add helper method `getBankTxFromRefundEntity` to handle different refund entity types

## Field Mapping
| BankTx Field | RefundDataDto Field |
|--------------|---------------------|
| name | name |
| addressLine1 | address |
| addressLine2 | city |
| country | country |
| iban | iban |
| bic | bic |

## Related PRs
- packages: feature/refund-bank-details
- services: feature/refund-bank-details