### PR TITLE
fix: enable pipeline price feature flag in tests

### DIFF
--- a/src/subdomains/core/buy-crypto/process/entities/__tests__/buy-crypto.entity.spec.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/__tests__/buy-crypto.entity.spec.ts
@@ -94,6 +94,17 @@ describe('BuyCrypto', () => {
     });
 
     describe('with liquidityPipeline', () => {
+      beforeEach(async () => {
+        // Enable pipeline price feature for these tests
+        await Test.createTestingModule({
+          providers: [
+            TestUtil.provideConfig({
+              liquidityManagement: { usePipelinePriceForAllAssets: true, bankMinBalance: 100, fiatOutput: { batchAmountLimit: 9500 } },
+            }),
+          ],
+        }).compile();
+      });
+
       it('uses pipeline price when pipeline is COMPLETE with exchange orders', () => {
         // Pipeline bought 1 BTC for 50000 USDT (price = 50000)
         const pipelineOrder = createPipelineOrderMock(50000, 1);


### PR DESCRIPTION
## Summary
- Enable `usePipelinePriceForAllAssets` config option in pipeline price tests
- Tests for the liquidityPipeline functionality require this feature flag to be enabled

## Changes
- Add `beforeEach` block in `describe('with liquidityPipeline')` to configure the feature flag

## Context
Fixes failing tests after merging the pipeline price feature flag in #2756.