### PR TITLE
Fix remaining ESLint warnings for scripts folder

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,12 +40,12 @@ module.exports = tseslint.config(
     },
   },
   {
-    files: ['**/*.spec.ts', '**/*.test.ts', '**/__tests__/**/*.ts'],
+    files: ['**/*.spec.ts', '**/*.test.ts', '**/__tests__/**/*.ts', 'scripts/**/*.ts'],
     rules: {
       'no-console': 'off',
     },
   },
   {
-    ignores: ['eslint.config.js', 'migration/*.js', 'dist/**', 'node_modules/**'],
+    ignores: ['eslint.config.js', 'migration/**/*.js', 'scripts/*.js', 'dist/**', 'node_modules/**'],
   },
 );

--- a/scripts/test-delegation.ts
+++ b/scripts/test-delegation.ts
@@ -81,7 +81,7 @@ async function testDelegation() {
     transport: http(rpcUrl),
   });
 
-  const walletClient = createWalletClient({
+  const _walletClient = createWalletClient({
     account: relayerAccount,
     chain: sepolia,
     transport: http(rpcUrl),
@@ -233,7 +233,7 @@ async function testDelegation() {
     const gasPriceWithBuffer = (gasPrice * 120n) / 100n;
     console.log('Current gas price:', gasPrice.toString(), 'wei');
     console.log('Gas price with 20% buffer:', gasPriceWithBuffer.toString(), 'wei');
-  } catch (error) {
+  } catch {
     console.log('Could not get gas price (expected if no RPC connection)');
   }
 


### PR DESCRIPTION
## Summary
- Add `scripts/**/*.ts` to no-console override (eliminates 73 warnings)
- Add `migration/**/*.js` and `scripts/*.js` to ignores (fixes 3 parsing errors)
- Fix unused `walletClient` variable with underscore prefix
- Fix unused `error` in catch block with empty catch syntax

**Result: 0 ESLint warnings remaining**

## Test plan
- [x] ESLint passes with no warnings
- [x] TypeScript compiles without errors
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)