### PR TITLE
Fix: Auto-generate EVM wallet addresses in setup script

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -407,6 +407,29 @@ async function main() {
     }
   }
 
+  // Derive and set wallet addresses from private keys
+  const wallet = new ethers.Wallet(sharedEvmKey);
+  const sharedEvmAddress = wallet.address;
+
+  const addressesToGenerate = [
+    'ETH_WALLET_ADDRESS',
+    'SEPOLIA_WALLET_ADDRESS',
+    'BSC_WALLET_ADDRESS',
+    'OPTIMISM_WALLET_ADDRESS',
+    'BASE_WALLET_ADDRESS',
+    'ARBITRUM_WALLET_ADDRESS',
+    'POLYGON_WALLET_ADDRESS',
+    'GNOSIS_WALLET_ADDRESS',
+    'CITREA_TESTNET_WALLET_ADDRESS',
+  ];
+
+  for (const addressName of addressesToGenerate) {
+    if (!readEnvValue(addressName)) {
+      updateEnvFile({ [addressName]: sharedEvmAddress });
+      generatedCount++;
+    }
+  }
+
   if (generatedCount > 0) {
     logSuccess(`Generated ${generatedCount} wallet seeds/keys`);
   } else {


### PR DESCRIPTION
## Problem

The setup script generated  environment variables for all EVM chains, but did not generate the corresponding  variables. This caused runtime errors when the backend tried to read undefined addresses:

```
TypeError: Cannot read properties of undefined (reading 'toHexString')
```

### Root Cause

In `scripts/setup.js` (lines 400-408), only private keys were generated, but `config.ts` expects both `PRIVATE_KEY` and `ADDRESS` for each chain.

### Missing Variables

- ETH_WALLET_ADDRESS
- SEPOLIA_WALLET_ADDRESS  
- BSC_WALLET_ADDRESS
- OPTIMISM_WALLET_ADDRESS
- BASE_WALLET_ADDRESS
- ARBITRUM_WALLET_ADDRESS
- POLYGON_WALLET_ADDRESS
- GNOSIS_WALLET_ADDRESS
- CITREA_TESTNET_WALLET_ADDRESS

## Solution

After generating private keys, derive the address using `ethers.Wallet` and automatically set all `*_WALLET_ADDRESS` environment variables.

## Impact

- ✅ Fixes "Cannot read properties of undefined (reading 'toHexString')" errors
- ✅ Prevents EVM strategy initialization failures
- ✅ Ensures all EVM chains can be used in local development

## Additional Changes

Added development helper scripts:
- `check-tx.js`: Direct Alchemy API query for transaction details
- `db-query.sh`: Quick MSSQL query wrapper for local dev
- `sync-transaction.js`: Manual transaction sync for testing