### PR TITLE
Add local development setup with Docker and fix fiatMap race condition

### DIFF
--- a/src/subdomains/supporting/pricing/services/pricing.service.ts
+++ b/src/subdomains/supporting/pricing/services/pricing.service.ts
@@ -86,10 +86,16 @@ export class PricingService implements OnModuleInit {
     };
   }
 
-  onModuleInit() {
-    void this.fiatService.getFiatByName('CHF').then((f) => this.fiatMap.set(PriceCurrency.CHF, f));
-    void this.fiatService.getFiatByName('EUR').then((f) => this.fiatMap.set(PriceCurrency.EUR, f));
-    void this.fiatService.getFiatByName('USD').then((f) => this.fiatMap.set(PriceCurrency.USD, f));
+  async onModuleInit() {
+    const [chf, eur, usd] = await Promise.all([
+      this.fiatService.getFiatByName('CHF'),
+      this.fiatService.getFiatByName('EUR'),
+      this.fiatService.getFiatByName('USD'),
+    ]);
+
+    if (chf) this.fiatMap.set(PriceCurrency.CHF, chf);
+    if (eur) this.fiatMap.set(PriceCurrency.EUR, eur);
+    if (usd) this.fiatMap.set(PriceCurrency.USD, usd);
   }
 
   async getPrice(


### PR DESCRIPTION
## Summary

- Add complete local development environment with Docker (MSSQL) and one-command setup
- Add automatic mocking for external services (Alchemy, Tatum, Sift, CoinGecko, SumSub, Azure Storage)
- Fix race condition in PricingService where fiatMap was empty during early API requests
- Add seed data (language, fiat, country, asset, bank, fee, price_rule) for local development

## Changes

**Infrastructure:**
- `docker-compose.yml` - MSSQL Server for local database
- `.env.local.example` - Minimal config template (no secrets)
- `scripts/setup.js` - One-command setup script

**Setup Script (`npm run setup`):**
- Generates 19 wallet seeds/keys securely on first run
- Starts API in background
- Registers admin user and grants admin role
- Seeds deposit addresses directly in database

**Mock Mode (`ENVIRONMENT=loc`):**
- Mock external HTTP calls with predefined responses
- Mock Azure Storage with in-memory storage
- Skip Alchemy webhook creation

**Bug Fix:**
- Make `PricingService.onModuleInit` async and await fiat loading
- Run database seeding synchronously before `app.listen()` in LOC env
- Prevents "Cannot read properties of undefined (reading 'id')" errors

## Test plan

- [ ] Run `npm run setup` on fresh clone
- [ ] Verify API starts and responds at http://localhost:3000
- [ ] Verify seed data is loaded (assets, fiats, countries)
- [ ] Test buy/sell flows work with mocked external services