### PR TITLE
feat(realunit): set KYC Level 20 on registration completion

### DIFF
--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -534,6 +534,12 @@ export class RealUnitService {
       });
 
       await this.kycService.saveKycStepUpdate(kycStep.complete());
+
+      // Set KYC Level 20 if not already higher (same as NATIONALITY_DATA step)
+      if (kycStep.userData.kycLevel < KycLevel.LEVEL_20) {
+        await this.userDataService.updateUserDataInternal(kycStep.userData, { kycLevel: KycLevel.LEVEL_20 });
+      }
+
       return true;
     } catch (error) {
       const message = error?.response?.data ? JSON.stringify(error.response.data) : error?.message || error;


### PR DESCRIPTION
## Summary
- RealUnit registration now automatically sets KYC Level 20 when completed successfully

## Changes
- Modified `forwardRegistration` to set KYC Level 20 after successful registration
- Same behavior as `NATIONALITY_DATA` step in the regular KYC flow

## Test plan
- [ ] Complete RealUnit registration with a user that has KYC Level < 20
- [ ] Verify KYC Level is set to 20 after successful registration
- [ ] Verify users with KYC Level >= 20 are not affected