### PR TITLE
Refactor: Consolidate EVM chain code

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,6 +24,11 @@ import { MailOptions } from 'src/subdomains/supporting/notification/services/mai
 import { LoggerOptions } from 'typeorm';
 import { EVM_CHAINS } from './chains.config';
 
+// Helper function to get chain-specific private key with fallback to standard EVM wallet
+const getWalletPrivateKey = (chainSpecific: string | undefined): string | undefined => {
+  return chainSpecific || process.env.STANDARD_EVM_WALLET_PRIVATE_KEY;
+};
+
 export enum Environment {
   LOC = 'loc',
   DEV = 'dev',
@@ -721,7 +726,7 @@ export class Configuration {
       ethGatewayUrl: EVM_CHAINS.ethereum.gatewayUrl,
       ethChainId: EVM_CHAINS.ethereum.chainId,
       ethWalletAddress: process.env.ETH_WALLET_ADDRESS,
-      ethWalletPrivateKey: process.env.ETH_WALLET_PRIVATE_KEY,
+      ethWalletPrivateKey: getWalletPrivateKey(process.env.ETH_WALLET_PRIVATE_KEY),
       ethApiKey: process.env.ALCHEMY_API_KEY,
     },
     sepolia: {
@@ -729,7 +734,7 @@ export class Configuration {
       sepoliaGatewayUrl: EVM_CHAINS.sepolia.gatewayUrl,
       sepoliaChainId: EVM_CHAINS.sepolia.chainId,
       sepoliaWalletAddress: process.env.SEPOLIA_WALLET_ADDRESS,
-      sepoliaWalletPrivateKey: process.env.SEPOLIA_WALLET_PRIVATE_KEY,
+      sepoliaWalletPrivateKey: getWalletPrivateKey(process.env.SEPOLIA_WALLET_PRIVATE_KEY),
       sepoliaApiKey: process.env.ALCHEMY_API_KEY,
     },
     optimism: {
@@ -737,7 +742,7 @@ export class Configuration {
       optimismGatewayUrl: EVM_CHAINS.optimism.gatewayUrl,
       optimismChainId: EVM_CHAINS.optimism.chainId,
       optimismWalletAddress: process.env.OPTIMISM_WALLET_ADDRESS,
-      optimismWalletPrivateKey: process.env.OPTIMISM_WALLET_PRIVATE_KEY,
+      optimismWalletPrivateKey: getWalletPrivateKey(process.env.OPTIMISM_WALLET_PRIVATE_KEY),
       optimismApiKey: process.env.ALCHEMY_API_KEY,
     },
     arbitrum: {
@@ -745,7 +750,7 @@ export class Configuration {
       arbitrumGatewayUrl: EVM_CHAINS.arbitrum.gatewayUrl,
       arbitrumChainId: EVM_CHAINS.arbitrum.chainId,
       arbitrumWalletAddress: process.env.ARBITRUM_WALLET_ADDRESS,
-      arbitrumWalletPrivateKey: process.env.ARBITRUM_WALLET_PRIVATE_KEY,
+      arbitrumWalletPrivateKey: getWalletPrivateKey(process.env.ARBITRUM_WALLET_PRIVATE_KEY),
       arbitrumApiKey: process.env.ALCHEMY_API_KEY,
     },
     polygon: {
@@ -753,7 +758,7 @@ export class Configuration {
       polygonGatewayUrl: EVM_CHAINS.polygon.gatewayUrl,
       polygonChainId: EVM_CHAINS.polygon.chainId,
       polygonWalletAddress: process.env.POLYGON_WALLET_ADDRESS,
-      polygonWalletPrivateKey: process.env.POLYGON_WALLET_PRIVATE_KEY,
+      polygonWalletPrivateKey: getWalletPrivateKey(process.env.POLYGON_WALLET_PRIVATE_KEY),
       polygonApiKey: process.env.ALCHEMY_API_KEY,
     },
     base: {
@@ -761,7 +766,7 @@ export class Configuration {
       baseGatewayUrl: EVM_CHAINS.base.gatewayUrl,
       baseChainId: EVM_CHAINS.base.chainId,
       baseWalletAddress: process.env.BASE_WALLET_ADDRESS,
-      baseWalletPrivateKey: process.env.BASE_WALLET_PRIVATE_KEY,
+      baseWalletPrivateKey: getWalletPrivateKey(process.env.BASE_WALLET_PRIVATE_KEY),
       baseApiKey: process.env.ALCHEMY_API_KEY,
     },
     gnosis: {
@@ -769,7 +774,7 @@ export class Configuration {
       gnosisGatewayUrl: EVM_CHAINS.gnosis.gatewayUrl,
       gnosisChainId: EVM_CHAINS.gnosis.chainId,
       gnosisWalletAddress: process.env.GNOSIS_WALLET_ADDRESS,
-      gnosisWalletPrivateKey: process.env.GNOSIS_WALLET_PRIVATE_KEY,
+      gnosisWalletPrivateKey: getWalletPrivateKey(process.env.GNOSIS_WALLET_PRIVATE_KEY),
       gnosisApiKey: process.env.ALCHEMY_API_KEY,
     },
     bsc: {
@@ -777,7 +782,7 @@ export class Configuration {
       bscGatewayUrl: EVM_CHAINS.bsc.gatewayUrl,
       bscChainId: EVM_CHAINS.bsc.chainId,
       bscWalletAddress: process.env.BSC_WALLET_ADDRESS,
-      bscWalletPrivateKey: process.env.BSC_WALLET_PRIVATE_KEY,
+      bscWalletPrivateKey: getWalletPrivateKey(process.env.BSC_WALLET_PRIVATE_KEY),
       bscApiKey: process.env.ALCHEMY_API_KEY,
       gasPrice: process.env.BSC_GAS_PRICE,
     },
@@ -786,7 +791,7 @@ export class Configuration {
       citreaTestnetGatewayUrl: EVM_CHAINS.citreaTestnet.gatewayUrl,
       citreaTestnetChainId: EVM_CHAINS.citreaTestnet.chainId,
       citreaTestnetWalletAddress: process.env.CITREA_TESTNET_WALLET_ADDRESS,
-      citreaTestnetWalletPrivateKey: process.env.CITREA_TESTNET_WALLET_PRIVATE_KEY,
+      citreaTestnetWalletPrivateKey: getWalletPrivateKey(process.env.CITREA_TESTNET_WALLET_PRIVATE_KEY),
       citreaTestnetApiKey: process.env.CITREA_TESTNET_API_KEY,
       goldskySubgraphUrl: process.env.CITREA_TESTNET_GOLDSKY_SUBGRAPH_URL,
     },

--- a/src/integration/blockchain/shared/services/crypto.service.ts
+++ b/src/integration/blockchain/shared/services/crypto.service.ts
@@ -51,103 +51,45 @@ export class CryptoService {
   ): Promise<string | undefined> {
     if (!isValid) return undefined;
 
-    switch (asset.blockchain) {
-      case Blockchain.BITCOIN:
-        return this.bitcoinService.getPaymentRequest(address, amount, label);
+    if (asset.blockchain === Blockchain.BITCOIN) return this.bitcoinService.getPaymentRequest(address, amount, label);
+    if (asset.blockchain === Blockchain.LIGHTNING) return this.lightningService.getInvoiceByLnurlp(address, amount);
+    if (asset.blockchain === Blockchain.SPARK) return this.sparkService.getPaymentRequest(address, amount);
+    if (asset.blockchain === Blockchain.MONERO) return this.moneroService.getPaymentRequest(address, amount);
+    if (asset.blockchain === Blockchain.ZANO) return this.zanoService.getPaymentRequest(address, amount);
+    if (asset.blockchain === Blockchain.SOLANA) return this.solanaService.getPaymentRequest(address, amount);
+    if (asset.blockchain === Blockchain.TRON) return this.tronService.getPaymentRequest(address, amount);
+    if (asset.blockchain === Blockchain.CARDANO) return this.cardanoService.getPaymentRequest(address, amount);
 
-      case Blockchain.LIGHTNING:
-        return this.lightningService.getInvoiceByLnurlp(address, amount);
+    // Standard EVM chains
+    if (EvmBlockchains.includes(asset.blockchain)) return EvmUtil.getPaymentRequest(address, asset, amount);
 
-      case Blockchain.SPARK:
-        return this.sparkService.getPaymentRequest(address, amount);
-
-      case Blockchain.MONERO:
-        return this.moneroService.getPaymentRequest(address, amount);
-
-      case Blockchain.ZANO:
-        return this.zanoService.getPaymentRequest(address, amount);
-
-      case Blockchain.ETHEREUM:
-      case Blockchain.SEPOLIA:
-      case Blockchain.ARBITRUM:
-      case Blockchain.OPTIMISM:
-      case Blockchain.POLYGON:
-      case Blockchain.BASE:
-      case Blockchain.GNOSIS:
-      case Blockchain.HAQQ:
-      case Blockchain.BINANCE_SMART_CHAIN:
-      case Blockchain.CITREA_TESTNET:
-        return EvmUtil.getPaymentRequest(address, asset, amount);
-
-      case Blockchain.SOLANA:
-        return this.solanaService.getPaymentRequest(address, amount);
-
-      case Blockchain.TRON:
-        return this.tronService.getPaymentRequest(address, amount);
-
-      case Blockchain.CARDANO:
-        return this.cardanoService.getPaymentRequest(address, amount);
-
-      default:
-        return undefined;
-    }
+    return undefined;
   }
 
   // --- ADDRESSES --- //
   public static getAddressType(address: string): UserAddressType {
     const blockchain = CryptoService.getDefaultBlockchainBasedOn(address);
 
-    switch (blockchain) {
-      case Blockchain.BITCOIN:
-        if (address.startsWith('bc1')) return UserAddressType.BITCOIN_BECH32;
-        return UserAddressType.BITCOIN_LEGACY;
-
-      case Blockchain.LIGHTNING:
-        if (address.startsWith('$')) return UserAddressType.UMA;
-        return LightningHelper.getAddressType(address) as unknown as UserAddressType;
-
-      case Blockchain.SPARK:
-        return UserAddressType.SPARK;
-
-      case Blockchain.MONERO:
-        return UserAddressType.MONERO;
-
-      case Blockchain.ZANO:
-        return UserAddressType.ZANO;
-
-      case Blockchain.ETHEREUM:
-      case Blockchain.SEPOLIA:
-      case Blockchain.BINANCE_SMART_CHAIN:
-      case Blockchain.POLYGON:
-      case Blockchain.ARBITRUM:
-      case Blockchain.OPTIMISM:
-      case Blockchain.BASE:
-      case Blockchain.GNOSIS:
-      case Blockchain.HAQQ:
-      case Blockchain.CITREA_TESTNET:
-        return UserAddressType.EVM;
-
-      case Blockchain.SOLANA:
-        return UserAddressType.SOLANA;
-
-      case Blockchain.TRON:
-        return UserAddressType.TRON;
-
-      case Blockchain.LIQUID:
-        return UserAddressType.LIQUID;
-
-      case Blockchain.ARWEAVE:
-        return UserAddressType.ARWEAVE;
-
-      case Blockchain.CARDANO:
-        return UserAddressType.CARDANO;
-
-      case Blockchain.RAILGUN:
-        return UserAddressType.RAILGUN;
-
-      default:
-        return UserAddressType.OTHER;
+    if (blockchain === Blockchain.BITCOIN) {
+      return address.startsWith('bc1') ? UserAddressType.BITCOIN_BECH32 : UserAddressType.BITCOIN_LEGACY;
     }
+    if (blockchain === Blockchain.LIGHTNING) {
+      return address.startsWith('$') ? UserAddressType.UMA : LightningHelper.getAddressType(address) as unknown as UserAddressType;
+    }
+    if (blockchain === Blockchain.SPARK) return UserAddressType.SPARK;
+    if (blockchain === Blockchain.MONERO) return UserAddressType.MONERO;
+    if (blockchain === Blockchain.ZANO) return UserAddressType.ZANO;
+    if (blockchain === Blockchain.SOLANA) return UserAddressType.SOLANA;
+    if (blockchain === Blockchain.TRON) return UserAddressType.TRON;
+    if (blockchain === Blockchain.LIQUID) return UserAddressType.LIQUID;
+    if (blockchain === Blockchain.ARWEAVE) return UserAddressType.ARWEAVE;
+    if (blockchain === Blockchain.CARDANO) return UserAddressType.CARDANO;
+    if (blockchain === Blockchain.RAILGUN) return UserAddressType.RAILGUN;
+
+    // Standard EVM chains
+    if (EvmBlockchains.includes(blockchain)) return UserAddressType.EVM;
+
+    return UserAddressType.OTHER;
   }
 
   public static getBlockchainsBasedOn(address: string): Blockchain[] {

--- a/src/integration/blockchain/shared/util/blockchain.util.ts
+++ b/src/integration/blockchain/shared/util/blockchain.util.ts
@@ -137,61 +137,33 @@ const TxPaths: { [b in Blockchain]: string } = {
 };
 
 function assetPaths(asset: Asset): string | undefined {
-  switch (asset.blockchain) {
-    case Blockchain.DEFICHAIN:
-      return `tokens/${asset.name}`;
+  if (asset.blockchain === Blockchain.DEFICHAIN) return `tokens/${asset.name}`;
+  if (asset.blockchain === Blockchain.ZANO) return asset.chainId ? `assets?asset_id=${asset.chainId}` : undefined;
+  if (asset.blockchain === Blockchain.TRON) return asset.chainId ? `token20/${asset.chainId}` : undefined;
 
-    case Blockchain.BITCOIN:
-    case Blockchain.LIGHTNING:
-    case Blockchain.MONERO:
-      return undefined;
-
-    case Blockchain.ZANO:
-      return asset.chainId ? `assets?asset_id=${asset.chainId}` : undefined;
-
-    case Blockchain.ETHEREUM:
-    case Blockchain.BINANCE_SMART_CHAIN:
-    case Blockchain.OPTIMISM:
-    case Blockchain.ARBITRUM:
-    case Blockchain.POLYGON:
-    case Blockchain.BASE:
-    case Blockchain.GNOSIS:
-    case Blockchain.CITREA_TESTNET:
-    case Blockchain.SOLANA:
-    case Blockchain.HAQQ:
-    case Blockchain.CARDANO:
-      return asset.chainId ? `token/${asset.chainId}` : undefined;
-
-    case Blockchain.TRON:
-      return asset.chainId ? `token20/${asset.chainId}` : undefined;
+  // Standard EVM chains + Solana + Cardano use token/{chainId}
+  if (EvmBlockchains.includes(asset.blockchain) ||
+      asset.blockchain === Blockchain.SOLANA ||
+      asset.blockchain === Blockchain.CARDANO) {
+    return asset.chainId ? `token/${asset.chainId}` : undefined;
   }
+
+  return undefined;
 }
 
 function addressPaths(blockchain: Blockchain): string | undefined {
-  switch (blockchain) {
-    case Blockchain.LIGHTNING:
-    case Blockchain.MONERO:
-    case Blockchain.ZANO:
-      return undefined;
+  if (blockchain === Blockchain.SOLANA) return 'account';
 
-    case Blockchain.DEFICHAIN:
-    case Blockchain.BITCOIN:
-    case Blockchain.ETHEREUM:
-    case Blockchain.BINANCE_SMART_CHAIN:
-    case Blockchain.OPTIMISM:
-    case Blockchain.ARBITRUM:
-    case Blockchain.POLYGON:
-    case Blockchain.BASE:
-    case Blockchain.GNOSIS:
-    case Blockchain.CITREA_TESTNET:
-    case Blockchain.TRON:
-    case Blockchain.HAQQ:
-    case Blockchain.LIQUID:
-    case Blockchain.ARWEAVE:
-    case Blockchain.CARDANO:
-      return 'address';
-
-    case Blockchain.SOLANA:
-      return 'account';
+  // Standard EVM chains + other blockchains with address explorers
+  if (EvmBlockchains.includes(blockchain) ||
+      blockchain === Blockchain.DEFICHAIN ||
+      blockchain === Blockchain.BITCOIN ||
+      blockchain === Blockchain.TRON ||
+      blockchain === Blockchain.LIQUID ||
+      blockchain === Blockchain.ARWEAVE ||
+      blockchain === Blockchain.CARDANO) {
+    return 'address';
   }
+
+  return undefined;
 }

--- a/src/subdomains/supporting/payin/strategies/register/impl/arbitrum.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/arbitrum.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class ArbitrumStrategy extends AlchemyStrategy implements OnModuleInit {
+export class ArbitrumStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(ArbitrumStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.ARBITRUM;

--- a/src/subdomains/supporting/payin/strategies/register/impl/base.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/base.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class BaseStrategy extends AlchemyStrategy implements OnModuleInit {
+export class BaseStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(BaseStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.BASE;

--- a/src/subdomains/supporting/payin/strategies/register/impl/bsc.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/bsc.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class BscStrategy extends AlchemyStrategy implements OnModuleInit {
+export class BscStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(BscStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.BINANCE_SMART_CHAIN;

--- a/src/subdomains/supporting/payin/strategies/register/impl/ethereum.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/ethereum.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class EthereumStrategy extends AlchemyStrategy implements OnModuleInit {
+export class EthereumStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(EthereumStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.ETHEREUM;

--- a/src/subdomains/supporting/payin/strategies/register/impl/optimism.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/optimism.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class OptimismStrategy extends AlchemyStrategy implements OnModuleInit {
+export class OptimismStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(OptimismStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.OPTIMISM;

--- a/src/subdomains/supporting/payin/strategies/register/impl/polygon.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/polygon.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class PolygonStrategy extends AlchemyStrategy implements OnModuleInit {
+export class PolygonStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(PolygonStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.POLYGON;

--- a/src/subdomains/supporting/payin/strategies/register/impl/sepolia.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/sepolia.strategy.ts
@@ -1,29 +1,12 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Config } from 'src/config/config';
-import { AlchemyNetworkMapper } from 'src/integration/alchemy/alchemy-network-mapper';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
-import { QueueHandler } from 'src/shared/utils/queue-handler';
 import { AlchemyStrategy } from './base/alchemy.strategy';
 
 @Injectable()
-export class SepoliaStrategy extends AlchemyStrategy implements OnModuleInit {
+export class SepoliaStrategy extends AlchemyStrategy {
   protected readonly logger = new DfxLogger(SepoliaStrategy);
-
-  onModuleInit() {
-    super.onModuleInit();
-
-    this.addressWebhookMessageQueue = new QueueHandler();
-    this.assetTransfersMessageQueue = new QueueHandler();
-
-    this.alchemyWebhookService
-      .getAddressWebhookObservable(AlchemyNetworkMapper.toAlchemyNetworkByBlockchain(this.blockchain))
-      .subscribe((dto) => this.processAddressWebhookMessageQueue(dto));
-
-    this.alchemyService
-      .getAssetTransfersObservable(this.blockchain)
-      .subscribe((at) => this.processAssetTransfersMessageQueue(at));
-  }
 
   get blockchain(): Blockchain {
     return Blockchain.SEPOLIA;


### PR DESCRIPTION
## Summary
- Replace switch statements with Map-based lookups in `BlockchainRegistryService`
- Consolidate EVM chain handling using `EvmBlockchains` array in `blockchain.util.ts` and `CryptoService`
- Move duplicate `onModuleInit()` logic from 7 register strategies to `AlchemyStrategy` base class
- Add `STANDARD_EVM_WALLET_PRIVATE_KEY` fallback to reduce .env duplication (9 vars → 1)

## Code Reduction
- ~305 lines removed
- 12 files modified

## Testing
- [ ] Verify blockchain services still work correctly
- [ ] Test register strategies initialization
- [ ] Confirm wallet address config fallback works