### PR TITLE
fix: remove DeFiChain signature verification

### DIFF
--- a/src/subdomains/generic/user/models/auth/auth.service.ts
+++ b/src/subdomains/generic/user/models/auth/auth.service.ts
@@ -433,6 +433,11 @@ export class AuthService {
       return !dbSignature || signature === dbSignature;
     }
 
+    if (blockchains.includes(Blockchain.DEFICHAIN)) {
+      // DeFiChain wallet, only comparison check (no new registrations)
+      return dbSignature && signature === dbSignature;
+    }
+
     let isValid = await this.cryptoService.verifySignature(defaultMessage, address, signature, key);
     if (!isValid) isValid = await this.cryptoService.verifySignature(fallbackMessage, address, signature, key);
 


### PR DESCRIPTION
## Summary
- Removes DeFiChain signature verification from CryptoService
- Removes unused `@defichain/jellyfish-network` import

Existing users can be verified by comparing the stored signature in the database.