### PR TITLE
fix: use Bitcoin instead of DeFiChain in liquidity-order factory test

### DIFF
--- a/src/subdomains/supporting/dex/factories/__tests__/liquidity-order.factory.spec.ts
+++ b/src/subdomains/supporting/dex/factories/__tests__/liquidity-order.factory.spec.ts
@@ -35,7 +35,7 @@ describe('LiquidityOrderFactory', () => {
     it('sets purchaseStrategy to AssetCategory', () => {
       const entity = factory.createPurchaseOrder(
         createDefaultGetLiquidityRequest(),
-        Blockchain.DEFICHAIN,
+        Blockchain.BITCOIN,
         AssetCategory.PUBLIC,
       );
 


### PR DESCRIPTION
Replace DeFiChain with Bitcoin as example blockchain value in test.