### PR TITLE
Remove Maerki Baumann integration and set Yapeal as default bank

### DIFF
--- a/src/shared/models/country/__mocks__/country.entity.mock.ts
+++ b/src/shared/models/country/__mocks__/country.entity.mock.ts
@@ -7,7 +7,6 @@ const defaultCountry: Partial<Country> = {
   dfxEnable: true,
   lockEnable: true,
   ipEnable: true,
-  maerkiBaumannEnable: true,
   yapealEnable: true,
   updated: undefined,
   created: undefined,

--- a/src/shared/models/country/country.entity.ts
+++ b/src/shared/models/country/country.entity.ts
@@ -31,9 +31,6 @@ export class Country extends IEntity {
   ipEnable: boolean;
 
   @Column({ default: false })
-  maerkiBaumannEnable: boolean;
-
-  @Column({ default: false })
   yapealEnable: boolean;
 
   @Column({ default: true })

--- a/src/subdomains/core/history/__tests__/transaction-helper.spec.ts
+++ b/src/subdomains/core/history/__tests__/transaction-helper.spec.ts
@@ -106,7 +106,7 @@ describe('TransactionHelper', () => {
       txHelper.getRefundData(
         transaction.refundTargetEntity,
         defaultUserData,
-        IbanBankName.MAERKI,
+        IbanBankName.YAPEAL,
         'DE12500105170648489890',
         !transaction.cryptoInput,
       ),
@@ -135,7 +135,7 @@ describe('TransactionHelper', () => {
       txHelper.getRefundData(
         transaction.refundTargetEntity,
         defaultUserData,
-        IbanBankName.MAERKI,
+        IbanBankName.YAPEAL,
         'DE12500105170648489890',
         !transaction.cryptoInput,
       ),

--- a/src/subdomains/core/sell-crypto/process/services/buy-fiat-preparation.service.ts
+++ b/src/subdomains/core/sell-crypto/process/services/buy-fiat-preparation.service.ts
@@ -201,7 +201,7 @@ export class BuyFiatPreparationService {
           CryptoPaymentMethod.CRYPTO,
           FiatPaymentMethod.BANK,
           undefined,
-          IbanBankName.MAERKI,
+          IbanBankName.YAPEAL,
           entity.user,
         );
 

--- a/src/subdomains/supporting/bank/bank/__mocks__/bank.entity.mock.ts
+++ b/src/subdomains/supporting/bank/bank/__mocks__/bank.entity.mock.ts
@@ -19,19 +19,19 @@ export const olkyEUR = createCustomBank({
   sctInst: true,
 });
 
-export const maerkiEUR = createCustomBank({
-  name: IbanBankName.MAERKI,
+export const yapealEUR = createCustomBank({
+  name: IbanBankName.YAPEAL,
   currency: 'EUR',
-  iban: 'CH6808573177975201814',
-  bic: 'MAEBCHZZ',
+  iban: 'CH1234567890123456789',
+  bic: 'YAPECHCHXXX',
   receive: true,
 });
 
-export const maerkiCHF = createCustomBank({
-  name: IbanBankName.MAERKI,
+export const yapealCHF = createCustomBank({
+  name: IbanBankName.YAPEAL,
   currency: 'CHF',
-  iban: 'CH3408573177975200001',
-  bic: 'MAEBCHZZ',
+  iban: 'CH9876543210987654321',
+  bic: 'YAPECHCHXXX',
   receive: true,
 });
 
@@ -44,10 +44,10 @@ export function createCustomBank(customValues: Partial<Bank>): Bank {
 }
 
 export function createDefaultBanks(): Bank[] {
-  return [olkyEUR, maerkiEUR, maerkiCHF];
+  return [olkyEUR, yapealEUR, yapealCHF];
 }
 
 export function createDefaultDisabledBanks(): Bank[] {
   olkyEUR.receive = false;
-  return [olkyEUR, maerkiEUR, maerkiCHF];
+  return [olkyEUR, yapealEUR, yapealCHF];
 }

--- a/src/subdomains/supporting/bank/bank/__tests__/bank.service.spec.ts
+++ b/src/subdomains/supporting/bank/bank/__tests__/bank.service.spec.ts
@@ -14,8 +14,8 @@ import { FiatPaymentMethod } from 'src/subdomains/supporting/payment/dto/payment
 import {
   createDefaultBanks,
   createDefaultDisabledBanks,
-  maerkiCHF,
-  maerkiEUR,
+  yapealCHF,
+  yapealEUR,
   olkyEUR,
 } from '../__mocks__/bank.entity.mock';
 import { BankRepository } from '../bank.repository';
@@ -70,10 +70,10 @@ describe('BankService', () => {
     service = module.get<BankService>(BankService);
   });
 
-  function defaultSetup(maerkiBaumannEnable = true, disabledBank = false) {
+  function defaultSetup(yapealEnable = true, disabledBank = false) {
     jest
       .spyOn(countryService, 'getCountryWithSymbol')
-      .mockResolvedValue(createCustomCountry({ maerkiBaumannEnable: maerkiBaumannEnable }));
+      .mockResolvedValue(createCustomCountry({ yapealEnable: yapealEnable }));
 
     const allBanks = disabledBank ? createDefaultDisabledBanks() : createDefaultBanks();
     jest.spyOn(bankRepo, 'findCachedBy').mockImplementation(async (_key: string, filter?: any) => {
@@ -91,8 +91,8 @@ describe('BankService', () => {
   it('should return first matching bank for CHF currency', async () => {
     defaultSetup();
     const result = await service.getBank(createBankSelectorInput('CHF', 10000));
-    expect(result.iban).toBe(maerkiCHF.iban);
-    expect(result.bic).toBe(maerkiCHF.bic);
+    expect(result.iban).toBe(yapealCHF.iban);
+    expect(result.bic).toBe(yapealCHF.bic);
   });
 
   it('should return matching bank for EUR currency', async () => {
@@ -112,8 +112,8 @@ describe('BankService', () => {
   it('should return first matching bank for CHF currency with standard payment', async () => {
     defaultSetup(true);
     const result = await service.getBank(createBankSelectorInput('CHF'));
-    expect(result.iban).toBe(maerkiCHF.iban);
-    expect(result.bic).toBe(maerkiCHF.bic);
+    expect(result.iban).toBe(yapealCHF.iban);
+    expect(result.bic).toBe(yapealCHF.bic);
   });
 
   it('should fallback to EUR for unsupported currency', async () => {
@@ -126,7 +126,7 @@ describe('BankService', () => {
   it('should fallback to first EUR bank when sctInst bank is disabled', async () => {
     defaultSetup(true, true);
     const result = await service.getBank(createBankSelectorInput('EUR', undefined, FiatPaymentMethod.INSTANT));
-    expect(result.iban).toBe(maerkiEUR.iban);
-    expect(result.bic).toBe(maerkiEUR.bic);
+    expect(result.iban).toBe(yapealEUR.iban);
+    expect(result.bic).toBe(yapealEUR.bic);
   });
 });

--- a/src/subdomains/supporting/bank/bank/bank.entity.ts
+++ b/src/subdomains/supporting/bank/bank/bank.entity.ts
@@ -38,9 +38,6 @@ export class Bank extends IEntity {
   // --- ENTITY METHODS --- //
 
   isCountryEnabled(country: Country): boolean {
-    return (
-      (this.name === IbanBankName.YAPEAL && country.yapealEnable) ||
-      (this.name === IbanBankName.MAERKI && country.maerkiBaumannEnable)
-    );
+    return this.name === IbanBankName.YAPEAL && country.yapealEnable;
   }
 }

--- a/src/subdomains/supporting/bank/bank/bank.service.ts
+++ b/src/subdomains/supporting/bank/bank/bank.service.ts
@@ -107,8 +107,6 @@ export class BankService implements OnModuleInit {
 
   private static blockchainToBankName(blockchain: Blockchain): IbanBankName | undefined {
     switch (blockchain) {
-      case Blockchain.MAERKI_BAUMANN:
-        return IbanBankName.MAERKI;
       case Blockchain.OLKYPAY:
         return IbanBankName.OLKY;
       case Blockchain.YAPEAL:

--- a/src/subdomains/supporting/fiat-output/__tests__/fiat-output-job.service.spec.ts
+++ b/src/subdomains/supporting/fiat-output/__tests__/fiat-output-job.service.spec.ts
@@ -17,7 +17,7 @@ import { BankTxService } from 'src/subdomains/supporting/bank-tx/bank-tx/service
 import { BankTxRepeatService } from '../../bank-tx/bank-tx-repeat/bank-tx-repeat.service';
 import { BankTxReturnService } from '../../bank-tx/bank-tx-return/bank-tx-return.service';
 import { createDefaultBankTx } from '../../bank-tx/bank-tx/__mocks__/bank-tx.entity.mock';
-import { createCustomBank, maerkiEUR } from '../../bank/bank/__mocks__/bank.entity.mock';
+import { createCustomBank, yapealEUR } from '../../bank/bank/__mocks__/bank.entity.mock';
 import { BankService } from '../../bank/bank/bank.service';
 import { IbanBankName } from '../../bank/bank/dto/bank.dto';
 import { createCustomVirtualIban } from '../../bank/virtual-iban/__mocks__/virtual-iban.entity.mock';
@@ -119,18 +119,18 @@ describe('FiatOutputJobService', () => {
 
       jest
         .spyOn(countryService, 'getCountryWithSymbol')
-        .mockResolvedValue(createCustomCountry({ maerkiBaumannEnable: true }));
+        .mockResolvedValue(createCustomCountry({ yapealEnable: true }));
 
-      jest.spyOn(bankService, 'getSenderBank').mockResolvedValue(maerkiEUR);
+      jest.spyOn(bankService, 'getSenderBank').mockResolvedValue(yapealEUR);
 
       await service['assignBankAccount']();
 
       const updateCalls = (fiatOutputRepo.update as jest.Mock).mock.calls;
       expect(updateCalls[0][0]).toBe(1);
-      expect(updateCalls[0][1]).toMatchObject({ originEntityId: 100, accountIban: maerkiEUR.iban });
+      expect(updateCalls[0][1]).toMatchObject({ originEntityId: 100, accountIban: yapealEUR.iban });
 
       expect(updateCalls[1][0]).toBe(3);
-      expect(updateCalls[1][1]).toMatchObject({ originEntityId: 102, accountIban: maerkiEUR.iban });
+      expect(updateCalls[1][1]).toMatchObject({ originEntityId: 102, accountIban: yapealEUR.iban });
     });
 
     it('should use virtual IBAN when user has one for BuyFiat', async () => {
@@ -147,12 +147,12 @@ describe('FiatOutputJobService', () => {
 
       jest
         .spyOn(countryService, 'getCountryWithSymbol')
-        .mockResolvedValue(createCustomCountry({ maerkiBaumannEnable: true }));
+        .mockResolvedValue(createCustomCountry({ yapealEnable: true }));
 
       // Mock virtual IBAN for user
       jest
         .spyOn(virtualIbanService, 'getActiveForUserAndCurrency')
-        .mockResolvedValue(createCustomVirtualIban({ iban: virtualIban, bank: maerkiEUR }));
+        .mockResolvedValue(createCustomVirtualIban({ iban: virtualIban, bank: yapealEUR }));
 
       await service['assignBankAccount']();
 
@@ -175,12 +175,12 @@ describe('FiatOutputJobService', () => {
 
       jest
         .spyOn(countryService, 'getCountryWithSymbol')
-        .mockResolvedValue(createCustomCountry({ maerkiBaumannEnable: true }));
+        .mockResolvedValue(createCustomCountry({ yapealEnable: true }));
 
       // Mock virtual IBAN for user
       jest
         .spyOn(virtualIbanService, 'getActiveForUserAndCurrency')
-        .mockResolvedValue(createCustomVirtualIban({ iban: virtualIban, bank: maerkiEUR }));
+        .mockResolvedValue(createCustomVirtualIban({ iban: virtualIban, bank: yapealEUR }));
 
       await service['assignBankAccount']();
 

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -730,7 +730,7 @@ export class TransactionHelper implements OnModuleInit {
   static getDefaultBankByPaymentMethod(paymentMethod: PaymentMethod): CardBankName | IbanBankName {
     switch (paymentMethod) {
       case FiatPaymentMethod.BANK:
-        return IbanBankName.MAERKI;
+        return IbanBankName.YAPEAL;
       case FiatPaymentMethod.CARD:
         return CardBankName.CHECKOUT;
       case FiatPaymentMethod.INSTANT:


### PR DESCRIPTION
## Summary
- Removed Maerki Baumann integration from codebase
- Set Yapeal as new default bank for SEPA payments
- Preserved database compatibility through existing enums

## Changes
- Removed `maerkiBaumannEnable` flag from Country entity
- Removed Maerki-specific logic from Bank entity methods
- Updated default bank mapping: `FiatPaymentMethod.BANK` now uses Yapeal instead of Maerki
- Removed Maerki from `blockchainToBankName()` mapping
- Updated fee calculation in BuyFiat preparation to use Yapeal
- Replaced test mocks: `maerkiEUR`/`maerkiCHF` → `yapealEUR`/`yapealCHF`
- Updated all unit tests to reflect new default bank

## Database Compatibility
The following enums are preserved for historical data:
- `IbanBankName.MAERKI = 'Maerki Baumann'`
- `Blockchain.MAERKI_BAUMANN = 'MaerkiBaumann'`

## Test Plan
- [x] TypeScript compilation successful
- [x] All unit tests updated
- [ ] Manual testing on dev environment