### PR TITLE
perf: parallelize async operations in swap quote API

### DIFF
--- a/src/subdomains/supporting/payment/services/fee.service.ts
+++ b/src/subdomains/supporting/payment/services/fee.service.ts
@@ -323,9 +323,11 @@ export class FeeService {
     paymentMethodIn: PaymentMethod,
     userDataId?: number,
   ): Promise<InternalFeeDto> {
-    const blockchainFee =
-      (await this.getBlockchainFeeInChf(from, allowCachedBlockchainFee)) +
-      (await this.getBlockchainFeeInChf(to, allowCachedBlockchainFee));
+    const [fromFee, toFee] = await Promise.all([
+      this.getBlockchainFeeInChf(from, allowCachedBlockchainFee),
+      this.getBlockchainFeeInChf(to, allowCachedBlockchainFee),
+    ]);
+    const blockchainFee = fromFee + toFee;
 
     // get min special fee
     const specialFee = Util.minObj(

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -321,8 +321,10 @@ export class TransactionHelper implements OnModuleInit {
       },
     };
 
-    const sourceSpecs = await this.getSourceSpecs(from, extendedSpecs, priceValidity);
-    const targetSpecs = await this.getTargetSpecs(to, extendedSpecs, priceValidity);
+    const [sourceSpecs, targetSpecs] = await Promise.all([
+      this.getSourceSpecs(from, extendedSpecs, priceValidity),
+      this.getTargetSpecs(to, extendedSpecs, priceValidity),
+    ]);
 
     const target = await this.getTargetEstimation(
       sourceAmount,


### PR DESCRIPTION
## Summary
- Parallelize `getSourceSpecs`/`getTargetSpecs` calls in transaction-helper
- Parallelize blockchain fee calculations in fee.service

These independent operations were running sequentially, causing unnecessary latency in the swap quote endpoint.

## Test plan
- [x] Unit tests pass (29/29)
- [ ] Verify swap quote response time improvement in dev environment