### PR TITLE
fix(eslint): fix simple warnings

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -17,7 +17,7 @@ describe('AppController', () => {
       ],
     }).compile();
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     controller = app.get<AppController>(AppController);
   });
 

--- a/src/integration/bank/services/iso20022.service.ts
+++ b/src/integration/bank/services/iso20022.service.ts
@@ -225,7 +225,7 @@ export class Iso20022Service {
       for (const entry of stmt.Ntry) {
         try {
           transactions.push(Iso20022Service.parseCamt053JsonEntry(entry, accountIban));
-        } catch (error) {
+        } catch {
           continue;
         }
       }

--- a/src/integration/blockchain/base/base-client.ts
+++ b/src/integration/blockchain/base/base-client.ts
@@ -136,7 +136,7 @@ export class BaseClient extends EvmClient implements L2BridgeEvmClient {
         default:
           return false;
       }
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/src/integration/blockchain/bitcoin/node/node-client.ts
+++ b/src/integration/blockchain/bitcoin/node/node-client.ts
@@ -241,7 +241,7 @@ export abstract class NodeClient extends BlockchainClient {
         return { feeRate, vsize: result.vsize };
       }
       return null;
-    } catch (e) {
+    } catch {
       // TX not in mempool (already confirmed or doesn't exist)
       return null;
     }

--- a/src/integration/blockchain/optimism/optimism-client.ts
+++ b/src/integration/blockchain/optimism/optimism-client.ts
@@ -136,7 +136,7 @@ export class OptimismClient extends EvmClient implements L2BridgeEvmClient {
         default:
           return false;
       }
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-delegation.integration.spec.ts
+++ b/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-delegation.integration.spec.ts
@@ -118,7 +118,7 @@ describeIfSepolia('EIP-7702 Delegation Integration Tests (Sepolia)', () => {
   const depositAccount = privateKeyToAccount(depositPrivateKey);
   const relayerAccount = privateKeyToAccount(relayerPrivateKey);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   let publicClient: any;
 
   beforeAll(() => {

--- a/src/integration/blockchain/spark/spark.service.ts
+++ b/src/integration/blockchain/spark/spark.service.ts
@@ -53,7 +53,7 @@ export class SparkService extends BlockchainService {
       const signature = secp256k1.Signature.fromBytes(signatureBytes, 'compact').addRecoveryBit(recovery);
       const recoveredPubKey = signature.recoverPublicKey(messageHash);
       return Buffer.from(recoveredPubKey.toBytes(true));
-    } catch (error) {
+    } catch {
       return undefined;
     }
   }

--- a/src/subdomains/core/buy-crypto/routes/buy/dto/get-buy-payment-info.dto.ts
+++ b/src/subdomains/core/buy-crypto/routes/buy/dto/get-buy-payment-info.dto.ts
@@ -65,7 +65,7 @@ export class GetBuyPaymentInfoDto {
   @Transform(Util.sanitize)
   externalTransactionId?: string;
 
-  //eslint-disable-next-line @typescript-eslint/no-inferrable-types
+   
   @ApiPropertyOptional({ description: 'Require an exact price (may take longer)' })
   @IsNotEmpty()
   @IsBoolean()

--- a/src/subdomains/core/buy-crypto/routes/swap/dto/get-swap-payment-info.dto.ts
+++ b/src/subdomains/core/buy-crypto/routes/swap/dto/get-swap-payment-info.dto.ts
@@ -49,7 +49,7 @@ export class GetSwapPaymentInfoDto {
   @Transform(Util.sanitize)
   externalTransactionId?: string;
 
-  //eslint-disable-next-line @typescript-eslint/no-inferrable-types
+   
   @ApiPropertyOptional({ description: 'Require an exact price (may take longer)' })
   @IsNotEmpty()
   @IsBoolean()

--- a/src/subdomains/core/payment-link/services/c2b-payment-link.service.ts
+++ b/src/subdomains/core/payment-link/services/c2b-payment-link.service.ts
@@ -46,7 +46,7 @@ export class C2BPaymentLinkService {
     try {
       C2BPaymentLinkService.mapBlockchainToProvider(blockchain);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/src/subdomains/core/referral/reward/services/ref-reward-out.service.ts
+++ b/src/subdomains/core/referral/reward/services/ref-reward-out.service.ts
@@ -50,7 +50,7 @@ export class RefRewardOutService {
         try {
           await this.doPayout(transaction);
           successfulRequests.push(transaction);
-        } catch (e) {
+        } catch {
           this.logger.error(`Failed to initiate ref-reward payout. Transaction ID: ${transaction.id}`);
           // continue with next transaction in case payout initiation failed
           continue;

--- a/src/subdomains/core/sell-crypto/route/dto/get-sell-payment-info.dto.ts
+++ b/src/subdomains/core/sell-crypto/route/dto/get-sell-payment-info.dto.ts
@@ -59,7 +59,7 @@ export class GetSellPaymentInfoDto {
   @Transform(Util.sanitize)
   externalTransactionId?: string;
 
-  //eslint-disable-next-line @typescript-eslint/no-inferrable-types
+   
   @ApiPropertyOptional({ description: 'Require an exact price (may take longer)' })
   @IsNotEmpty()
   @IsBoolean()

--- a/src/subdomains/generic/kyc/controllers/kyc.controller.ts
+++ b/src/subdomains/generic/kyc/controllers/kyc.controller.ts
@@ -11,7 +11,6 @@ import {
   Put,
   Query,
   Req,
-  Res,
   UseGuards,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
@@ -28,7 +27,7 @@ import {
 } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { RealIP } from 'nestjs-real-ip';
-import { Config, GetConfig } from 'src/config/config';
+import { GetConfig } from 'src/config/config';
 import { GetJwt } from 'src/shared/auth/get-jwt.decorator';
 import { JwtPayload } from 'src/shared/auth/jwt-payload.interface';
 import { OptionalJwtAuthGuard } from 'src/shared/auth/optional.guard';

--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -3,7 +3,6 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
-  InternalServerErrorException,
   NotFoundException,
   forwardRef,
 } from '@nestjs/common';
@@ -38,14 +37,8 @@ import { UserDataService } from '../../user/models/user-data/user-data.service';
 import { WalletService } from '../../user/models/wallet/wallet.service';
 import { WebhookService } from '../../user/services/webhook/webhook.service';
 import { IdentResultData, IdentType, NationalityDocType, ValidDocType } from '../dto/ident-result-data.dto';
-import {
-  IdNowReason,
-  IdNowResult,
-  IdentShortResult,
-  getIdNowIdentReason,
-  getIdentResult,
-} from '../dto/ident-result.dto';
-import { IdentDocument, IdentStatus } from '../dto/ident.dto';
+import { IdNowReason, IdNowResult, IdentShortResult, getIdNowIdentReason } from '../dto/ident-result.dto';
+import { IdentDocument } from '../dto/ident.dto';
 import {
   ContactPersonData,
   KycBeneficialData,
@@ -398,7 +391,7 @@ export class KycService {
     }
   }
 
-  async syncIdentStep(kycStep: KycStep): Promise<void> {
+  async syncIdentStep(_kycStep: KycStep): Promise<void> {
     throw new BadRequestException('IDnow integration has been removed. Use Sumsub or Manual ident instead.');
   }
 
@@ -738,7 +731,7 @@ export class KycService {
     );
   }
 
-  async updateIntrumIdent(dto: IdNowResult): Promise<void> {
+  async updateIntrumIdent(_dto: IdNowResult): Promise<void> {
     this.logger.warn('IDnow webhook called but integration has been removed');
     throw new BadRequestException('IDnow integration has been removed');
   }

--- a/src/subdomains/generic/user/models/user-data/user-data.service.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.service.ts
@@ -380,7 +380,7 @@ export class UserDataService {
             );
             const filePath = `${userDataId}-${fileName?.(selectedFile) ?? name}.${selectedFile.name.split('.').pop()}`;
             subFolder.file(filePath, fileData.data);
-          } catch (error) {
+          } catch {
             errorLog += `Error: Failed to download file '${selectedFile.name}' for UserData ${userDataId}\n`;
           }
         }

--- a/src/subdomains/supporting/log/log-job.service.ts
+++ b/src/subdomains/supporting/log/log-job.service.ts
@@ -208,7 +208,7 @@ export class LogJobService {
           const liqAddress = this.blockchainRegistryService.getClient(blockchain)?.walletAddress;
 
           return [blockchain, liqAddress];
-        } catch (e) {
+        } catch {
           return [blockchain, undefined];
         }
       }),


### PR DESCRIPTION
## Summary
- Remove 5 unused eslint-disable directives (auto-fixed)
- Remove 9 unused catch error variables (use empty catch `} catch {`)
- Remove 3 unused imports in kyc files (`InternalServerErrorException`, `getIdentResult`, `IdentStatus`, `Res`, `Config`)
- Prefix 2 unused function params with underscore (`_kycStep`, `_dto`)

## Remaining Warnings
66 `no-console` warnings in test files (intentional for debugging):
- `bitcoin-rpc.integration.spec.ts` (48)
- `evm-client.ts` (7)
- `eip7702-delegation.integration.spec.ts` (5)

## Test plan
- [x] ESLint passes with 0 errors
- [x] TypeScript compilation succeeds