### PR TITLE
Fix email UX: display button before fallback link

### DIFF
--- a/src/shared/i18n/de/mail.json
+++ b/src/shared/i18n/de/mail.json
@@ -7,13 +7,13 @@
         "welcome": "Hi {name}",
         "team_questions": "Bei Fragen zögere bitte nicht, uns anzusprechen.",
         "personal_closing": "Freundliche Grüsse,<br>{closingName}",
-        "button": "oder<br>[url:Klick hier]",
+        "button": "[url:Klick hier]",
         "link": "oder<br>[url:{urlText}]"
     },
     "login": {
         "title": "DFX Login",
         "salutation": "DFX Login",
-        "message": "Klicke den nachfolgenden Link innerhalb von {expiration} Minuten um dich bei DFX einzuloggen:<br>[url:{urlText}]"
+        "message": "oder klicke den nachfolgenden Link innerhalb von {expiration} Minuten um dich bei DFX einzuloggen:<br>[url:{urlText}]"
     },
     "payment": {
         "crypto_input": {
@@ -331,7 +331,7 @@
             "salutation": "Forderungsabtretungsvertrag (Zession)",
             "message": "DFX bietet seinen Kunden die Möglichkeit, offene Forderungen aus dem Verkauf von Waren und Dienstleistungen an DFX abzutreten, um eine Bezahlung mittels Kryptowährungen zu ermöglichen. Der Kunde hat die Möglichkeit, eine offene Forderung über unsere API (api.dfx.swiss) oder über das Frontend auf app.dfx.swiss zu übermitteln.<br>Der geschuldete Betrag wird nach Abzug einer Bearbeitungsgebühr von 0.2% an den Kunden ausbezahlt. Die Auszahlung kann, entsprechend der kundenspezifischen Konfiguration, entweder in Kryptowährungen oder als Fiat-Währung per Banktransaktion erfolgen.<br>Für alle Transaktionen gelten die AGB der DFX. Die Zession endet automatisch mit der Schliessung des DFX-Kontos oder kann bei Vertragsverstössen oder Zahlungsunfähigkeit sofort durch DFX oder den Kunden beendet werden.<br><br>Zugestimmt am {date}"
         },
-        "retry": "Bitte versuche es über die folgende URL erneut:<br>[url:{urlText}]",
+        "retry": "oder versuche es über die folgende URL erneut:<br>[url:{urlText}]",
         "next_step": "Um mit deiner Verifizierung fortzufahren, klicke auf der DFX-Services Webseite<br> oben rechts auf den Menüpunkt und dann auf \"KYC\"<br> und klicke den \"Weiter\" Button oder nutze den folgenden Link:<br>[url:{urlText}]",
         "step_names": {
             "ident": "Identifikation",
@@ -354,7 +354,7 @@
         "request": {
             "title": "E-Mail bestätigen",
             "salutation": "Bestätige deine E-Mail",
-            "message": "Klicke den nachfolgenden Link, um deine E-Mail für einen anderen Account zu bestätigen:<br>[url:{urlText}]"
+            "message": "oder klicke den nachfolgenden Link, um deine E-Mail für einen anderen Account zu bestätigen:<br>[url:{urlText}]"
         },
         "added_address": {
             "title": "Adresse zu Account hinzugefügt",

--- a/src/shared/i18n/en/mail.json
+++ b/src/shared/i18n/en/mail.json
@@ -7,13 +7,13 @@
         "welcome": "Hi {name}",
         "team_questions": "If you have any questions, please do not hesitate to contact us.",
         "personal_closing": "Kind regards,<br>{closingName}",
-        "button": "or<br>[url:Click here]",
+        "button": "[url:Click here]",
         "link": "or<br>[url:{urlText}]"
     },
     "login": {
         "title": "DFX Login",
         "salutation": "DFX Login",
-        "message": "Click the following link within {expiration} minutes to log in to DFX:<br>[url:{urlText}]"
+        "message": "or click the following link within {expiration} minutes to log in to DFX:<br>[url:{urlText}]"
     },
     "payment": {
         "crypto_input": {
@@ -331,7 +331,7 @@
             "salutation": "Assignment agreement",
             "message": "DFX offers its customers the option of assigning outstanding receivables from the sale of goods and services to DFX to enable payment using cryptocurrencies. The customer has the option of submitting an outstanding claim via our API (api.dfx.swiss) or via the front end on app.dfx.swiss.<br>The amount owed is paid out to the customer after deduction of a processing fee of 0.2%. Depending on the customer-specific configuration, the payout can be made either in cryptocurrencies or as fiat currency via bank transaction.<br>The DFX General Terms and Conditions apply to all transactions. The assignment ends automatically when the DFX account is closed or can be terminated immediately by DFX or the customer in the event of breaches of contract or insolvency.<br><br>Agreed on {date}"
         },
-        "retry": "Please try it again with the following URL:<br>[url:{urlText}]",
+        "retry": "or try it again with the following URL:<br>[url:{urlText}]",
         "next_step": "To proceed with your verification, click on the menu item at the top right of the DFX-Services website<br> and then on \"KYC\"<br> and click the \"Continue\" button or use the following link:<br>[url:{urlText}]",
         "step_names": {
             "ident": "Identification",
@@ -354,7 +354,7 @@
         "request": {
             "title": "Confirm mail",
             "salutation": "Confirm your mail",
-            "message": "Click the following link to confirm your mail for another account:<br>[url:{urlText}]"
+            "message": "or click the following link to confirm your mail for another account:<br>[url:{urlText}]"
         },
         "added_address": {
             "title": "Address added to account",

--- a/src/shared/i18n/es/mail.json
+++ b/src/shared/i18n/es/mail.json
@@ -7,13 +7,13 @@
         "welcome": "Hola {name}",
         "team_questions": "If you have any questions, please do not hesitate to contact us.",
         "personal_closing": "Kind regards,<br>{closingName}",
-        "button": "o<br>[url:Haga clic aquí]",
+        "button": "[url:Haga clic aquí]",
         "link": "o<br>[url:{urlText}]"
     },
     "login": {
         "title": "DFX Entrar",
         "salutation": "DFX Entrar",
-        "message": "Haga clic en el siguiente enlace dentro de {expiration} minutos para iniciar sesión en DFX:<br>[url:{urlText}]"
+        "message": "o haga clic en el siguiente enlace dentro de {expiration} minutos para iniciar sesión en DFX:<br>[url:{urlText}]"
     },
     "payment": {
         "crypto_input": {
@@ -331,7 +331,7 @@
             "salutation": "Acuerdo de cesión",
             "message": "DFX ofrece a sus clientes la opción de ceder a DFX los créditos pendientes de la venta de bienes y servicios para permitir el pago mediante criptomonedas. El cliente tiene la opción de presentar una reclamación pendiente a través de nuestra API (api.dfx.swiss) o a través del front-end en app.dfx.swiss.<br>El importe adeudado se abona al cliente una vez deducida una comisión de tramitación del 0,2%. Dependiendo de la configuración específica del cliente, el pago puede realizarse en criptomonedas o en moneda fiduciaria mediante una transacción bancaria.<br>Las Condiciones Generales de DFX se aplican a todas las transacciones. La cesión finaliza automáticamente cuando se cierra la cuenta DFX o puede ser rescindida inmediatamente por DFX o el cliente en caso de incumplimiento de contrato o insolvencia.<br><br>De acuerdo {date}"
         },
-        "retry": "Por favor, inténtelo de nuevo con la siguiente URL:<br>[url:{urlText}]",
+        "retry": "o inténtelo de nuevo con la siguiente URL:<br>[url:{urlText}]",
         "next_step": "Para proceder a su verificación, haga clic en el elemento de menú situado en la parte superior derecha del sitio web de DFX-Services<br> y, a continuación, en \"KYC\"<br> y haga clic en el botón \"Continuar\"<br> o utilice el siguiente enlace:<br>[url:{urlText}]",
         "step_names": {
             "ident": "Identificación",
@@ -354,7 +354,7 @@
         "request": {
             "title": "Confirmar correo electrónico",
             "salutation": "Confirme su correo electrónico",
-            "message": "Haga clic en el siguiente enlace para confirmar su correo para otra cuenta:<br>[url:{urlText}]"
+            "message": "o haga clic en el siguiente enlace para confirmar su correo para otra cuenta:<br>[url:{urlText}]"
         },
         "added_address": {
             "title": "Dirección añadida a la cuenta",

--- a/src/shared/i18n/fr/mail.json
+++ b/src/shared/i18n/fr/mail.json
@@ -7,13 +7,13 @@
         "welcome": "Bonjour {name}",
         "team_questions": "If you have any questions, please do not hesitate to contact us.",
         "personal_closing": "Kind regards,<br>{closingName}",
-        "button": "ou<br>[url:Cliquez ici]",
+        "button": "[url:Cliquez ici]",
         "link": "ou<br>[url:{urlText}]"
     },
     "login": {
         "title": "Connexion DFX",
         "salutation": "Connexion DFX",
-        "message": "Cliquez sur le lien suivant dans les {expiration} minutes pour vous connecter à DFX:<br>[url:{urlText}]"
+        "message": "ou cliquez sur le lien suivant dans les {expiration} minutes pour vous connecter à DFX:<br>[url:{urlText}]"
     },
     "payment": {
         "crypto_input": {
@@ -331,7 +331,7 @@
             "salutation": "Accord de cession",
             "message": "DFX offre à ses clients la possibilité de lui céder des créances impayées résultant de la vente de biens et de services afin de permettre le paiement au moyen de crypto-monnaiesAccord de cession. Le client a la possibilité de soumettre une réclamation en suspens via notre API (api.dfx.swiss) ou via le front-end sur app.dfx.swiss.<br>Le montant dû est versé au client après déduction d'une commission de traitement de 0,2 %. Selon la configuration propre au client, le paiement peut être effectué soit en crypto-monnaies, soit en monnaie fiduciaire par le biais d'une transaction bancaire.<br>Les conditions générales de DFX s'appliquent à toutes les transactions. La cession prend fin automatiquement à la clôture du compte DFX ou peut être résiliée immédiatement par DFX ou le client en cas de rupture de contrat ou d'insolvabilité.<br><br>D'accord sur {date}"
         },
-        "retry": "Veuillez réessayer avec l'URL suivante:<br>[url:{urlText}]",
+        "retry": "ou réessayez avec l'URL suivante:<br>[url:{urlText}]",
         "next_step": "Pour procéder à votre vérification, cliquez sur l'élément de menu en haut à droite du site Web de DFX-Services<br>, puis sur \"KYC\"<br> et cliquez sur le bouton \"Continuer\" ou utilisez le lien suivant :<br>[url:{urlText}]",
         "step_names": {
             "ident": "Identification",
@@ -354,7 +354,7 @@
         "request": {
             "title": "Confirmer l'e-mail",
             "salutation": "Confirmez votre e-mail",
-            "message": "Cliquez sur le lien suivant pour confirmer votre courrier pour un autre compte:<br>[url:{urlText}]"
+            "message": "ou cliquez sur le lien suivant pour confirmer votre courrier pour un autre compte:<br>[url:{urlText}]"
         },
         "added_address": {
             "title": "Adresse ajoutée au compte",

--- a/src/shared/i18n/it/mail.json
+++ b/src/shared/i18n/it/mail.json
@@ -7,13 +7,13 @@
         "welcome": "Ciao {name}",
         "team_questions": "If you have any questions, please do not hesitate to contact us.",
         "personal_closing": "Kind regards,<br>{closingName}",
-        "button": "o<br>[url:Clicca qui]",
+        "button": "[url:Clicca qui]",
         "link": "o<br>[url:{urlText}]"
     },
     "login": {
         "title": "Accesso DFX",
         "salutation": "Accesso DFX",
-        "message": "Fare clic sul seguente link entro {expiration} minuti per accedere a DFX:<br>[url:{urlText}]"
+        "message": "o fare clic sul seguente link entro {expiration} minuti per accedere a DFX:<br>[url:{urlText}]"
     },
     "payment": {
         "crypto_input": {
@@ -331,7 +331,7 @@
             "salutation": "Accordo di assegnazione",
             "message": "DFX offre ai suoi clienti la possibilità di cedere a DFX i crediti in sospeso derivanti dalla vendita di beni e servizi per consentire il pagamento con le criptovalute. Il cliente ha la possibilità di inoltrare un reclamo insoluto tramite la nostra API (api.dfx.swiss) o tramite il front-end su app.dfx.swiss.<br>L'importo dovuto viene versato al cliente dopo la deduzione di una commissione di elaborazione dello 0,2%. A seconda della configurazione specifica del cliente, il pagamento può essere effettuato in criptovalute o in valuta fiat tramite transazione bancaria.<br>Le condizioni generali di DFX si applicano a tutte le transazioni. L'incarico termina automaticamente con la chiusura del conto DFX o può essere interrotto immediatamente da DFX o dal cliente in caso di violazione del contratto o di insolvenza.<br><br>Concordato su {date}"
         },
-        "retry": "Riprovare con il seguente URL:<br>[url:{urlText}]",
+        "retry": "o riprovare con il seguente URL:<br>[url:{urlText}]",
         "next_step": "Per procedere alla verifica, cliccare sulla voce di menu in alto a destra del sito web di DFX-Services<br> e poi su \"KYC\"<br> e cliccare sul pulsante \"Continua\" o utilizzare il seguente link:<br>[url:{urlText}]",
         "step_names": {
             "ident": "Identificazione",
@@ -354,7 +354,7 @@
         "request": {
             "title": "Confermare l'e-mail",
             "salutation": "Confermare l'e-mail",
-            "message": "Fare clic sul seguente link per confermare la posta per un altro account:<br>[url:{urlText}]"
+            "message": "o fare clic sul seguente link per confermare la posta per un altro account:<br>[url:{urlText}]"
         },
         "added_address": {
             "title": "Indirizzo aggiunto al conto",

--- a/src/shared/i18n/pt/mail.json
+++ b/src/shared/i18n/pt/mail.json
@@ -7,13 +7,13 @@
         "welcome": "Hi {name}",
         "team_questions": "If you have any questions, please do not hesitate to contact us.",
         "personal_closing": "Kind regards,<br>{closingName}",
-        "button": "or<br>[url:Click here]",
+        "button": "[url:Click here]",
         "link": "or<br>[url:{urlText}]"
     },
     "login": {
         "title": "DFX Login",
         "salutation": "DFX Login",
-        "message": "Click the following link within {expiration} minutes to log in to DFX:<br>[url:{urlText}]"
+        "message": "or click the following link within {expiration} minutes to log in to DFX:<br>[url:{urlText}]"
     },
     "payment": {
         "crypto_input": {
@@ -331,7 +331,7 @@
             "salutation": "Assignment agreement",
             "message": "DFX offers its customers the option of assigning outstanding receivables from the sale of goods and services to DFX to enable payment using cryptocurrencies. The customer has the option of submitting an outstanding claim via our API (api.dfx.swiss) or via the front end on app.dfx.swiss.<br>The amount owed is paid out to the customer after deduction of a processing fee of 0.2%. Depending on the customer-specific configuration, the payout can be made either in cryptocurrencies or as fiat currency via bank transaction.<br>The DFX General Terms and Conditions apply to all transactions. The assignment ends automatically when the DFX account is closed or can be terminated immediately by DFX or the customer in the event of breaches of contract or insolvency.<br><br>Agreed on {date}"
         },
-        "retry": "Please try it again with the following URL:<br>[url:{urlText}]",
+        "retry": "or try it again with the following URL:<br>[url:{urlText}]",
         "next_step": "To proceed with your verification, click on the menu item at the top right of the DFX-Services website<br> and then on \"KYC\"<br> and click the \"Continue\" button or use the following link:<br>[url:{urlText}]",
         "step_names": {
             "ident": "Identification",
@@ -354,7 +354,7 @@
         "request": {
             "title": "Confirm mail",
             "salutation": "Confirm your mail",
-            "message": "Click the following link to confirm your mail for another account:<br>[url:{urlText}]"
+            "message": "or click the following link to confirm your mail for another account:<br>[url:{urlText}]"
         },
         "added_address": {
             "title": "Address added to account",

--- a/src/subdomains/generic/kyc/services/kyc-notification.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc-notification.service.ts
@@ -66,12 +66,12 @@ export class KycNotificationService {
                 { key: `${MailTranslationKey.KYC_REMINDER}.message` },
                 { key: MailKey.SPACE, params: { value: '2' } },
                 {
-                  key: `${MailTranslationKey.KYC}.next_step`,
-                  params: { url: entity.userData.kycUrl, urlText: entity.userData.kycUrl },
-                },
-                {
                   key: `${MailTranslationKey.GENERAL}.button`,
                   params: { url: entity.userData.kycUrl, button: 'true' },
+                },
+                {
+                  key: `${MailTranslationKey.KYC}.next_step`,
+                  params: { url: entity.userData.kycUrl, urlText: entity.userData.kycUrl },
                 },
                 { key: MailKey.DFX_TEAM_CLOSING },
               ],
@@ -107,12 +107,12 @@ export class KycNotificationService {
               },
               { key: MailKey.SPACE, params: { value: '2' } },
               {
-                key: `${MailTranslationKey.KYC}.retry`,
-                params: { url: userData.kycUrl, urlText: userData.kycUrl },
-              },
-              {
                 key: `${MailTranslationKey.GENERAL}.button`,
                 params: { url: userData.kycUrl, button: 'true' },
+              },
+              {
+                key: `${MailTranslationKey.KYC}.retry`,
+                params: { url: userData.kycUrl, urlText: userData.kycUrl },
               },
               { key: MailKey.DFX_TEAM_CLOSING },
             ],
@@ -149,12 +149,12 @@ export class KycNotificationService {
               },
               { key: MailKey.SPACE, params: { value: '2' } },
               {
-                key: `${MailTranslationKey.KYC}.retry`,
-                params: { url: userData.kycUrl, urlText: userData.kycUrl },
-              },
-              {
                 key: `${MailTranslationKey.GENERAL}.button`,
                 params: { url: userData.kycUrl, button: 'true' },
+              },
+              {
+                key: `${MailTranslationKey.KYC}.retry`,
+                params: { url: userData.kycUrl, urlText: userData.kycUrl },
               },
               { key: MailKey.DFX_TEAM_CLOSING },
             ],

--- a/src/subdomains/generic/user/models/account-merge/account-merge.service.ts
+++ b/src/subdomains/generic/user/models/account-merge/account-merge.service.ts
@@ -71,12 +71,12 @@ export class AccountMergeService {
           { key: `${MailTranslationKey.GENERAL}.welcome`, params: { name } },
           { key: MailKey.SPACE, params: { value: '2' } },
           {
-            key: `${MailTranslationKey.ACCOUNT_MERGE_REQUEST}.message`,
-            params: { url, urlText: url },
-          },
-          {
             key: `${MailTranslationKey.GENERAL}.button`,
             params: { url, button: 'true' },
+          },
+          {
+            key: `${MailTranslationKey.ACCOUNT_MERGE_REQUEST}.message`,
+            params: { url, urlText: url },
           },
           { key: MailKey.SPACE, params: { value: '2' } },
           { key: MailKey.DFX_TEAM_CLOSING },

--- a/src/subdomains/generic/user/models/auth/auth.service.ts
+++ b/src/subdomains/generic/user/models/auth/auth.service.ts
@@ -276,16 +276,16 @@ export class AuthService {
         texts: [
           { key: MailKey.SPACE, params: { value: '1' } },
           {
+            key: `${MailTranslationKey.GENERAL}.button`,
+            params: { url: loginUrl, button: 'true' },
+          },
+          {
             key: `${MailTranslationKey.LOGIN}.message`,
             params: {
               url: loginUrl,
               urlText: loginUrl,
               expiration: `${Config.auth.mailLoginExpiresIn}`,
             },
-          },
-          {
-            key: `${MailTranslationKey.GENERAL}.button`,
-            params: { url: loginUrl, button: 'true' },
           },
           { key: MailKey.SPACE, params: { value: '2' } },
           { key: MailKey.DFX_TEAM_CLOSING },


### PR DESCRIPTION
## Problem

Email templates currently display content in a suboptimal order:
1. First: Plain text URL link
2. Then: Button with "or" prefix

This creates confusion because:
- The majority of email clients support buttons
- Users see the link first (less user-friendly) before the button (more user-friendly)
- The "or" prefix on the button implies it's a secondary option, when it should be primary

## Solution

Reorder email content to prioritize the button:
1. First: Button (primary action)
2. Then: Plain text URL link with "or" prefix (fallback for clients without button support)

## Changes

### Code changes
- `auth.service.ts` - Login email: button before link
- `kyc-notification.service.ts` - KYC emails (reminder, failed, missing data): button before link
- `account-merge.service.ts` - Account merge request: button before link

### Translation changes (de/en/pt/fr/it/es)
- `general.button` - Removed "or" prefix (now primary action)
- `login.message` - Added "or" prefix to link text
- `kyc.retry` - Added "or" prefix to link text
- `kyc.next_step` - Fixed to avoid double "or" (kept original text structure)
- `account_merge.request.message` - Added "or" prefix to link text

**Note:** Albanian (sq) has no mail.json file and was skipped.

## Verified correct order already

These notification services already had the correct button-first order and required no changes:
- `bank-tx-return-notification.service.ts`
- `buy-fiat-notification.service.ts`
- `buy-crypto-notification.service.ts`
- `transaction-notification.service.ts`
- `recommendation.service.ts`

## Impact

- Improved UX for all users receiving emails across all 6 supported languages
- Better accessibility (button is more prominent)
- Consistent email structure across all notification types
- Link remains available for email clients that don't support buttons

## Test plan

- [ ] Send login email and verify button appears first, link second
- [ ] Send KYC reminder/failed/missing data emails and verify order
- [ ] Send account merge request email and verify order
- [ ] Verify all six languages (de/en/pt/fr/it/es) display correctly
- [ ] Test in email clients with and without button support