### PR TITLE
Disable EIP-7702 delegation for sell/swap transactions

### DIFF
--- a/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
+++ b/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
@@ -68,9 +68,15 @@ export class Eip7702DelegationService {
 
   /**
    * Check if delegation is enabled and supported for the given blockchain
+   *
+   * DISABLED: EIP-7702 gasless transactions require Pimlico integration.
+   * The manual signing approach (eth_sign + eth_signTypedData_v4) doesn't work
+   * because eth_sign is disabled by default in MetaMask.
+   * TODO: Re-enable once Pimlico integration is complete.
    */
-  isDelegationSupported(blockchain: Blockchain): boolean {
-    return this.config.evm.delegationEnabled && CHAIN_CONFIG[blockchain] !== undefined;
+  isDelegationSupported(_blockchain: Blockchain): boolean {
+    // Original: return this.config.evm.delegationEnabled && CHAIN_CONFIG[blockchain] !== undefined;
+    return false;
   }
 
   /**

--- a/src/subdomains/core/buy-crypto/routes/swap/swap.service.ts
+++ b/src/subdomains/core/buy-crypto/routes/swap/swap.service.ts
@@ -257,8 +257,12 @@ export class SwapService {
         type = 'signed transaction';
         payIn = await this.transactionUtilService.handleSignedTxInput(route, request, dto.signedTxHex);
       } else if (dto.eip7702) {
-        type = 'EIP-7702 delegation';
-        payIn = await this.transactionUtilService.handleEip7702Input(route, request, dto.eip7702);
+        // DISABLED: EIP-7702 gasless transactions require Pimlico integration
+        // The manual signing approach doesn't work because eth_sign is disabled in MetaMask
+        // TODO: Re-enable once Pimlico integration is complete
+        throw new BadRequestException(
+          'EIP-7702 delegation is currently not available. Please ensure you have enough gas for the transaction.',
+        );
       } else {
         throw new BadRequestException('Either permit, signedTxHex, or eip7702 must be provided');
       }

--- a/src/subdomains/core/sell-crypto/route/sell.service.ts
+++ b/src/subdomains/core/sell-crypto/route/sell.service.ts
@@ -275,8 +275,12 @@ export class SellService {
         type = 'signed transaction';
         payIn = await this.transactionUtilService.handleSignedTxInput(route, request, dto.signedTxHex);
       } else if (dto.eip7702) {
-        type = 'EIP-7702 delegation';
-        payIn = await this.transactionUtilService.handleEip7702Input(route, request, dto.eip7702);
+        // DISABLED: EIP-7702 gasless transactions require Pimlico integration
+        // The manual signing approach doesn't work because eth_sign is disabled in MetaMask
+        // TODO: Re-enable once Pimlico integration is complete
+        throw new BadRequestException(
+          'EIP-7702 delegation is currently not available. Please ensure you have enough gas for the transaction.',
+        );
       } else {
         throw new BadRequestException('Either permit, signedTxHex, or eip7702 must be provided');
       }


### PR DESCRIPTION
## Summary
- Temporarily disable EIP-7702 gasless transactions for sell/swap
- The manual signing approach (`eth_sign` + `eth_signTypedData_v4`) doesn't work because `eth_sign` is disabled by default in MetaMask
- `isDelegationSupported()` now returns `false` unconditionally
- `confirmSell`/`confirmSwap` reject `eip7702` input with helpful error message

## Why this is needed
Users with zero ETH balance cannot complete sell/swap transactions using the current EIP-7702 implementation. Rather than showing a broken flow, we disable it until proper Pimlico integration is ready.

## Test plan
- [ ] Verify sell/swap still works normally for users with gas
- [ ] Verify users with zero balance get appropriate error message (not EIP-7702 flow)