### PR TITLE
ci: add automatic release PR workflow

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -1,0 +1,70 @@
+name: Auto Release PR
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-release-pr
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch master branch
+        run: git fetch origin master
+
+      - name: Check for existing PR
+        id: check-pr
+        run: |
+          PR_COUNT=$(gh pr list --base master --head develop --state open --json number --jq 'length')
+          echo "pr_exists=$([[ $PR_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "::notice::Open PRs from develop to master: $PR_COUNT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for differences
+        id: check-diff
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          DIFF_COUNT=$(git rev-list --count origin/master..origin/develop)
+          echo "has_changes=$([[ $DIFF_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "commit_count=$DIFF_COUNT" >> $GITHUB_OUTPUT
+          echo "::notice::Commits ahead of master: $DIFF_COUNT"
+
+      - name: Create Release PR
+        if: steps.check-pr.outputs.pr_exists == 'false' && steps.check-diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_COUNT: ${{ steps.check-diff.outputs.commit_count }}
+        run: |
+          printf '%s\n' \
+            "## Automatic Release PR" \
+            "" \
+            "This PR was automatically created after changes were pushed to develop." \
+            "" \
+            "**Commits:** ${COMMIT_COUNT} new commit(s)" \
+            "" \
+            "### Checklist" \
+            "- [ ] Review all changes" \
+            "- [ ] Verify CI passes" \
+            "- [ ] Approve and merge when ready for production" \
+            > /tmp/pr-body.md
+
+          gh pr create \
+            --base master \
+            --head develop \
+            --title "Release: develop -> master" \
+            --body-file /tmp/pr-body.md


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates a PR from `develop` to `master` whenever changes are pushed to develop.

## Features

- **Automatic trigger**: Runs on every push to develop
- **Duplicate prevention**: Checks if a release PR already exists
- **Diff validation**: Only creates PR if there are actual changes
- **Concurrency control**: Prevents race conditions with multiple pushes
- **Manual trigger**: Supports `workflow_dispatch` for manual runs

## Workflow

```
Push to develop
      ↓
Check: PR exists? ──Yes──> End
      ↓ No
Check: Changes? ──No──> End
      ↓ Yes
Create PR: develop -> master
```

## PR Format

- **Title**: `Release: develop -> master`
- **Body**: Commit count + checklist