### PR TITLE
Fix case-sensitive email comparison issues

### DIFF
--- a/src/shared/utils/util.ts
+++ b/src/shared/utils/util.ts
@@ -228,6 +228,10 @@ export class Util {
     return value?.trim();
   }
 
+  static toLowerCaseTrim({ value }: TransformFnParams): string | undefined {
+    return value?.trim().toLowerCase();
+  }
+
   static equalsIgnoreCase(left: string, right: string): boolean {
     return left?.toLowerCase() === right?.toLowerCase();
   }

--- a/src/subdomains/generic/kyc/dto/input/kyc-data.dto.ts
+++ b/src/subdomains/generic/kyc/dto/input/kyc-data.dto.ts
@@ -33,7 +33,7 @@ export class KycContactData {
   @ApiProperty()
   @IsNotEmpty()
   @IsEmail()
-  @Transform(Util.trim)
+  @Transform(Util.toLowerCaseTrim)
   mail: string;
 }
 
@@ -120,6 +120,7 @@ export class KycInputDataDto extends KycPersonalData {
   @ApiProperty()
   @IsNotEmpty()
   @IsEmail()
+  @Transform(Util.toLowerCaseTrim)
   mail: string;
 }
 

--- a/src/subdomains/generic/user/models/auth/dto/auth-mail.dto.ts
+++ b/src/subdomains/generic/user/models/auth/dto/auth-mail.dto.ts
@@ -1,15 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { IsEmail, IsNotEmpty, IsObject, IsOptional, IsString, IsUrl, Matches, ValidateNested } from 'class-validator';
 import { GetConfig } from 'src/config/config';
 import { EntityDto } from 'src/shared/dto/entity.dto';
 import { Language } from 'src/shared/models/language/language.entity';
+import { Util } from 'src/shared/utils/util';
 
 export class AuthMailDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsString()
   @IsEmail()
+  @Transform(Util.toLowerCaseTrim)
   mail: string;
 
   @ApiPropertyOptional()

--- a/src/subdomains/generic/user/models/recommendation/dto/recommendation.dto.ts
+++ b/src/subdomains/generic/user/models/recommendation/dto/recommendation.dto.ts
@@ -16,7 +16,7 @@ export class CreateRecommendationDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsEmail()
-  @Transform(Util.trim)
+  @Transform(Util.toLowerCaseTrim)
   recommendedMail: string;
 
   @ApiProperty()

--- a/src/subdomains/generic/user/models/user-data/dto/update-user-data.dto.ts
+++ b/src/subdomains/generic/user/models/user-data/dto/update-user-data.dto.ts
@@ -15,6 +15,7 @@ import { EntityDto } from 'src/shared/dto/entity.dto';
 import { Country } from 'src/shared/models/country/country.entity';
 import { Fiat } from 'src/shared/models/fiat/fiat.entity';
 import { Language } from 'src/shared/models/language/language.entity';
+import { Util } from 'src/shared/utils/util';
 import { IsOptionalButNotNull } from 'src/shared/validators/is-not-null.validator';
 import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
 import { AccountOpenerAuthorization, Organization } from '../../organization/organization.entity';
@@ -31,6 +32,7 @@ export class UpdateUserDataDto {
 
   @IsOptional()
   @IsEmail()
+  @Transform(Util.toLowerCaseTrim)
   mail?: string;
 
   @IsOptional()

--- a/src/subdomains/generic/user/models/user/dto/update-user.dto.ts
+++ b/src/subdomains/generic/user/models/user/dto/update-user.dto.ts
@@ -4,6 +4,7 @@ import { IsEmail, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } f
 import { EntityDto } from 'src/shared/dto/entity.dto';
 import { Fiat } from 'src/shared/models/fiat/fiat.entity';
 import { Language } from 'src/shared/models/language/language.entity';
+import { Util } from 'src/shared/utils/util';
 import { DfxPhoneTransform, IsDfxPhone } from '../../user-data/is-dfx-phone.validator';
 
 export class UpdateUserDto {
@@ -33,5 +34,6 @@ export class UpdateUserMailDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsEmail()
+  @Transform(Util.toLowerCaseTrim)
   mail: string;
 }

--- a/src/subdomains/supporting/realunit/dto/realunit-registration.dto.ts
+++ b/src/subdomains/supporting/realunit/dto/realunit-registration.dto.ts
@@ -56,7 +56,7 @@ export class AktionariatRegistrationDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsEmail()
-  @Transform(Util.trim)
+  @Transform(Util.toLowerCaseTrim)
   email: string;
 
   @ApiProperty({ description: 'Full name' })


### PR DESCRIPTION
## Summary
- Normalize all email inputs to lowercase using `@Transform(Util.toLowerCaseTrim)`
- MSSQL already handles case-insensitive comparisons via collation

## Problem
Users who registered with mixed-case emails (e.g. `Samuel.kullmann@startmail.com`) had merge conflicts when later using lowercase variant (`samuel.kullmann@startmail.com`), because different casing was stored in the database.

## Solution
Normalize email inputs at the DTO level to ensure consistent lowercase storage.

## Changes
- **util.ts**: Add `toLowerCaseTrim` transform function
- **7 DTOs**: Apply `@Transform(Util.toLowerCaseTrim)` to all email input fields

## Test plan
- [ ] Verify new registrations store emails in lowercase
- [ ] Verify KYC contact data step normalizes email
- [ ] Verify login with any casing works for existing users