### PR TITLE
Skip EIP-7702 tests while delegation is disabled

### DIFF
--- a/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-delegation.service.spec.ts
+++ b/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-delegation.service.spec.ts
@@ -115,7 +115,8 @@ jest.mock('../../evm.util', () => ({
   },
 }));
 
-describe('Eip7702DelegationService', () => {
+// TODO: Re-enable when EIP-7702 delegation is reactivated
+describe.skip('Eip7702DelegationService', () => {
   let service: Eip7702DelegationService;
 
   const validDepositAccount: WalletAccount = {


### PR DESCRIPTION
## Summary
- Skip EIP-7702 delegation service tests with `describe.skip`
- Tests were failing because `isDelegationSupported()` now returns `false` for all chains
- Tests will be re-enabled when EIP-7702 delegation is reactivated

## Context
PR #2816 disabled EIP-7702 delegation, causing 57 test failures in CI.