### PR TITLE
fix: enable no-case-declarations ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,6 @@ module.exports = tseslint.config(
         },
       ],
       '@typescript-eslint/no-unused-expressions': 'off',
-      'no-case-declarations': 'off',
       'no-async-promise-executor': 'off',
     },
   },

--- a/src/integration/exchange/services/exchange.service.ts
+++ b/src/integration/exchange/services/exchange.service.ts
@@ -132,7 +132,7 @@ export abstract class ExchangeService extends PricingProvider implements OnModul
     const order = await this.getTrade(id, from, to);
 
     switch (order.status) {
-      case OrderStatus.OPEN:
+      case OrderStatus.OPEN: {
         const price = await this.fetchCurrentOrderPrice(order.symbol, order.side);
 
         // price changed -> update price
@@ -173,8 +173,9 @@ export abstract class ExchangeService extends PricingProvider implements OnModul
         }
 
         return false;
+      }
 
-      case OrderStatus.CANCELED:
+      case OrderStatus.CANCELED: {
         // check for min. amount
         const minAmount = await this.getMinTradeAmount(order.symbol);
         if (order.remaining < minAmount) {
@@ -188,6 +189,7 @@ export abstract class ExchangeService extends PricingProvider implements OnModul
         this.logger.verbose(`Order ${order.id} changed to ${id}`);
 
         throw new TradeChangedException(id);
+      }
 
       case OrderStatus.CLOSED:
         this.logger.verbose(`Order ${order.id} closed`);

--- a/src/subdomains/core/history/controllers/transaction.controller.ts
+++ b/src/subdomains/core/history/controllers/transaction.controller.ts
@@ -646,26 +646,29 @@ export class TransactionController {
     detailed = false,
   ): Promise<TransactionDto | TransactionDetailDto | UnassignedTransactionDto | undefined> {
     switch (transaction?.targetEntity?.constructor) {
-      case BuyCrypto:
+      case BuyCrypto: {
         const buyCryptoExtended = await this.buyCryptoWebhookService.extendBuyCrypto(transaction.buyCrypto);
         return detailed
           ? TransactionDtoMapper.mapBuyCryptoTransactionDetail(buyCryptoExtended)
           : TransactionDtoMapper.mapBuyCryptoTransaction(buyCryptoExtended);
+      }
 
-      case BuyFiat:
+      case BuyFiat: {
         const buyFiatExtended = await this.buyFiatService.extendBuyFiat(transaction.buyFiat);
         return detailed
           ? TransactionDtoMapper.mapBuyFiatTransactionDetail(buyFiatExtended)
           : TransactionDtoMapper.mapBuyFiatTransaction(buyFiatExtended);
+      }
 
       case RefReward:
         return detailed
           ? TransactionDtoMapper.mapReferralRewardDetail(transaction.refReward)
           : TransactionDtoMapper.mapReferralReward(transaction.refReward);
 
-      case BankTxReturn:
+      case BankTxReturn: {
         const currency = await this.fiatService.getFiatByName(transaction.bankTx.txCurrency);
         return TransactionDtoMapper.mapUnassignedTransaction(transaction.bankTx, currency, transaction.bankTxReturn);
+      }
 
       default:
         if (transaction?.sourceEntity instanceof BankTx && !transaction?.type) {

--- a/src/subdomains/core/history/services/history.service.ts
+++ b/src/subdomains/core/history/services/history.service.ts
@@ -204,7 +204,7 @@ export class HistoryService {
           'DESC',
         ) as HistoryDto<T>[];
 
-      case ExportType.COMPACT:
+      case ExportType.COMPACT: {
         const extendedBuyCryptos = buyCryptos.length
           ? await Util.asyncMap(buyCryptos, (b) => this.buyCryptoWebhookService.extendBuyCrypto(b))
           : [];
@@ -221,6 +221,7 @@ export class HistoryService {
           'date',
           'DESC',
         ) as HistoryDto<T>[];
+      }
     }
   }
 

--- a/src/subdomains/core/liquidity-management/adapters/actions/liquidity-pipeline.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/liquidity-pipeline.adapter.ts
@@ -94,7 +94,7 @@ export class LiquidityPipelineAdapter extends LiquidityActionAdapter {
         return true;
 
       case LiquidityManagementPipelineStatus.STOPPED:
-      case LiquidityManagementPipelineStatus.FAILED:
+      case LiquidityManagementPipelineStatus.FAILED: {
         const failedOrder = await this.orderRepo.findOne({
           where: { pipeline: { id: pipeline.id } },
           order: { id: 'DESC' },
@@ -103,6 +103,7 @@ export class LiquidityPipelineAdapter extends LiquidityActionAdapter {
         throw new OrderNotProcessableException(
           `Triggered pipeline ${pipeline.id} (rule ${pipeline.rule.id}) for ${pipeline.rule.targetAsset.uniqueName} failed with error: ${failedOrder.errorMessage}`,
         );
+      }
     }
   }
 

--- a/src/subdomains/core/liquidity-management/adapters/balances/bank.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/bank.adapter.ts
@@ -56,13 +56,14 @@ export class BankAdapter implements LiquidityBalanceIntegration {
 
     try {
       switch (bankName) {
-        case IbanBankName.OLKY:
+        case IbanBankName.OLKY: {
           const olkyBalance = await this.olkypayService.getBalance().then((b) => b.balance);
           assets.forEach((asset) => balances.push(LiquidityBalance.create(asset, olkyBalance)));
 
           break;
+        }
 
-        case IbanBankName.YAPEAL:
+        case IbanBankName.YAPEAL: {
           const yapealBalances = await this.yapealService.getBalances();
 
           for (const balance of yapealBalances) {
@@ -71,8 +72,9 @@ export class BankAdapter implements LiquidityBalanceIntegration {
           }
 
           break;
+        }
 
-        case CardBankName.CHECKOUT:
+        case CardBankName.CHECKOUT: {
           const checkoutBalances = await this.checkoutService.getBalances();
 
           assets.forEach((asset) => {
@@ -83,6 +85,7 @@ export class BankAdapter implements LiquidityBalanceIntegration {
           });
 
           break;
+        }
 
         default:
           for (const asset of assets) {

--- a/src/subdomains/generic/kyc/services/kyc-admin.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc-admin.service.ts
@@ -71,12 +71,13 @@ export class KycAdminService {
           await this.kycService.completeCommercialRegister(kycStep.userData);
           break;
 
-        case KycStepName.IDENT:
+        case KycStepName.IDENT: {
           const nationalityData = kycStep.userData
             .getCompletedStepWith(KycStepName.NATIONALITY_DATA)
             ?.getResult<KycNationalityData>();
           await this.kycService.completeIdent(kycStep, undefined, nationalityData);
           break;
+        }
 
         case KycStepName.FINANCIAL_DATA:
           await this.kycService.completeFinancialData(kycStep);

--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -1039,7 +1039,7 @@ export class KycService {
       case KycStepName.STATUTES:
         return { nextStep: { name: nextStep, preventDirectEvaluation } };
 
-      case KycStepName.RECOMMENDATION:
+      case KycStepName.RECOMMENDATION: {
         const recommendationSteps = user.getStepsWith(KycStepName.RECOMMENDATION);
         if (
           (recommendationSteps.some((r) => r.comment?.split(';').includes(KycError.BLOCKED)) ||
@@ -1049,8 +1049,9 @@ export class KycService {
           return { nextStep: undefined };
 
         return { nextStep: { name: nextStep, preventDirectEvaluation } };
+      }
 
-      case KycStepName.IDENT:
+      case KycStepName.IDENT: {
         const identSteps = user.getStepsWith(KycStepName.IDENT);
         if (
           identSteps.some((i) => i.comment?.split(';').includes(KycError.USER_DATA_EXISTING)) ||
@@ -1090,8 +1091,9 @@ export class KycService {
             preventDirectEvaluation,
           },
         };
+      }
 
-      case KycStepName.DFX_APPROVAL:
+      case KycStepName.DFX_APPROVAL: {
         const approvalSteps = user.getStepsWith(KycStepName.DFX_APPROVAL);
         if (
           (approvalSteps.some((i) => i.comment?.split(';').includes(KycError.BLOCKED)) &&
@@ -1101,6 +1103,7 @@ export class KycService {
           return { nextStep: undefined };
 
         return { nextStep: { name: nextStep, preventDirectEvaluation } };
+      }
 
       default:
         return { nextStep: undefined };
@@ -1145,7 +1148,7 @@ export class KycService {
 
         break;
 
-      case KycStepName.DFX_APPROVAL:
+      case KycStepName.DFX_APPROVAL: {
         const missingCompletedSteps = requiredKycSteps(user).filter((rs) => !user.hasCompletedStep(rs));
 
         user.kycLevel >= KycLevel.LEVEL_50
@@ -1155,6 +1158,7 @@ export class KycService {
             : kycStep.onHold();
 
         break;
+      }
     }
 
     return this.kycStepRepo.save(kycStep);

--- a/src/subdomains/generic/user/models/user-data/user-data.entity.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.entity.ts
@@ -757,9 +757,10 @@ export function Blank(value: string, type: BlankType): string {
       return `${createStringOf('*', value.length - numberOfLastVisibleNumbers)}${value.substring(
         value.length - numberOfLastVisibleNumbers,
       )}`;
-    case BlankType.MAIL:
+    case BlankType.MAIL: {
       const [name, domain] = value.split('@');
       return `${name[0]}${createStringOf('*', name.length - 1)}@${domain}`;
+    }
     case BlankType.WALLET_ADDRESS:
       return `${value.substring(0, 4)}${createStringOf('*', 8)}${value.substring(value.length - 4)}`;
   }

--- a/src/subdomains/supporting/notification/factories/mail.factory.ts
+++ b/src/subdomains/supporting/notification/factories/mail.factory.ts
@@ -258,7 +258,7 @@ export class MailFactory {
           DefaultEmptyLine,
         ];
 
-      default:
+      default: {
         const params = Util.removeNullFields(element.params);
         const translatedParams = this.translateParams(params, lang);
         const text = this.translate(element.key, lang, translatedParams);
@@ -290,6 +290,7 @@ export class MailFactory {
             underline: element.params?.underline,
           },
         ];
+      }
     }
   }
 

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/send.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/send.strategy.ts
@@ -71,7 +71,7 @@ export abstract class SendStrategy implements OnModuleInit, OnModuleDestroy {
     feeAmount: number = null,
   ): Promise<CryptoInput | null> {
     switch (type) {
-      case SendType.FORWARD:
+      case SendType.FORWARD: {
         const feeAsset = await this.assetService.getNativeAsset(payIn.asset.blockchain);
         const feeAmountChf = feeAmount
           ? await this.pricingService
@@ -80,6 +80,7 @@ export abstract class SendStrategy implements OnModuleInit, OnModuleDestroy {
           : null;
 
         return payIn.forward(outTxId, feeAmount, feeAmountChf);
+      }
 
       case SendType.RETURN:
         return payIn.return(outTxId, feeAmount);

--- a/src/subdomains/supporting/payment/services/swiss-qr.service.ts
+++ b/src/subdomains/supporting/payment/services/swiss-qr.service.ts
@@ -474,7 +474,7 @@ export class SwissQRService {
     };
 
     switch (transactionType) {
-      case TransactionType.BUY:
+      case TransactionType.BUY: {
         const outputAsset = transaction.buyCrypto?.outputAsset;
 
         return {
@@ -487,8 +487,9 @@ export class SwissQRService {
           fiatAmount: transaction.buyCrypto?.inputAmount,
           ...titleAndDate,
         };
+      }
 
-      case TransactionType.SELL:
+      case TransactionType.SELL: {
         const inputAsset = transaction.buyFiat?.cryptoInput?.asset;
 
         return {
@@ -501,8 +502,9 @@ export class SwissQRService {
           fiatAmount: transaction.buyFiat?.outputAmount,
           ...titleAndDate,
         };
+      }
 
-      case TransactionType.SWAP:
+      case TransactionType.SWAP: {
         const sourceAsset = transaction.buyCrypto?.cryptoInput?.asset;
         const targetAsset = transaction.buyCrypto?.outputAsset;
 
@@ -520,8 +522,9 @@ export class SwissQRService {
           fiatAmount: currency === 'CHF' ? transaction.buyCrypto?.amountInChf : transaction.buyCrypto?.amountInEur,
           ...titleAndDate,
         };
+      }
 
-      case TransactionType.REFERRAL:
+      case TransactionType.REFERRAL: {
         const targetBlockchain = transaction.refReward?.targetBlockchain;
         if (!targetBlockchain) throw new Error('Missing blockchain information for referral');
         const asset = await this.assetService.getNativeAsset(targetBlockchain);
@@ -536,6 +539,7 @@ export class SwissQRService {
           fiatAmount: currency === 'CHF' ? transaction.refReward?.amountInChf : transaction.refReward?.amountInEur,
           ...titleAndDate,
         };
+      }
 
       default:
         throw new Error('Unsupported transaction type');

--- a/src/subdomains/supporting/payment/services/transaction-request.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction-request.service.ts
@@ -115,7 +115,7 @@ export class TransactionRequestService {
       let siftOrder: boolean;
 
       switch (type) {
-        case TransactionRequestType.BUY:
+        case TransactionRequestType.BUY: {
           const buyRequest = request as GetBuyPaymentInfoDto;
           const buyResponse = response as BuyPaymentInfoDto;
 
@@ -129,8 +129,9 @@ export class TransactionRequestService {
           blockchain = buyResponse.asset.blockchain;
           siftOrder = true;
           break;
+        }
 
-        case TransactionRequestType.SELL:
+        case TransactionRequestType.SELL: {
           const sellResponse = response as SellPaymentInfoDto;
 
           transactionRequest.sourcePaymentMethod = CryptoPaymentMethod.CRYPTO;
@@ -141,8 +142,9 @@ export class TransactionRequestService {
           targetCurrencyName = sellResponse.currency.name;
           blockchain = sellResponse.asset.blockchain;
           break;
+        }
 
-        case TransactionRequestType.SWAP:
+        case TransactionRequestType.SWAP: {
           const convertResponse = response as SwapPaymentInfoDto;
 
           transactionRequest.sourcePaymentMethod = CryptoPaymentMethod.CRYPTO;
@@ -152,6 +154,7 @@ export class TransactionRequestService {
           sourceCurrencyName = convertResponse.sourceAsset.name;
           targetCurrencyName = convertResponse.targetAsset.name;
           break;
+        }
       }
 
       // save


### PR DESCRIPTION
## Summary

Re-enables the `no-case-declarations` ESLint rule and fixes all 35 violations by wrapping case blocks containing lexical declarations (`const`, `let`) in curly braces.

### Why this matters

Without braces, variables declared in one case block are technically in scope for all subsequent cases, which can lead to confusing behavior:

```typescript
// Before (problematic)
switch (x) {
  case 1:
    const value = 1;
    break;
  case 2:
    // 'value' is technically in scope here but uninitialized
    break;
}

// After (correct)
switch (x) {
  case 1: {
    const value = 1;
    break;
  }
  case 2:
    // 'value' is not in scope
    break;
}
```

### Files modified

- `exchange.service.ts` - 2 cases
- `transaction.controller.ts` - 3 cases
- `history.service.ts` - 1 case
- `liquidity-pipeline.adapter.ts` - 1 case
- `bank.adapter.ts` - 3 cases
- `kyc-admin.service.ts` - 1 case
- `kyc.service.ts` - 5 cases
- `user-data.entity.ts` - 1 case
- `mail.factory.ts` - 1 case (default)
- `send.strategy.ts` - 1 case
- `swiss-qr.service.ts` - 4 cases
- `transaction-request.service.ts` - 3 cases

## Test plan

- [ ] CI build passes
- [ ] CI tests pass
- [ ] CI linter passes (0 errors, same warnings as before)