### PR TITLE
fix(bitcoin): enable 0-conf by default

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -700,7 +700,7 @@ export class Configuration {
       walletPassword: process.env.NODE_WALLET_PASSWORD,
       utxoSpenderAddress: process.env.UTXO_SPENDER_ADDRESS,
       minTxAmount: 0.00000297,
-      allowUnconfirmedUtxos: process.env.ALLOW_UNCONFIRMED_UTXOS === 'true',
+      allowUnconfirmedUtxos: true,
       cpfpFeeMultiplier: +(process.env.CPFP_FEE_MULTIPLIER ?? '2.0'),
       defaultFeeMultiplier: +(process.env.DEFAULT_FEE_MULTIPLIER ?? '1.5'),
     },


### PR DESCRIPTION
## Summary
- Remove `ALLOW_UNCONFIRMED_UTXOS` env variable dependency
- Always enable unconfirmed UTXO support for BTC transactions

## Changes
- `allowUnconfirmedUtxos` is now hardcoded to `true` instead of reading from env