### PR TITLE
Skip bank transaction check when Olky bank is not configured

### DIFF
--- a/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
@@ -163,6 +163,7 @@ export class BankTxService implements OnModuleInit {
     const newModificationTime = new Date().toISOString();
 
     const olkyBank = await this.bankService.getBankInternal(IbanBankName.OLKY, 'EUR');
+    if (!olkyBank) return;
 
     // Get bank transactions
     const olkyTransactions = await this.olkyService.getOlkyTransactions(lastModificationTimeOlky, olkyBank.iban);


### PR DESCRIPTION
## Summary
- Return early from `checkTransactions()` if no Olky bank is found in the database
- Prevents `Cannot read properties of null (reading 'iban')` errors in local development

## Test plan
- [x] Verified locally: No more BankTxService errors
- [ ] Verify bank transaction processing still works when Olky bank is configured