### PR TITLE
Fix: Auto-generate EVM wallet addresses in setup script

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -407,6 +407,29 @@ async function main() {
     }
   }
 
+  // Derive and set wallet addresses from private keys
+  const wallet = new ethers.Wallet(sharedEvmKey);
+  const sharedEvmAddress = wallet.address;
+
+  const addressesToGenerate = [
+    'ETH_WALLET_ADDRESS',
+    'SEPOLIA_WALLET_ADDRESS',
+    'BSC_WALLET_ADDRESS',
+    'OPTIMISM_WALLET_ADDRESS',
+    'BASE_WALLET_ADDRESS',
+    'ARBITRUM_WALLET_ADDRESS',
+    'POLYGON_WALLET_ADDRESS',
+    'GNOSIS_WALLET_ADDRESS',
+    'CITREA_TESTNET_WALLET_ADDRESS',
+  ];
+
+  for (const addressName of addressesToGenerate) {
+    if (!readEnvValue(addressName)) {
+      updateEnvFile({ [addressName]: sharedEvmAddress });
+      generatedCount++;
+    }
+  }
+
   if (generatedCount > 0) {
     logSuccess(`Generated ${generatedCount} wallet seeds/keys`);
   } else {


### PR DESCRIPTION
Problem:
Setup script generated WALLET_PRIVATE_KEY variables but not the corresponding WALLET_ADDRESS variables, causing runtime errors: TypeError: Cannot read properties of undefined (reading 'toHexString')

Solution:
Derive wallet address from private key using ethers.Wallet and automatically set all *_WALLET_ADDRESS environment variables.

Missing variables that are now auto-generated:
- ETH_WALLET_ADDRESS
- SEPOLIA_WALLET_ADDRESS
- BSC_WALLET_ADDRESS
- OPTIMISM_WALLET_ADDRESS
- BASE_WALLET_ADDRESS
- ARBITRUM_WALLET_ADDRESS
- POLYGON_WALLET_ADDRESS
- GNOSIS_WALLET_ADDRESS
- CITREA_TESTNET_WALLET_ADDRESS

### Release Checklist

#### Pre-Release

- [ ] Check migrations
  - No database related infos (sqldb-xxx)
  - Impact on GS (new/removed columns)
- [ ] Check for linter errors (in PR)
- [ ] Test basic user operations (on [DFX services](https://dev.app.dfx.swiss))
  - Login/logout
  - Buy/sell payment request
  - KYC page

#### Post-Release

- Test basic user operations
- Monitor application insights log
