### PR TITLE
Fix: Redirect mail login to /account instead of /kyc

### DIFF
--- a/src/subdomains/generic/user/models/auth/auth.service.ts
+++ b/src/subdomains/generic/user/models/auth/auth.service.ts
@@ -313,7 +313,7 @@ export class AuthService {
 
       if (!account.tradeApprovalDate) await this.checkPendingRecommendation(account);
 
-      const url = new URL(entry.redirectUri ?? `${Config.frontend.services}/kyc`);
+      const url = new URL(entry.redirectUri ?? `${Config.frontend.services}/account`);
       url.searchParams.set('session', token);
       return url.toString();
     } catch (e) {


### PR DESCRIPTION
## Summary
- Change default redirect after email login from `/kyc` to `/account`
- Provides better user experience for general email login flow

## Changes
- Updated `auth.service.ts:316` to redirect to `/account` instead of `/kyc`
- All other KYC-specific email URLs remain unchanged (transactions, KYC steps, etc.)

## Context
When users sign in via email link without a specific redirect URI, they should land on the general account page rather than the KYC page. The KYC page is only relevant when there's explicit KYC context (e.g., pending transactions requiring KYC).

## Test plan
- [ ] Test email login flow and verify redirect to `/account`
- [ ] Verify email login with custom `redirectUri` still works correctly
- [ ] Confirm KYC-specific emails still redirect to appropriate pages