### PR TITLE
feat(realunit): adjust KYC level requirements based on amount

### DIFF
--- a/src/subdomains/supporting/realunit/dto/realunit.dto.ts
+++ b/src/subdomains/supporting/realunit/dto/realunit.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsPositive, IsString } from 'class-validator';
 import { FeeDto } from 'src/subdomains/supporting/payment/dto/fee.dto';
 import { QuoteError } from 'src/subdomains/supporting/payment/dto/transaction-helper/quote-error.enum';
 import { PriceStep } from 'src/subdomains/supporting/pricing/domain/entities/price';
@@ -272,6 +272,7 @@ export enum RealUnitBuyCurrency {
 export class RealUnitBuyDto {
   @ApiProperty({ description: 'Amount in fiat currency' })
   @IsNumber()
+  @IsPositive()
   @Type(() => Number)
   amount: number;
 


### PR DESCRIPTION
## Summary
- KYC Level 20 is now sufficient for RealUnit purchases up to 1000 CHF
- KYC Level 50 is still required for amounts above 1000 CHF
- EUR amounts are automatically converted to CHF for the limit check

## Changes
- Modified `getPaymentInfo` in `realunit.service.ts` to check amount before determining required KYC level
- Uses existing `Config.tradingLimits.monthlyDefaultWoKyc` (1000 CHF) threshold
- Error message uses dynamic value from config (not hardcoded)
- Added `@IsPositive()` validator to `RealUnitBuyDto.amount` to prevent 0/negative amounts

## Test plan
- [ ] Test RealUnit purchase with KYC Level 20 and amount <= 1000 CHF (should work)
- [ ] Test RealUnit purchase with KYC Level 20 and amount > 1000 CHF (should fail with clear error)
- [ ] Test RealUnit purchase with KYC Level 50 and amount > 1000 CHF (should work)
- [ ] Test with EUR currency to verify conversion works correctly
- [ ] Test with amount = 0 or negative (should fail validation)