### PR TITLE
fix(test): add forceExit to Jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "forceExit": true
   },
   "overrides": {
     "request": {


### PR DESCRIPTION
## Summary
- Add `forceExit: true` to Jest configuration
- Prevents "worker process failed to exit gracefully" warning
- Caused by open handles (timers, connections) in tests

## Test plan
- [ ] CI tests pass without exit warning