### PR TITLE
fix: use Bitcoin instead of DeFiChain in test

### DIFF
--- a/src/subdomains/supporting/dex/strategies/purchase-liquidity/__tests__/purchase-liquidity.registry.spec.ts
+++ b/src/subdomains/supporting/dex/strategies/purchase-liquidity/__tests__/purchase-liquidity.registry.spec.ts
@@ -344,7 +344,7 @@ describe('PurchaseLiquidityStrategyRegistry', () => {
 
       it('fails to get strategy for non-supported AssetCategory', () => {
         const strategy = registry.getPurchaseLiquidityStrategy(
-          createCustomAsset({ blockchain: Blockchain.DEFICHAIN, category: 'NewCategory' as AssetCategory }),
+          createCustomAsset({ blockchain: Blockchain.BITCOIN, category: 'NewCategory' as AssetCategory }),
         );
 
         expect(strategy).toBeUndefined();


### PR DESCRIPTION
## Summary
- Uses Bitcoin instead of DeFiChain in the test for non-supported AssetCategory
- DeFiChain should not be used as example value in tests

Follow-up to #2726