### PR TITLE
🚨 Hotfix: Fix Gnosis config crash in dev/prod

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -771,8 +771,6 @@ export class Configuration {
       gnosisWalletAddress: process.env.GNOSIS_WALLET_ADDRESS,
       gnosisWalletPrivateKey: process.env.GNOSIS_WALLET_PRIVATE_KEY,
       gnosisApiKey: process.env.ALCHEMY_API_KEY,
-      swapContractAddress: process.env.GNOSIS_SWAP_CONTRACT_ADDRESS,
-      quoteContractAddress: process.env.GNOSIS_QUOTE_CONTRACT_ADDRESS,
     },
     bsc: {
       ...EVM_CHAINS.bsc,

--- a/src/integration/blockchain/gnosis/gnosis.service.ts
+++ b/src/integration/blockchain/gnosis/gnosis.service.ts
@@ -8,14 +8,8 @@ import { GnosisClient } from './gnosis-client';
 @Injectable()
 export class GnosisService extends EvmService {
   constructor(http: HttpService, alchemyService: AlchemyService) {
-    const {
-      gnosisGatewayUrl,
-      gnosisApiKey,
-      gnosisWalletPrivateKey,
-      gnosisChainId,
-      swapContractAddress,
-      quoteContractAddress,
-    } = GetConfig().blockchain.gnosis;
+    const { gnosisGatewayUrl, gnosisApiKey, gnosisWalletPrivateKey, gnosisChainId } =
+      GetConfig().blockchain.gnosis;
 
     super(GnosisClient, {
       http,
@@ -24,8 +18,6 @@ export class GnosisService extends EvmService {
       apiKey: gnosisApiKey,
       walletPrivateKey: gnosisWalletPrivateKey,
       chainId: gnosisChainId,
-      swapContractAddress,
-      quoteContractAddress,
     });
   }
 }


### PR DESCRIPTION
## Problem
The dev API has been down since commit `270d890ef` was merged to develop. 

**Azure Error:**
- HTTP 500 errors
- "Application Error"  
- "App-Container startete nicht"

## Root Cause Analysis

The commit `270d890ef` introduced an **incomplete migration** for Gnosis chain configuration:

### What went wrong:

1. **chains.config.ts** was created with Gnosis config **WITHOUT** swap/quote addresses:
```typescript
gnosis: {
  chainId: 100,
  gatewayUrl: 'https://gnosis-mainnet.g.alchemy.com/v2',
  // ❌ Missing: swapContractAddress, quoteContractAddress
}
```

2. **config.ts** still tried to read these from env vars:
```typescript
gnosis: {
  ...EVM_CHAINS.gnosis,  // spread doesn't include swap/quote
  swapContractAddress: process.env.GNOSIS_SWAP_CONTRACT_ADDRESS,  // undefined in Azure!
  quoteContractAddress: process.env.GNOSIS_QUOTE_CONTRACT_ADDRESS, // undefined in Azure!
}
```

3. **GnosisService** tried to destructure these undefined properties:
```typescript
const { ..., swapContractAddress, quoteContractAddress } = GetConfig().blockchain.gnosis;
// ❌ TypeScript error: Properties don't exist
```

4. **Result:** App crashes on startup when initializing GnosisService

### Why it worked locally but failed in Azure:

- Local env might have had empty strings (`GNOSIS_SWAP_CONTRACT_ADDRESS=""`)
- Azure env likely has these vars **not set at all** (undefined)
- The spread operator doesn't provide these properties for Gnosis

## Solution

✅ Remove `swapContractAddress` and `quoteContractAddress` from:
- Gnosis blockchain config
- GnosisService constructor

This aligns with the original behavior where Gnosis had **empty swap addresses** (Gnosis doesn't support swapping in our setup).

## Changes

- `src/config/config.ts`: Remove swap/quote contract address properties
- `src/integration/blockchain/gnosis/gnosis.service.ts`: Don't destructure undefined properties

## Testing

✅ Build successful: `npm run build`  
✅ API starts without errors  
✅ Swagger endpoint responds correctly  

## Comparison with BSC

BSC works correctly because it **has** swap/quote addresses defined in `chains.config.ts`:
```typescript
bsc: {
  chainId: 56,
  gatewayUrl: 'https://bsc-dataseed.binance.org',
  swapContractAddress: '0xD99D1c33F9fC3444f8101754aBC46c52416550D1',  // ✅ Defined
  quoteContractAddress: '0x78D78E420Da98ad378D7799bE8f4AF69033EB077',   // ✅ Defined
}
```

## Deployment

This hotfix should be merged and deployed to dev **immediately** to restore service.

🔴 **Priority: CRITICAL** - Dev API is currently down