### PR TITLE
ci: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+
+updates:
+  # NPM dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "DFXswiss/backend"
+    labels:
+      - "dependencies"
+    groups:
+      # Group all production dependencies together
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group all dev dependencies together
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignore major updates for stability (review manually)
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

Aktiviert Dependabot für automatische Dependency-Updates.

## Konfiguration

| Setting | Wert |
|---------|------|
| Schedule | Wöchentlich, Montag 06:00 CET |
| npm Updates | Minor + Patch (gruppiert) |
| Major Updates | Ignoriert (manuelles Review) |
| GitHub Actions | Inkludiert |
| PR Limit | Max 10 offene PRs |

## Gruppierung

- **production-dependencies**: Alle Prod-Dependencies (minor/patch) in einem PR
- **dev-dependencies**: Alle Dev-Dependencies (minor/patch) in einem PR

## Vorteile

- Automatische Security-Updates
- Weniger PR-Noise durch Gruppierung
- Kontrollierte Updates (keine Breaking Changes durch Major-Ignore)

## Wichtig

Nach dem Merge muss in den Repository Settings noch **Dependabot Security Updates** aktiviert werden:
Settings → Code security and analysis → Dependabot alerts → Enable