### PR TITLE
revert: remove batch reset in setMissingLiquidityStatus

### DIFF
--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -349,7 +349,6 @@ export class BuyCrypto extends IEntity {
   setMissingLiquidityStatus(): UpdateResult<BuyCrypto> {
     const update: Partial<BuyCrypto> = {
       status: BuyCryptoStatus.MISSING_LIQUIDITY,
-      batch: null,
       ...this.resetTransaction(),
     };
 


### PR DESCRIPTION
## Summary
- Reverts the change from PR #2762 that added `batch: null` when setting MISSING_LIQUIDITY status

## Changed file
- `src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts`

## Test plan
- [x] Build passes
- [x] Tests pass