### PR TITLE
Add warning logs for missing config in non-local environments

### DIFF
--- a/src/integration/blockchain/deuro/deuro.service.ts
+++ b/src/integration/blockchain/deuro/deuro.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { CronExpression } from '@nestjs/schedule';
 import { Contract } from 'ethers';
-import { GetConfig } from 'src/config/config';
+import { Config } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { Process } from 'src/shared/services/process.service';
 import { DfxCron } from 'src/shared/utils/cron';
@@ -57,7 +57,10 @@ export class DEuroService extends FrankencoinBasedService implements OnModuleIni
 
   @DfxCron(CronExpression.EVERY_10_MINUTES, { process: Process.DEURO_LOG_INFO })
   async processLogInfo(): Promise<void> {
-    if (!GetConfig().blockchain.deuro.graphUrl) return;
+    if (!Config.blockchain.deuro.graphUrl) {
+      this.logger.warn('DEuro graphUrl not configured - skipping processLogInfo');
+      return;
+    }
 
     const collateralTvl = await this.getCollateralTvl();
     const bridgeTvl = await this.getBridgeTvl();

--- a/src/integration/blockchain/frankencoin/frankencoin.service.ts
+++ b/src/integration/blockchain/frankencoin/frankencoin.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { CronExpression } from '@nestjs/schedule';
 import { Contract } from 'ethers';
-import { Config, GetConfig } from 'src/config/config';
+import { Config } from 'src/config/config';
 import { Process } from 'src/shared/services/process.service';
 import { DfxCron } from 'src/shared/utils/cron';
 import { CreateLogDto } from 'src/subdomains/supporting/log/dto/create-log.dto';
@@ -48,7 +48,10 @@ export class FrankencoinService extends FrankencoinBasedService implements OnMod
 
   @DfxCron(CronExpression.EVERY_10_MINUTES, { process: Process.FRANKENCOIN_LOG_INFO })
   async processLogInfo() {
-    if (!GetConfig().blockchain.frankencoin.contractAddress.xchf) return;
+    if (!Config.blockchain.frankencoin.contractAddress.xchf) {
+      this.logger.warn('Frankencoin xchf contract not configured - skipping processLogInfo');
+      return;
+    }
 
     const logMessage: FrankencoinLogDto = {
       swap: await this.getSwap(),

--- a/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
@@ -163,7 +163,10 @@ export class BankTxService implements OnModuleInit {
     const newModificationTime = new Date().toISOString();
 
     const olkyBank = await this.bankService.getBankInternal(IbanBankName.OLKY, 'EUR');
-    if (!olkyBank) return;
+    if (!olkyBank) {
+      this.logger.warn('Olky bank not configured - skipping checkTransactions');
+      return;
+    }
 
     // Get bank transactions
     const olkyTransactions = await this.olkyService.getOlkyTransactions(lastModificationTimeOlky, olkyBank.iban);

--- a/src/subdomains/supporting/payin/services/payin.service.ts
+++ b/src/subdomains/supporting/payin/services/payin.service.ts
@@ -313,7 +313,10 @@ export class PayInService {
 
   private async getUnconfirmedNextBlockPayIns(): Promise<CryptoInput[]> {
     if (!Config.blockchain.default.allowUnconfirmedUtxos) return [];
-    if (!this.payInBitcoinService.isAvailable()) return [];
+    if (!this.payInBitcoinService.isAvailable()) {
+      this.logger.warn('Bitcoin service not available - skipping unconfirmed UTXO processing');
+      return [];
+    }
 
     // Only Bitcoin supports unconfirmed UTXO forwarding
     const candidates = await this.payInRepository.find({

--- a/src/subdomains/supporting/payin/strategies/register/impl/bitcoin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/register/impl/bitcoin.strategy.ts
@@ -31,7 +31,10 @@ export class BitcoinStrategy extends PollingStrategy {
   //*** JOBS ***//
   @DfxCron(CronExpression.EVERY_SECOND, { process: Process.PAY_IN, timeout: 7200 })
   async checkPayInEntries(): Promise<void> {
-    if (!this.payInBitcoinService.isAvailable()) return;
+    if (!this.payInBitcoinService.isAvailable()) {
+      this.logger.warn('Bitcoin node not configured - skipping checkPayInEntries');
+      return;
+    }
 
     return super.checkPayInEntries();
   }


### PR DESCRIPTION
## Summary
Log a warning when config is missing instead of silently skipping or throwing errors.

### Changes
| Service | Warning Message |
|---------|-----------------|
| BitcoinStrategy | `Bitcoin node not configured - skipping checkPayInEntries` |
| PayInService | `Bitcoin service not available - skipping unconfirmed UTXO processing` |
| BankTxService | `Olky bank not configured - skipping checkTransactions` |
| FrankencoinService | `Frankencoin xchf contract not configured - skipping processLogInfo` |
| DEuroService | `DEuro graphUrl not configured - skipping processLogInfo` |

Simple approach: Always log warning when config missing, no environment distinction needed.

## Test plan
- [x] All tests passing (688 passed)