### PR TITLE
fix: replace DeFiChain with Bitcoin as default blockchain

### DIFF
--- a/src/integration/blockchain/shared/services/crypto.service.ts
+++ b/src/integration/blockchain/shared/services/crypto.service.ts
@@ -167,7 +167,7 @@ export class CryptoService {
     if (CryptoService.isArweaveAddress(address)) return [Blockchain.ARWEAVE];
     if (CryptoService.isCardanoAddress(address)) return [Blockchain.CARDANO];
     if (CryptoService.isRailgunAddress(address)) return [Blockchain.RAILGUN];
-    return [Blockchain.DEFICHAIN];
+    return [Blockchain.BITCOIN];
   }
 
   public static getDefaultBlockchainBasedOn(address: string): Blockchain {

--- a/src/shared/models/asset/asset.entity.ts
+++ b/src/shared/models/asset/asset.entity.ts
@@ -82,7 +82,7 @@ export class Asset extends IEntity {
   @Column({ default: false })
   personalIbanEnabled: boolean;
 
-  @Column({ length: 256, default: Blockchain.DEFICHAIN })
+  @Column({ length: 256, default: Blockchain.BITCOIN })
   blockchain: Blockchain;
 
   @Column({ default: false })

--- a/src/subdomains/core/buy-crypto/process/entities/__mocks__/buy-crypto-batch.entity.mock.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/__mocks__/buy-crypto-batch.entity.mock.ts
@@ -10,7 +10,7 @@ const defaultBatch: Partial<BuyCryptoBatch> = {
   outputAsset: createCustomAsset({ dexName: 'dTSLA' }),
   outputAmount: 1,
   status: BuyCryptoBatchStatus.CREATED,
-  blockchain: Blockchain.DEFICHAIN,
+  blockchain: Blockchain.BITCOIN,
 };
 
 export function createDefaultBuyCryptoBatch(): BuyCryptoBatch {

--- a/src/subdomains/supporting/address-pool/deposit/__mocks__/deposit.entity.mock.ts
+++ b/src/subdomains/supporting/address-pool/deposit/__mocks__/deposit.entity.mock.ts
@@ -3,7 +3,7 @@ import { Deposit } from '../deposit.entity';
 
 const defaultDeposit: Partial<Deposit> = {
   address: 'someAddress',
-  blockchains: `${Blockchain.DEFICHAIN}`,
+  blockchains: `${Blockchain.BITCOIN}`,
 };
 
 export function createDefaultDeposit(): Deposit {

--- a/src/subdomains/supporting/dex/entities/__mocks__/liquidity-order.entity.mock.ts
+++ b/src/subdomains/supporting/dex/entities/__mocks__/liquidity-order.entity.mock.ts
@@ -32,7 +32,7 @@ export function createCustomLiquidityOrder(customValues: Partial<LiquidityOrder>
   entity.type = keys.includes('type') ? type : LiquidityOrderType.PURCHASE;
   entity.context = keys.includes('context') ? context : LiquidityOrderContext.BUY_CRYPTO;
   entity.correlationId = keys.includes('correlationId') ? correlationId : 'CID_01';
-  entity.chain = keys.includes('chain') ? chain : Blockchain.DEFICHAIN;
+  entity.chain = keys.includes('chain') ? chain : Blockchain.BITCOIN;
   entity.referenceAsset = keys.includes('referenceAsset') ? referenceAsset : createCustomAsset({ dexName: 'BTC' });
   entity.referenceAmount = keys.includes('referenceAmount') ? referenceAmount : 1;
   entity.targetAsset = keys.includes('targetAsset') ? targetAsset : createDefaultAsset();

--- a/src/subdomains/supporting/payout/entities/__mocks__/payout-order.entity.mock.ts
+++ b/src/subdomains/supporting/payout/entities/__mocks__/payout-order.entity.mock.ts
@@ -16,7 +16,7 @@ export function createCustomPayoutOrder(customValues: Partial<PayoutOrder>): Pay
   entity.id = keys.includes('id') ? id : 1;
   entity.context = keys.includes('context') ? context : PayoutOrderContext.BUY_CRYPTO;
   entity.correlationId = keys.includes('correlationId') ? correlationId : 'CID_01';
-  entity.chain = keys.includes('chain') ? chain : Blockchain.DEFICHAIN;
+  entity.chain = keys.includes('chain') ? chain : Blockchain.BITCOIN;
   entity.asset = keys.includes('asset') ? asset : createDefaultAsset();
   entity.amount = keys.includes('amount') ? amount : 1;
   entity.destinationAddress = keys.includes('destinationAddress') ? destinationAddress : 'ADDR_01';


### PR DESCRIPTION
## Summary
- DeFiChain should never be the default or fallback blockchain
- Replaced all default/fallback values from `Blockchain.DEFICHAIN` to `Blockchain.BITCOIN`

## Changes
- **Asset entity**: Column default changed
- **CryptoService**: Address detection fallback changed
- **Mock entities**: Test defaults updated (payout-order, liquidity-order, deposit, buy-crypto-batch)

## Note
DeFiChain signature verification and explicit test cases remain unchanged - only default/fallback values were replaced.