### PR TITLE
fix(eslint): fix all remaining console warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,12 @@ module.exports = tseslint.config(
     },
   },
   {
+    files: ['**/*.spec.ts', '**/*.test.ts', '**/__tests__/**/*.ts'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
     ignores: ['eslint.config.js', 'migration/*.js', 'dist/**', 'node_modules/**'],
   },
 );

--- a/src/integration/blockchain/arbitrum/arbitrum-client.ts
+++ b/src/integration/blockchain/arbitrum/arbitrum-client.ts
@@ -21,7 +21,7 @@ import { EvmUtil } from '../shared/evm/evm.util';
 import { L2BridgeEvmClient } from '../shared/evm/interfaces';
 
 export class ArbitrumClient extends EvmClient implements L2BridgeEvmClient {
-  private readonly logger = new DfxLogger(ArbitrumClient);
+  protected override readonly logger = new DfxLogger(ArbitrumClient);
 
   private readonly l1Provider: ethers.providers.JsonRpcProvider;
   private readonly l1Wallet: ethers.Wallet;

--- a/src/integration/blockchain/base/base-client.ts
+++ b/src/integration/blockchain/base/base-client.ts
@@ -16,7 +16,7 @@ interface BaseTransactionReceipt extends ethers.providers.TransactionReceipt {
 }
 
 export class BaseClient extends EvmClient implements L2BridgeEvmClient {
-  private readonly logger = new DfxLogger(BaseClient);
+  protected override readonly logger = new DfxLogger(BaseClient);
 
   private readonly l1Provider: ethers.providers.JsonRpcProvider;
   private readonly l1Wallet: ethers.Wallet;

--- a/src/integration/blockchain/citrea-testnet/citrea-testnet-client.ts
+++ b/src/integration/blockchain/citrea-testnet/citrea-testnet-client.ts
@@ -10,7 +10,7 @@ import { EvmUtil } from '../shared/evm/evm.util';
 import { EvmCoinHistoryEntry, EvmTokenHistoryEntry } from '../shared/evm/interfaces';
 
 export class CitreaTestnetClient extends EvmClient {
-  private readonly logger = new DfxLogger(CitreaTestnetClient);
+  protected override readonly logger = new DfxLogger(CitreaTestnetClient);
 
   private readonly goldsky?: GoldskyService;
   private readonly maxRpcBlockRange = 100;

--- a/src/integration/blockchain/optimism/optimism-client.ts
+++ b/src/integration/blockchain/optimism/optimism-client.ts
@@ -16,7 +16,7 @@ interface OptimismTransactionReceipt extends ethers.providers.TransactionReceipt
 }
 
 export class OptimismClient extends EvmClient implements L2BridgeEvmClient {
-  private readonly logger = new DfxLogger(OptimismClient);
+  protected override readonly logger = new DfxLogger(OptimismClient);
 
   private readonly l1Provider: ethers.providers.JsonRpcProvider;
   private readonly l1Wallet: ethers.Wallet;

--- a/src/integration/blockchain/polygon/polygon-client.ts
+++ b/src/integration/blockchain/polygon/polygon-client.ts
@@ -11,7 +11,7 @@ import { EvmUtil } from '../shared/evm/evm.util';
 import { L2BridgeEvmClient } from '../shared/evm/interfaces';
 
 export class PolygonClient extends EvmClient implements L2BridgeEvmClient {
-  private readonly logger = new DfxLogger(PolygonClient);
+  protected override readonly logger = new DfxLogger(PolygonClient);
 
   private readonly l1Provider: ethers.providers.JsonRpcProvider;
   private readonly l1Wallet: ethers.Wallet;


### PR DESCRIPTION
## Summary
- Add ESLint override to disable `no-console` for test files (`*.spec.ts`, `*.test.ts`, `__tests__/**`)
- Replace 7 `console.log` DEBUG statements in `evm-client.ts` with `this.logger.verbose()`
- Change `logger` from `private` to `protected` in `EvmClient` and subclasses for proper inheritance

## Result
**0 ESLint warnings** (previously 87)

## Files changed
- `eslint.config.js` - Added test file override
- `evm-client.ts` - Added DfxLogger, replaced console.log
- `arbitrum-client.ts`, `base-client.ts`, `optimism-client.ts`, `polygon-client.ts`, `citrea-testnet-client.ts` - Changed logger to protected override

## Test plan
- [x] ESLint passes with 0 errors and 0 warnings
- [x] TypeScript compilation succeeds