### PR TITLE
Skip blockchain services when config is unavailable

### DIFF
--- a/src/integration/blockchain/deuro/deuro.service.ts
+++ b/src/integration/blockchain/deuro/deuro.service.ts
@@ -2,6 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { CronExpression } from '@nestjs/schedule';
 import { Contract } from 'ethers';
+import { GetConfig } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { Process } from 'src/shared/services/process.service';
 import { DfxCron } from 'src/shared/utils/cron';
@@ -56,6 +57,8 @@ export class DEuroService extends FrankencoinBasedService implements OnModuleIni
 
   @DfxCron(CronExpression.EVERY_10_MINUTES, { process: Process.DEURO_LOG_INFO })
   async processLogInfo(): Promise<void> {
+    if (!GetConfig().blockchain.deuro.graphUrl) return;
+
     const collateralTvl = await this.getCollateralTvl();
     const bridgeTvl = await this.getBridgeTvl();
     const totalValueLocked = collateralTvl + bridgeTvl;

--- a/src/integration/blockchain/frankencoin/frankencoin.service.ts
+++ b/src/integration/blockchain/frankencoin/frankencoin.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { CronExpression } from '@nestjs/schedule';
 import { Contract } from 'ethers';
-import { Config } from 'src/config/config';
+import { Config, GetConfig } from 'src/config/config';
 import { Process } from 'src/shared/services/process.service';
 import { DfxCron } from 'src/shared/utils/cron';
 import { CreateLogDto } from 'src/subdomains/supporting/log/dto/create-log.dto';
@@ -48,6 +48,8 @@ export class FrankencoinService extends FrankencoinBasedService implements OnMod
 
   @DfxCron(CronExpression.EVERY_10_MINUTES, { process: Process.FRANKENCOIN_LOG_INFO })
   async processLogInfo() {
+    if (!GetConfig().blockchain.frankencoin.contractAddress.xchf) return;
+
     const logMessage: FrankencoinLogDto = {
       swap: await this.getSwap(),
       positionV1s: await this.getPositionV1s(),

--- a/src/subdomains/core/payment-link/services/payment-link-fee.service.ts
+++ b/src/subdomains/core/payment-link/services/payment-link-fee.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { CronExpression } from '@nestjs/schedule';
+import { Environment, GetConfig } from 'src/config/config';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { PaymentLinkBlockchains } from 'src/integration/blockchain/shared/util/blockchain.util';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
@@ -36,6 +37,8 @@ export class PaymentLinkFeeService implements OnModuleInit {
   // --- JOBS --- //
   @DfxCron(CronExpression.EVERY_MINUTE, { process: Process.UPDATE_BLOCKCHAIN_FEE })
   async updateFees(): Promise<void> {
+    if (GetConfig().environment === Environment.LOC) return;
+
     for (const blockchain of PaymentLinkBlockchains) {
       try {
         const fee = await this.calculateFee(blockchain);


### PR DESCRIPTION
## Summary
- **FrankencoinService**: Skip `processLogInfo` when xchf contract address is not configured
- **DEuroService**: Skip `processLogInfo` when graphUrl is not configured
- **PaymentLinkFeeService**: Skip `updateFees` in local environment (LOC)

Prevents recurring errors in local development when external blockchain services are not configured.

## Test plan
- [x] All tests passing (688 passed)
- [x] Verified locally: No more FrankencoinService, DEuroService, PaymentLinkFeeService errors