### PR TITLE
fix(gs): restore table-specific column blocking for debug endpoint

### DIFF
--- a/src/subdomains/generic/gs/gs.service.ts
+++ b/src/subdomains/generic/gs/gs.service.ts
@@ -59,63 +59,97 @@ export class GsService {
 
   private readonly sqlParser = new Parser();
 
-  // columns blocked for debug queries (personal data)
-  private readonly DebugBlockedColumns = [
-    // restricted (for DEBUG only, ADMIN can see via /gs/db)
-    'name',
-    'result',
-    'mail',
-    'recipientMail',
-    'phone',
-    'firstname',
-    'surname',
-    'verifiedName',
-    'organizationName',
-    'organizationStreet',
-    'organizationLocation',
-    'organizationZip',
-    'organizationCountryId',
-    'organizationId',
-    'allBeneficialOwnersName',
-    'allBeneficialOwnersDomicile',
-    'accountOpenerAuthorization',
-    'complexOrgStructure',
-    'accountOpener',
-    'legalEntity',
-    'signatoryPower',
-    'cardName',
-    'ultimateName',
-    // address
-    'street',
-    'houseNumber',
-    'location',
-    'zip',
-    'countryId',
-    'verifiedCountryId',
-    'nationalityId',
-    // identity
-    'birthday',
-    'tin',
-    'identDocumentId',
-    'identDocumentType',
-    // financial
-    'iban',
-    'accountNumber',
-    // network/security
-    'ip',
-    'ipCountry',
-    'apiKey',
-    'apiKeyCT',
-    'signature',
-    'kycHash',
-    'kycFileId',
-    'internalAmlNote',
-    'blackSquadRecipientMail',
-    'individualFees',
-    'totpSecret',
-    'paymentLinksConfig',
-    'paymentLinksName',
-  ];
+  // Table-specific blocked columns for debug queries (personal data)
+  private readonly TableBlockedColumns: Record<string, string[]> = {
+    // user_data - main table with PII
+    user_data: [
+      'mail', 'phone', 'firstname', 'surname', 'verifiedName',
+      'street', 'houseNumber', 'location', 'zip',
+      'countryId', 'verifiedCountryId', 'nationalityId', // Foreign keys to country
+      'birthday', 'tin', 'identDocumentId', 'identDocumentType',
+      'organizationName', 'organizationStreet', 'organizationLocation', 'organizationZip',
+      'organizationCountryId', 'organizationId',
+      'allBeneficialOwnersName', 'allBeneficialOwnersDomicile',
+      'accountOpenerAuthorization', 'complexOrgStructure', 'accountOpener', 'legalEntity', 'signatoryPower',
+      'kycHash', 'kycFileId', 'apiKeyCT', 'totpSecret',
+      'internalAmlNote', 'blackSquadRecipientMail', 'individualFees',
+      'paymentLinksConfig', 'paymentLinksName', 'comment', 'relatedUsers',
+    ],
+    // user
+    user: ['ip', 'ipCountry', 'apiKeyCT', 'signature', 'label', 'comment'],
+    // bank_tx - bank transactions
+    bank_tx: [
+      'name', 'ultimateName', 'iban', 'accountIban', 'senderAccount', 'bic',
+      'addressLine1', 'addressLine2', 'ultimateAddressLine1', 'ultimateAddressLine2',
+      'bankAddressLine1', 'bankAddressLine2',
+      'remittanceInfo', 'txInfo', 'txRaw',
+    ],
+    // bank_data
+    bank_data: ['name', 'iban', 'label', 'comment'],
+    // fiat_output
+    fiat_output: [
+      'name', 'iban', 'accountIban', 'accountNumber', 'bic', 'aba',
+      'address', 'houseNumber', 'zip', 'city',
+      'remittanceInfo',
+    ],
+    // checkout_tx - payment card data
+    checkout_tx: [
+      'cardName', 'ip',
+      'cardBin', 'cardLast4', 'cardFingerPrint', 'cardIssuer', 'cardIssuerCountry', 'raw',
+    ],
+    // bank_account
+    bank_account: ['accountNumber'],
+    // virtual_iban
+    virtual_iban: ['iban', 'bban', 'label'],
+    // kyc_step - KYC steps (result/data contains names, birthday, document number)
+    kyc_step: ['result', 'comment', 'data'],
+    // kyc_file
+    kyc_file: ['name'],
+    // kyc_log (includes TfaLog ChildEntity with ipAddress)
+    kyc_log: ['comment', 'ipAddress', 'result'],
+    // organization
+    organization: [
+      'name', 'street', 'houseNumber', 'location', 'zip',
+      'allBeneficialOwnersName', 'allBeneficialOwnersDomicile',
+    ],
+    // transactions
+    buy_crypto: ['recipientMail', 'comment', 'chargebackIban', 'chargebackRemittanceInfo', 'siftResponse'],
+    buy_fiat: ['recipientMail', 'comment', 'remittanceInfo', 'usedBank', 'info'],
+    transaction: ['recipientMail'],
+    crypto_input: ['recipientMail', 'senderAddresses'],
+    // payment_link
+    payment_link: ['comment', 'label'],
+    // wallet (integration)
+    wallet: ['apiKey'],
+    // ref - referral tracking
+    ref: ['ip'],
+    // ip_log - IP logging
+    ip_log: ['ip', 'country'],
+    // buy - buy crypto routes
+    buy: ['iban'],
+    // deposit_route - sell routes (Single Table Inheritance for Sell entity)
+    deposit_route: ['iban'],
+    // bank_tx_return - chargeback returns
+    bank_tx_return: ['chargebackIban', 'recipientMail', 'chargebackRemittanceInfo', 'info'],
+    // bank_tx_repeat - repeat transactions
+    bank_tx_repeat: ['chargebackIban', 'chargebackRemittanceInfo'],
+    // limit_request - limit increase requests
+    limit_request: ['recipientMail', 'fundOriginText'],
+    // ref_reward - referral rewards
+    ref_reward: ['recipientMail'],
+    // transaction_risk_assessment - AML/KYC assessments
+    transaction_risk_assessment: ['reason', 'methods', 'summary', 'result'],
+    // support_issue - support tickets with user data
+    support_issue: ['name', 'information'],
+    // support_message - message content and file URLs
+    support_message: ['message', 'fileUrl'],
+    // sift_error_log - Sift API request payloads containing PII
+    sift_error_log: ['requestPayload'],
+    // webhook - serialized user/transaction data
+    webhook: ['data'],
+    // notification - notification payloads with user data
+    notification: ['data'],
+  };
 
   private readonly DebugMaxResults = 10000;
 
@@ -371,7 +405,8 @@ export class GsService {
     }
 
     // 8. Check for blocked columns BEFORE execution (prevents alias bypass)
-    const blockedColumn = this.findBlockedColumnInQuery(sql);
+    const tables = this.getTablesFromQuery(sql);
+    const blockedColumn = this.findBlockedColumnInQuery(sql, stmt, tables);
     if (blockedColumn) {
       throw new BadRequestException(`Access to column '${blockedColumn}' is not allowed`);
     }
@@ -389,8 +424,8 @@ export class GsService {
       const limitedSql = this.ensureResultLimit(sql);
       const result = await this.dataSource.query(limitedSql);
 
-      // 12. Additional masking for any columns that might have slipped through
-      this.maskDebugBlockedColumns(result);
+      // 12. Post-execution masking (defense in depth - also catches pre-execution failures)
+      this.maskDebugBlockedColumns(result, tables);
 
       return result;
     } catch (e) {
@@ -743,42 +778,102 @@ export class GsService {
     }
   }
 
-  private maskDebugBlockedColumns(data: Record<string, unknown>[]): void {
-    if (!data?.length) return;
+  private maskDebugBlockedColumns(data: Record<string, unknown>[], tables: string[]): void {
+    if (!data?.length || !tables?.length) return;
+
+    // Collect all blocked columns from all tables in the query
+    const blockedColumns = new Set<string>();
+    for (const table of tables) {
+      const tableCols = this.TableBlockedColumns[table];
+      if (tableCols) {
+        for (const col of tableCols) {
+          blockedColumns.add(col.toLowerCase());
+        }
+      }
+    }
+
+    if (blockedColumns.size === 0) return;
 
     for (const entry of data) {
       for (const key of Object.keys(entry)) {
-        if (this.isDebugBlockedColumn(key)) {
+        if (this.shouldMaskDebugColumn(key, blockedColumns)) {
           entry[key] = this.RestrictedMarker;
         }
       }
     }
   }
 
-  private isDebugBlockedColumn(columnName: string): boolean {
-    const lowerKey = columnName.toLowerCase();
-    // Match exact column name or prefixed (e.g., "firstname" or "user_firstname")
-    return this.DebugBlockedColumns.some((blocked) => {
-      const lowerBlocked = blocked.toLowerCase();
-      return lowerKey === lowerBlocked || lowerKey.endsWith('_' + lowerBlocked);
-    });
+  private shouldMaskDebugColumn(columnName: string, blockedColumns: Set<string>): boolean {
+    const lower = columnName.toLowerCase();
+
+    // Check exact match or with table prefix (e.g., "name" or "bank_tx_name")
+    for (const blocked of blockedColumns) {
+      if (lower === blocked || lower.endsWith('_' + blocked)) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  private findBlockedColumnInQuery(sql: string): string | null {
+  private getTablesFromQuery(sql: string): string[] {
+    const tableList = this.sqlParser.tableList(sql, { database: 'TransactSQL' });
+    // Format: 'select::null::table_name' → extract table_name
+    return tableList.map((t) => t.split('::')[2]).filter(Boolean);
+  }
+
+  private getAliasToTableMap(ast: any): Map<string, string> {
+    const map = new Map<string, string>();
+    if (!ast.from) return map;
+
+    for (const item of ast.from) {
+      if (item.table) {
+        map.set(item.as || item.table, item.table);
+      }
+    }
+    return map;
+  }
+
+  private isColumnBlockedInTable(columnName: string, table: string | null, allTables: string[]): boolean {
+    const lower = columnName.toLowerCase();
+
+    if (table) {
+      // Explicit table known → check if this column is blocked in this table
+      const blockedCols = this.TableBlockedColumns[table];
+      return blockedCols?.some((b) => b.toLowerCase() === lower) ?? false;
+    } else {
+      // No explicit table → if ANY of the query tables blocks this column, block it
+      return allTables.some((t) => {
+        const blockedCols = this.TableBlockedColumns[t];
+        return blockedCols?.some((b) => b.toLowerCase() === lower) ?? false;
+      });
+    }
+  }
+
+  private findBlockedColumnInQuery(sql: string, ast: any, tables: string[]): string | null {
     try {
       // columnList returns: ['select::table::column', 'select::null::column', ...]
       const columns = this.sqlParser.columnList(sql, { database: 'TransactSQL' });
+      const aliasMap = this.getAliasToTableMap(ast);
 
       for (const col of columns) {
-        // Format: 'operation::schema::column' - extract the column part
         const parts = col.split('::');
-        const columnName = parts[parts.length - 1];
+        const tableOrAlias = parts[1]; // can be 'null'
+        const columnName = parts[2];
 
-        // Skip wildcard
+        // Skip wildcard - handled post-execution
         if (columnName === '*' || columnName === '(.*)') continue;
 
-        if (this.isDebugBlockedColumn(columnName)) {
-          return columnName;
+        // Resolve table from alias
+        const resolvedTable =
+          tableOrAlias === 'null'
+            ? tables.length === 1
+              ? tables[0]
+              : null // Single table without alias → use that table
+            : aliasMap.get(tableOrAlias) || tableOrAlias;
+
+        // Check if column is blocked in this table
+        if (this.isColumnBlockedInTable(columnName, resolvedTable, tables)) {
+          return `${resolvedTable || 'unknown'}.${columnName}`;
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes accidental regression from PR #2778 that removed `TableBlockedColumns` and replaced it with a simpler global `DebugBlockedColumns` list.

### Root Cause
PR #2778 was based on `feature/debug-endpoint` before PR #2782 was merged. After a `git reset` to sync with the updated branch, the local file `gs.service.ts` still contained the old version. When the new commit was created, it overwrote the `TableBlockedColumns` changes.

### What was lost (now restored)
- **42 blocked columns** across **23 tables** were unprotected
- Table-specific blocking logic (allows `SELECT name FROM asset` but blocks `SELECT name FROM bank_tx`)

### Restored columns include:
| Category | Columns |
|----------|---------|
| Comments/Labels | `comment`, `label`, `data` |
| Financial Data | `remittanceInfo`, `chargebackIban`, `bic`, `txRaw`, `txInfo` |
| Card Data | `cardBin`, `cardLast4`, `cardFingerPrint`, `raw` |
| Support/KYC | `message`, `fileUrl`, `information`, `requestPayload` |
| Address Data | `addressLine1/2`, `city`, `address` |

### Preserved features from later commits
- `BlockedSchemas` (sys, information_schema, etc.)
- `DangerousFunctions` (openrowset, etc.)
- `LogQueryTemplates` & `executeLogQuery()`
- `checkForBlockedSchemas()`, `checkForDangerousFunctionsRecursive()`

## Test plan
- [ ] Verify `SELECT name FROM asset` is allowed (no PII in asset.name)
- [ ] Verify `SELECT name FROM bank_tx` is blocked (PII)
- [ ] Verify `SELECT comment FROM user_data` is blocked
- [ ] Verify `SELECT * FROM bank_tx` masks blocked columns in result