### PR TITLE
Add assignMissingBank to set bank based on accountIban

### DIFF
--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -48,7 +48,6 @@ export class FiatOutputJobService {
   @DfxCron(CronExpression.EVERY_MINUTE, { process: Process.FIAT_OUTPUT, timeout: 1800 })
   async fillFiatOutput() {
     await this.assignBankAccount();
-    await this.assignMissingBank();
     await this.setReadyDate();
     await this.createBatches();
     await this.checkTransmission();
@@ -146,25 +145,6 @@ export class FiatOutputJobService {
         });
       } catch (e) {
         this.logger.error(`Error in fillPreValutaDate fiatOutput: ${entity.id}:`, e);
-      }
-    }
-  }
-
-  private async assignMissingBank(): Promise<void> {
-    if (DisabledProcess(Process.FIAT_OUTPUT_ASSIGN_BANK_ACCOUNT)) return;
-
-    const entities = await this.fiatOutputRepo.find({
-      where: { accountIban: Not(IsNull()), bank: IsNull(), isComplete: false },
-    });
-
-    for (const entity of entities) {
-      try {
-        const bank = await this.bankService.getBankByIban(entity.accountIban);
-        if (bank) {
-          await this.fiatOutputRepo.update(entity.id, { bank });
-        }
-      } catch (e) {
-        this.logger.error(`Error in assignMissingBank fiatOutput: ${entity.id}:`, e);
       }
     }
   }

--- a/src/subdomains/supporting/fiat-output/fiat-output.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output.service.ts
@@ -7,6 +7,7 @@ import { BankTxRepeatService } from '../bank-tx/bank-tx-repeat/bank-tx-repeat.se
 import { BankTxReturn } from '../bank-tx/bank-tx-return/bank-tx-return.entity';
 import { BankTxReturnService } from '../bank-tx/bank-tx-return/bank-tx-return.service';
 import { BankTxService } from '../bank-tx/bank-tx/services/bank-tx.service';
+import { BankService } from '../bank/bank/bank.service';
 import { PayInStatus } from '../payin/entities/crypto-input.entity';
 import { CreateFiatOutputDto } from './dto/create-fiat-output.dto';
 import { UpdateFiatOutputDto } from './dto/update-fiat-output.dto';
@@ -24,6 +25,7 @@ export class FiatOutputService {
     @Inject(forwardRef(() => BankTxReturnService))
     private readonly bankTxReturnService: BankTxReturnService,
     private readonly bankTxRepeatService: BankTxRepeatService,
+    private readonly bankService: BankService,
   ) {}
 
   async create(dto: CreateFiatOutputDto): Promise<FiatOutput> {
@@ -65,6 +67,11 @@ export class FiatOutputService {
     if (dto.bankTxRepeatId) {
       entity.bankTxRepeat = await this.bankTxRepeatService.getBankTxRepeat(dto.bankTxRepeatId);
       if (!entity.bankTxRepeat) throw new NotFoundException('BankTxRepeat not found');
+    }
+
+    if (entity.accountIban && !entity.bank) {
+      const bank = await this.bankService.getBankByIban(entity.accountIban);
+      if (bank) entity.bank = bank;
     }
 
     return this.fiatOutputRepo.save(entity);


### PR DESCRIPTION
## Summary
- Add new method `assignMissingBank()` to automatically assign bank for FiatOutputs that have `accountIban` but missing `bank`
- Covers LiqManagement and other manually created FiatOutputs that were not handled by `assignBankAccount()`
- Uses existing `getBankByIban()` from BankService to lookup bank by IBAN

## Test plan
- [ ] Verify LiqManagement FiatOutputs get bank assigned automatically
- [ ] Verify existing BuyFiat/BuyCrypto flows still work correctly