### PR TITLE
Change reset() to set type PENDING instead of GSHEET

### DIFF
--- a/src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity.ts
@@ -356,7 +356,7 @@ export class BankTx extends IEntity {
   reset(): UpdateResult<BankTx> {
     const update: Partial<BankTx> = {
       remittanceInfo: null,
-      type: BankTxType.GSHEET,
+      type: BankTxType.PENDING,
     };
 
     Object.assign(this, update);


### PR DESCRIPTION
## Summary
- Modified `BankTx.reset()` method to set type to `PENDING` instead of `GSHEET`
- When a BankTx with an incomplete BuyCrypto is reset, it now receives the `PENDING` type to properly reflect its state as an unprocessed transaction

## Test plan
- [ ] Verify that resetting a BankTx sets the type to PENDING
- [ ] Confirm that PENDING transactions are handled correctly in the workflow