### PR TITLE
fix(gs): replace semicolon regex to avoid CodeQL false positive

### DIFF
--- a/src/subdomains/generic/gs/gs.service.ts
+++ b/src/subdomains/generic/gs/gs.service.ts
@@ -1071,6 +1071,10 @@ export class GsService {
     const hasOrderBy = /order\s+by/i.test(normalized);
     const orderByClause = hasOrderBy ? '' : ' ORDER BY (SELECT NULL)';
 
-    return `${sql.trim().replace(/;*$/, '')}${orderByClause} OFFSET 0 ROWS FETCH NEXT ${DebugMaxResults} ROWS ONLY`;
+    // Remove trailing semicolons using string operations to avoid CodeQL false positive
+    let trimmed = sql.trim();
+    while (trimmed.endsWith(';')) trimmed = trimmed.slice(0, -1);
+
+    return `${trimmed}${orderByClause} OFFSET 0 ROWS FETCH NEXT ${DebugMaxResults} ROWS ONLY`;
   }
 }


### PR DESCRIPTION
## Summary

Replace the regex `/;*$/` with a string-based while loop to remove trailing semicolons.

The original regex is O(n) and not actually a ReDoS vulnerability, but CodeQL flags it as a potential issue. This change achieves the same result without triggering the static analysis warning.

## Changes

- Replace `sql.trim().replace(/;*$/, '')` with a while loop using `endsWith(';')` and `slice(0, -1)`

## Test plan

- [x] Linting passes
- [x] Formatting passes
- [ ] CI passes