### PR TITLE
Fix sell deposit tx creation with missing user address

### DIFF
--- a/src/subdomains/core/sell-crypto/route/sell.controller.ts
+++ b/src/subdomains/core/sell-crypto/route/sell.controller.ts
@@ -170,7 +170,7 @@ export class SellController {
     if (!request.isValid) throw new BadRequestException('Transaction request is not valid');
     if (request.isComplete) throw new ConflictException('Transaction request is already confirmed');
 
-    const route = await this.sellService.getById(request.routeId);
+    const route = await this.sellService.getById(request.routeId, { relations: { deposit: true } });
     if (!route) throw new NotFoundException('Sell route not found');
 
     return this.sellService.createDepositTx(request, route);


### PR DESCRIPTION
## Summary
Fix two bugs causing "Failed to create deposit transaction: invalid address or ENS name" error.

## Root Cause

### Bug 1: Missing user address in toPaymentInfoDto
In `toPaymentInfoDto()`, after calling `transactionRequestService.create()`, the returned `transactionRequest` only contains `user: { id: userId }` without the `address` field. When `createDepositTx()` tried to access `request.user.address`, it was `undefined`.

**Fix:** Add optional `userAddress` parameter to `createDepositTx()` and pass `user.address` from the already-loaded user object.

### Bug 2: Missing deposit relation in controller
In the `depositTx` controller endpoint, `getById()` was called without loading the `deposit` relation. This caused `route.deposit` to be `undefined`, resulting in the same error when accessing `route.deposit.address`.

**Fix:** Add `relations: { deposit: true }` to the `getById()` call.

## Changes
- `sell.service.ts`: Add optional `userAddress` parameter, validation for missing addresses
- `sell.controller.ts`: Load `deposit` relation in `getById()` call

## Test plan
- [ ] Sell page loads without "Failed to create deposit transaction" error
- [ ] Deposit transaction data is correctly returned in API response
- [ ] `/paymentInfos/:id/tx` endpoint works correctly