### PR TITLE
feat: add feature flag for pipeline price mechanism

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -101,6 +101,7 @@ export class Configuration {
     fiatOutput: {
       batchAmountLimit: 9500,
     },
+    usePipelinePriceForAllAssets: process.env.USE_PIPELINE_PRICE_FOR_ALL_ASSETS === 'true',
   };
 
   defaultVolumeDecimal = 2;

--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -270,10 +270,12 @@ export class BuyCrypto extends IEntity {
 
   calculateOutputReferenceAmount(price: Price, exchangeOrders?: LiquidityManagementOrder[]): this {
     // Use pipeline prices only if:
-    // 1. Pipeline exists and is COMPLETE
-    // 2. Exchange orders were found (actual trades happened)
+    // 1. Feature is enabled via config (USE_PIPELINE_PRICE_FOR_ALL_ASSETS=true)
+    // 2. Pipeline exists and is COMPLETE
+    // 3. Exchange orders were found (actual trades happened)
     // If no exchange orders exist, liquidity was available without trading -> use market price
     if (
+      Config.liquidityManagement.usePipelinePriceForAllAssets &&
       this.liquidityPipeline &&
       this.liquidityPipeline.status === LiquidityManagementPipelineStatus.COMPLETE &&
       exchangeOrders?.length

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-batch.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-batch.service.ts
@@ -144,9 +144,10 @@ export class BuyCryptoBatchService {
             PriceValidity.VALID_ONLY,
           );
 
-          const exchangeOrders = tx.liquidityPipeline
-            ? await this.findAllExchangeOrders(tx.liquidityPipeline)
-            : undefined;
+          const exchangeOrders =
+            Config.liquidityManagement.usePipelinePriceForAllAssets && tx.liquidityPipeline
+              ? await this.findAllExchangeOrders(tx.liquidityPipeline)
+              : undefined;
 
           tx.calculateOutputReferenceAmount(price, exchangeOrders);
         }


### PR DESCRIPTION
## Summary
- Add `USE_PIPELINE_PRICE_FOR_ALL_ASSETS` environment variable to control whether the pipeline price (actual exchange rate from liquidity purchase) is used for all assets
- When disabled (default): Market price is used for all assets
- When enabled: Pipeline price is used when available, protecting against price fluctuations during liquidity transfers

## Changes
- `src/config/config.ts`: Add `usePipelinePriceForAllAssets` config option
- `src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts`: Guard pipeline price logic with feature flag
- `src/subdomains/core/buy-crypto/process/services/buy-crypto-batch.service.ts`: Guard exchange order lookup with feature flag

## Usage
To enable the pipeline price mechanism for all assets, add to `.env`:
```
USE_PIPELINE_PRICE_FOR_ALL_ASSETS=true
```

## Context
This allows gradual rollout of the pipeline price feature introduced in commit 7b0b6e6a1 ([NO-TASK] Fix: Use pipeline price for all assets, not just FPS/nDEPS).