### PR TITLE
Skip Bitcoin pay-in processing when node is unavailable

### DIFF
--- a/src/subdomains/supporting/payin/services/payin-bitcoin.service.ts
+++ b/src/subdomains/supporting/payin/services/payin-bitcoin.service.ts
@@ -32,6 +32,10 @@ export class PayInBitcoinService extends PayInBitcoinBasedService {
     this.client = bitcoinService.getDefaultClient(BitcoinNodeType.BTC_INPUT);
   }
 
+  isAvailable(): boolean {
+    return this.client != null;
+  }
+
   async checkHealthOrThrow(): Promise<void> {
     await this.client.checkSync();
   }

--- a/src/subdomains/supporting/payin/services/payin.service.ts
+++ b/src/subdomains/supporting/payin/services/payin.service.ts
@@ -313,6 +313,7 @@ export class PayInService {
 
   private async getUnconfirmedNextBlockPayIns(): Promise<CryptoInput[]> {
     if (!Config.blockchain.default.allowUnconfirmedUtxos) return [];
+    if (!this.payInBitcoinService.isAvailable()) return [];
 
     // Only Bitcoin supports unconfirmed UTXO forwarding
     const candidates = await this.payInRepository.find({

--- a/src/subdomains/supporting/payin/strategies/register/impl/bitcoin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/bitcoin.strategy.ts
@@ -31,6 +31,8 @@ export class BitcoinStrategy extends PollingStrategy {
   //*** JOBS ***//
   @DfxCron(CronExpression.EVERY_SECOND, { process: Process.PAY_IN, timeout: 7200 })
   async checkPayInEntries(): Promise<void> {
+    if (!this.payInBitcoinService.isAvailable()) return;
+
     return super.checkPayInEntries();
   }
 


### PR DESCRIPTION
## Summary
- Add `isAvailable()` method to `PayInBitcoinService` to check if Bitcoin client is configured
- Skip `BitcoinStrategy.checkPayInEntries()` cron job when Bitcoin node is unavailable
- Skip unconfirmed UTXO processing in `PayInService` when Bitcoin service is unavailable

This prevents recurring errors in local development when no Bitcoin node is configured.

## Test plan
- [x] Verified locally: API starts without Bitcoin node errors
- [ ] Verify Bitcoin pay-in processing still works when node is configured