### PR TITLE
Fix: Include unconfirmed UTXOs in Bitcoin liquidity checks (#2768)

### DIFF
--- a/src/integration/blockchain/bitcoin/node/bitcoin-client.ts
+++ b/src/integration/blockchain/bitcoin/node/bitcoin-client.ts
@@ -59,6 +59,7 @@ export class BitcoinClient extends NodeClient {
     const options = {
       replaceable: true,
       change_address: Config.blockchain.default.btcOutput.address,
+      ...(Config.blockchain.default.allowUnconfirmedUtxos && { include_unsafe: true }),
     };
 
     const result = await this.callNode(

--- a/src/integration/blockchain/bitcoin/node/rpc/__tests__/bitcoin-rpc-client.spec.ts
+++ b/src/integration/blockchain/bitcoin/node/rpc/__tests__/bitcoin-rpc-client.spec.ts
@@ -358,6 +358,20 @@ describe('BitcoinRpcClient', () => {
       expect(lastPostCall?.body.params[4]).toEqual(options);
     });
 
+    it('send() with include_unsafe option should allow spending unconfirmed UTXOs', async () => {
+      const outputs = [{ bc1qtest: 0.001 }];
+      const options = {
+        replaceable: true,
+        change_address: 'bc1qchange',
+        include_unsafe: true,
+      };
+
+      await client.send(outputs, null, null, 10, options);
+
+      expect(lastPostCall?.body.params[4]).toEqual(options);
+      expect(lastPostCall?.body.params[4].include_unsafe).toBe(true);
+    });
+
     it('sendMany() should pass all 8 parameters in correct order', async () => {
       const amounts = { addr1: 0.001, addr2: 0.002 };
 

--- a/src/integration/blockchain/bitcoin/node/rpc/bitcoin-rpc-client.ts
+++ b/src/integration/blockchain/bitcoin/node/rpc/bitcoin-rpc-client.ts
@@ -219,6 +219,18 @@ export class BitcoinRpcClient {
       change_address?: string;
       replaceable?: boolean;
       locktime?: number;
+      include_unsafe?: boolean;
+      add_inputs?: boolean;
+      add_to_wallet?: boolean;
+      change_position?: number;
+      change_type?: string;
+      conf_target?: number;
+      estimate_mode?: string;
+      fee_rate?: number;
+      include_watching?: boolean;
+      lock_unspents?: boolean;
+      psbt?: boolean;
+      subtract_fee_from_outputs?: number[];
     },
   ): Promise<SendResult> {
     const params: unknown[] = [outputs];


### PR DESCRIPTION
* Fix Bitcoin liquidity check to include unconfirmed UTXOs

- Modified getBalance() to return confirmed + unconfirmed balance (trusted + untrusted_pending)
- Added include_unsafe option to sendMany() to allow spending unconfirmed UTXOs
- Extended TypeScript interface with all Bitcoin Core send() options
- Updated unit tests to verify new behavior

This fixes the issue where BuyCrypto transactions remain in 'MissingLiquidity' status even when sufficient unconfirmed UTXOs are available in the wallet.

* Use Config.blockchain.default.allowUnconfirmedUtxos flag

- Make getBalance() respect allowUnconfirmedUtxos config (currently hardcoded to true)
- Make sendMany() include_unsafe conditional on allowUnconfirmedUtxos config
- Update tests to mock allowUnconfirmedUtxos config value
- Improve comment accuracy: 'trusted' includes wallet's own unconfirmed UTXOs

### Release Checklist

#### Pre-Release

- [ ] Check migrations
  - No database related infos (sqldb-xxx)
  - Impact on GS (new/removed columns)
- [ ] Check for linter errors (in PR)
- [ ] Test basic user operations (on [DFX services](https://dev.app.dfx.swiss))
  - Login/logout
  - Buy/sell payment request
  - KYC page

#### Post-Release

- Test basic user operations
- Monitor application insights log
