### PR TITLE
Remove deprecated interface-name-prefix ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,6 @@ module.exports = tseslint.config(
       'no-console': ['warn'],
       '@typescript-eslint/return-await': ['warn', 'in-try-catch'],
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/interface-name-prefix': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION
## Summary
- Remove deprecated `@typescript-eslint/interface-name-prefix` rule from ESLint config
- This rule was removed from typescript-eslint in v4.0.0

## Test plan
- [x] ESLint passes
- [ ] CI pipeline passes