### PR TITLE
fix(realunit): add security validation for sell confirmation

### DIFF
--- a/src/subdomains/supporting/realunit/dto/realunit-sell.dto.ts
+++ b/src/subdomains/supporting/realunit/dto/realunit-sell.dto.ts
@@ -7,6 +7,7 @@ import {
   IsOptional,
   IsPositive,
   IsString,
+  Matches,
   Validate,
   ValidateIf,
   ValidateNested,
@@ -72,6 +73,7 @@ export class RealUnitSellConfirmDto {
   @ApiPropertyOptional({ description: 'Transaction hash if user sent manually (fallback)' })
   @IsOptional()
   @IsString()
+  @Matches(/^0x[a-fA-F0-9]{64}$/, { message: 'Invalid transaction hash format' })
   txHash?: string;
 }
 

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -773,12 +773,7 @@ export class RealUnitService {
 
       this.logger.info(`RealUnit sell confirmed via EIP-7702: ${txHash}`);
     } else if (dto.txHash) {
-      // Validate transaction hash format (0x + 64 hex chars)
-      if (!/^0x[a-fA-F0-9]{64}$/.test(dto.txHash)) {
-        throw new BadRequestException('Invalid transaction hash format');
-      }
-
-      // User sent manually
+      // User sent manually (format validated by DTO)
       txHash = dto.txHash;
       this.logger.info(`RealUnit sell confirmed with manual txHash: ${txHash}`);
     } else {


### PR DESCRIPTION
## Summary
- Validate `delegation.delegator` matches `request.user.address` before executing EIP-7702 transfer (defense-in-depth, contract also verifies signature)
- Validate transaction hash format for manual fallback (must be `0x` + 64 hex characters)

## Changes
- `realunit.service.ts`: Added delegator address validation in `confirmSell()`
- `realunit.service.ts`: Added txHash format regex validation

## Test plan
- [ ] Test EIP-7702 flow with correct delegator address
- [ ] Test EIP-7702 flow with mismatched delegator address (should fail)
- [ ] Test manual txHash with valid format (0x + 64 hex chars)
- [ ] Test manual txHash with invalid format (should fail)