### PR TITLE
refactor(eip7702): combine balance check and delegation data into single RPC call

### DIFF
--- a/src/subdomains/core/buy-crypto/routes/swap/swap.service.ts
+++ b/src/subdomains/core/buy-crypto/routes/swap/swap.service.ts
@@ -9,7 +9,10 @@ import {
 import { CronExpression } from '@nestjs/schedule';
 import { Config } from 'src/config/config';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
-import { Eip7702DelegationService } from 'src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service';
+import {
+  DelegationCheckResult,
+  Eip7702DelegationService,
+} from 'src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service';
 import { BlockchainRegistryService } from 'src/integration/blockchain/shared/services/blockchain-registry.service';
 import { CryptoService } from 'src/integration/blockchain/shared/services/crypto.service';
 import { Asset } from 'src/shared/models/asset/asset.entity';
@@ -292,34 +295,32 @@ export class SwapService {
 
     // Check if EIP-7702 delegation is supported and user has zero native balance
     const supportsEip7702 = this.eip7702DelegationService.isDelegationSupported(asset.blockchain);
-    let hasZeroGas = false;
+    let delegationResult: DelegationCheckResult | undefined;
 
     if (supportsEip7702) {
-      try {
-        hasZeroGas = await this.eip7702DelegationService.hasZeroNativeBalance(userAddress, asset.blockchain);
-      } catch (_) {
-        // If balance check fails (RPC error, network issue, etc.), assume user has gas
-        this.logger.verbose(`Balance check failed for ${userAddress} on ${asset.blockchain}, assuming user has gas`);
-        hasZeroGas = false;
-      }
+      delegationResult = await this.eip7702DelegationService.checkBalanceAndPrepareDelegation(
+        userAddress,
+        asset.blockchain,
+      );
     }
+
+    const hasZeroGas = delegationResult?.hasZeroBalance ?? false;
 
     try {
       const unsignedTx = await client.prepareTransaction(asset, userAddress, depositAddress, request.amount);
 
       // Add EIP-7702 delegation data if user has 0 gas
-      if (hasZeroGas) {
+      if (hasZeroGas && delegationResult) {
         this.logger.info(`User ${userAddress} has 0 gas on ${asset.blockchain}, providing EIP-7702 delegation data`);
-        const delegationData = await this.eip7702DelegationService.prepareDelegationData(userAddress, asset.blockchain);
 
         unsignedTx.eip7702 = {
-          relayerAddress: delegationData.relayerAddress,
-          delegationManagerAddress: delegationData.delegationManagerAddress,
-          delegatorAddress: delegationData.delegatorAddress,
-          userNonce: delegationData.userNonce,
-          domain: delegationData.domain,
-          types: delegationData.types,
-          message: delegationData.message,
+          relayerAddress: delegationResult.delegationData.relayerAddress,
+          delegationManagerAddress: delegationResult.delegationData.delegationManagerAddress,
+          delegatorAddress: delegationResult.delegationData.delegatorAddress,
+          userNonce: delegationResult.delegationData.userNonce,
+          domain: delegationResult.delegationData.domain,
+          types: delegationResult.delegationData.types,
+          message: delegationResult.delegationData.message,
         };
       }
 
@@ -328,15 +329,13 @@ export class SwapService {
       // Special handling for INSUFFICIENT_FUNDS error when EIP-7702 is available
       const isInsufficientFunds = e.code === 'INSUFFICIENT_FUNDS' || e.message?.includes('insufficient funds');
 
-      if (isInsufficientFunds && supportsEip7702) {
+      if (isInsufficientFunds && delegationResult) {
         this.logger.info(
           `Gas estimation failed due to insufficient funds for user ${userAddress}, creating transaction with EIP-7702 delegation`,
         );
 
         // Create a basic unsigned transaction without gas estimation
         // The actual gas will be paid by the relayer through EIP-7702 delegation
-        const delegationData = await this.eip7702DelegationService.prepareDelegationData(userAddress, asset.blockchain);
-
         const unsignedTx = {
           chainId: client.chainId,
           from: userAddress,
@@ -347,13 +346,13 @@ export class SwapService {
           gasPrice: '0', // Will be set by relayer
           gasLimit: '0', // Will be set by relayer
           eip7702: {
-            relayerAddress: delegationData.relayerAddress,
-            delegationManagerAddress: delegationData.delegationManagerAddress,
-            delegatorAddress: delegationData.delegatorAddress,
-            userNonce: delegationData.userNonce,
-            domain: delegationData.domain,
-            types: delegationData.types,
-            message: delegationData.message,
+            relayerAddress: delegationResult.delegationData.relayerAddress,
+            delegationManagerAddress: delegationResult.delegationData.delegationManagerAddress,
+            delegatorAddress: delegationResult.delegationData.delegatorAddress,
+            userNonce: delegationResult.delegationData.userNonce,
+            domain: delegationResult.delegationData.domain,
+            types: delegationResult.delegationData.types,
+            message: delegationResult.delegationData.message,
           },
         };
 


### PR DESCRIPTION
## Summary
- Combine `hasZeroNativeBalance()` + `prepareDelegationData()` into single `checkBalanceAndPrepareDelegation()` method
- Fetch balance and nonce in parallel using `Promise.all()` with one RPC client
- Remove try-catch fallback in `hasZeroNativeBalance()` - RPC errors now propagate directly

## Changes
- Add `checkBalanceAndPrepareDelegation()` in `eip7702-delegation.service.ts`
- Update `sell.service.ts` and `swap.service.ts` to use combined method
- Add 10 new tests for the new methods

## Performance
**Before:** 2 sequential RPC calls with 2 separate clients
**After:** 1 parallel RPC call with 1 client

## Test plan
- [x] All existing tests pass (89 passed)
- [x] New tests for `checkBalanceAndPrepareDelegation` and `hasZeroNativeBalance`
- [x] Build passes
- [x] Lint passes