### PR TITLE
fix(buy-crypto): reset batch when setting missing liquidity status

### DIFF
--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -349,6 +349,7 @@ export class BuyCrypto extends IEntity {
   setMissingLiquidityStatus(): UpdateResult<BuyCrypto> {
     const update: Partial<BuyCrypto> = {
       status: BuyCryptoStatus.MISSING_LIQUIDITY,
+      batch: null,
       ...this.resetTransaction(),
     };
 


### PR DESCRIPTION
## Summary

- Fix bug where BuyCrypto transactions get stuck in `MISSING_LIQUIDITY` status
- When liquidity is missing, the `batch` reference is now properly cleared
- This allows transactions to be re-processed when liquidity becomes available

## Problem

When a BuyCrypto transaction was assigned to a batch and liquidity was not available:
1. Status was set to `MISSING_LIQUIDITY`
2. But `batch` reference remained set
3. The batch query requires `batch: IsNull()` to find transactions for re-processing
4. Result: Transaction stuck forever, even when liquidity becomes available

## Solution

Added `batch: null` to `setMissingLiquidityStatus()` method to detach the transaction from its batch.

## Test plan

- [ ] Existing unit tests pass
- [ ] Verify transactions with missing liquidity are re-processed when liquidity is added