### PR TITLE
fix: replace DFI with active assets in mocks and tests

### DIFF
--- a/src/integration/exchange/dto/__mocks__/price.dto.mock.ts
+++ b/src/integration/exchange/dto/__mocks__/price.dto.mock.ts
@@ -11,7 +11,7 @@ export function createCustomPrice(customValues: Partial<Price>): Price {
   const entity = new Price();
 
   entity.source = keys.includes('source') ? source : 'BTC';
-  entity.target = keys.includes('target') ? target : 'DFI';
+  entity.target = keys.includes('target') ? target : 'USDT';
   entity.price = keys.includes('price') ? price : 10;
 
   return entity;

--- a/src/subdomains/supporting/dex/entities/__mocks__/liquidity-order.entity.mock.ts
+++ b/src/subdomains/supporting/dex/entities/__mocks__/liquidity-order.entity.mock.ts
@@ -39,7 +39,7 @@ export function createCustomLiquidityOrder(customValues: Partial<LiquidityOrder>
   entity.targetAmount = keys.includes('targetAmount') ? targetAmount : 2;
   entity.isReady = keys.includes('isReady') ? isReady : false;
   entity.isComplete = keys.includes('isComplete') ? isComplete : false;
-  entity.swapAsset = keys.includes('swapAsset') ? swapAsset : createCustomAsset({ dexName: 'DFI' });
+  entity.swapAsset = keys.includes('swapAsset') ? swapAsset : createCustomAsset({ dexName: 'USDT' });
   entity.swapAmount = keys.includes('swapAmount') ? swapAmount : 1;
   entity.strategy = keys.includes('strategy') ? strategy : AssetCategory.PUBLIC;
   entity.txId = keys.includes('txId') ? txId : 'PID_01';

--- a/src/subdomains/supporting/dex/entities/__tests__/liquidity-order.entity.spec.ts
+++ b/src/subdomains/supporting/dex/entities/__tests__/liquidity-order.entity.spec.ts
@@ -73,9 +73,9 @@ describe('LiquidityOrder', () => {
       expect(entity.swapAsset).toBeUndefined();
       expect(entity.swapAmount).toBeUndefined();
 
-      entity.addBlockchainTransactionMetadata('PID_01', createCustomAsset({ dexName: 'DFI' }), 20);
+      entity.addBlockchainTransactionMetadata('PID_01', createCustomAsset({ dexName: 'ETH' }), 20);
 
-      expect(entity.swapAsset.dexName).toBe('DFI');
+      expect(entity.swapAsset.dexName).toBe('ETH');
       expect(entity.swapAmount).toBe(20);
     });
   });
@@ -155,7 +155,6 @@ describe('LiquidityOrder', () => {
       expect(LiquidityOrder.getIsReferenceAsset('BNB')).toBe(true);
     });
     it('returns false if input asset is not in reference assets list list', () => {
-      expect(LiquidityOrder.getIsReferenceAsset('DFI')).toBe(false);
       expect(LiquidityOrder.getIsReferenceAsset('GOOGL')).toBe(false);
     });
   });
@@ -169,7 +168,6 @@ describe('LiquidityOrder', () => {
       expect(LiquidityOrder.getMaxPriceSlippage('BNB')).toBe(0.005);
     });
     it('returns 0.03 if input asset is not in reference assets list list', () => {
-      expect(LiquidityOrder.getMaxPriceSlippage('DFI')).toBe(0.03);
       expect(LiquidityOrder.getMaxPriceSlippage('GOOGL')).toBe(0.03);
     });
   });


### PR DESCRIPTION
## Summary
- Replace DFI references in mocks/tests with active assets (USDT, ETH)
- Remove redundant DFI test cases (GOOGL already tests the same behavior)

## Changes
- `price.dto.mock.ts`: target 'DFI' → 'USDT'
- `liquidity-order.entity.mock.ts`: swapAsset 'DFI' → 'USDT'
- `liquidity-order.entity.spec.ts`: test asset 'DFI' → 'ETH', removed redundant DFI assertions