### PR TITLE
Fix: Only show failure reason when AML check is not passed

### DIFF
--- a/src/subdomains/core/history/mappers/transaction-dto.mapper.ts
+++ b/src/subdomains/core/history/mappers/transaction-dto.mapper.ts
@@ -395,11 +395,12 @@ function getTransactionStateDetails(entity: BuyFiat | BuyCrypto | RefReward | Tr
     return { state: RefRewardStatusMapper[entity.status], reason: null };
   }
 
-  const reason = entity.amlReason
-    ? TransactionReasonMapper[entity.amlReason]
-    : entity.cryptoInput && !entity.cryptoInput.isSettled
-    ? TransactionReason.INPUT_NOT_CONFIRMED
-    : null;
+  const reason =
+    entity.amlReason && [CheckStatus.FAIL, CheckStatus.PENDING, CheckStatus.GSHEET].includes(entity.amlCheck)
+      ? TransactionReasonMapper[entity.amlReason]
+      : entity.cryptoInput && !entity.cryptoInput.isSettled
+      ? TransactionReason.INPUT_NOT_CONFIRMED
+      : null;
 
   if (entity instanceof BuyCrypto) {
     switch (entity.amlCheck) {


### PR DESCRIPTION
## Summary
- Fixed transaction reason display logic to only show failure reasons when AML check is in FAIL, PENDING, or GSHEET status
- Prevents misleading failure reasons from being shown on transactions with passed AML checks (PASS status)

## Changes
- Updated `transaction-dto.mapper.ts` to conditionally set the reason based on amlCheck status
- Transactions with `amlCheck = PASS` now only show `INPUT_NOT_CONFIRMED` reason if applicable, otherwise `null`

## Test plan
- [ ] Verify that transactions with `amlCheck = PASS` no longer display failure reasons in the UI
- [ ] Verify that transactions with `amlCheck = FAIL/PENDING/GSHEET` still display appropriate failure reasons
- [ ] Test edge cases with unconfirmed crypto inputs