### PR TITLE
feat: differentiate trading errors by KYC level

### DIFF
--- a/src/shared/services/payment-info.service.ts
+++ b/src/shared/services/payment-info.service.ts
@@ -11,6 +11,7 @@ import { NoSwapBlockchains } from 'src/subdomains/core/buy-crypto/routes/swap/sw
 import { CreateSellDto } from 'src/subdomains/core/sell-crypto/route/dto/create-sell.dto';
 import { GetSellPaymentInfoDto } from 'src/subdomains/core/sell-crypto/route/dto/get-sell-payment-info.dto';
 import { GetSellQuoteDto } from 'src/subdomains/core/sell-crypto/route/dto/get-sell-quote.dto';
+import { KycLevel } from 'src/subdomains/generic/user/models/user-data/user-data.enum';
 import { User } from 'src/subdomains/generic/user/models/user/user.entity';
 import { FiatPaymentMethod } from 'src/subdomains/supporting/payment/dto/payment-method.enum';
 import { JwtPayload } from '../auth/jwt-payload.interface';
@@ -61,8 +62,11 @@ export class PaymentInfoService {
       !DisabledProcess(Process.TRADE_APPROVAL_DATE) &&
       !user.userData.tradeApprovalDate &&
       !user.wallet?.autoTradeApproval
-    )
-      throw new BadRequestException('Trading not allowed');
+    ) {
+      throw new BadRequestException(
+        user.userData.kycLevel >= KycLevel.LEVEL_10 ? 'RecommendationRequired' : 'EmailRequired',
+      );
+    }
 
     return dto;
   }

--- a/src/subdomains/supporting/payment/dto/transaction-helper/quote-error.enum.ts
+++ b/src/subdomains/supporting/payment/dto/transaction-helper/quote-error.enum.ts
@@ -12,4 +12,6 @@ export enum QuoteError {
   VIDEO_IDENT_REQUIRED = 'VideoIdentRequired',
   IBAN_CURRENCY_MISMATCH = 'IbanCurrencyMismatch',
   TRADING_NOT_ALLOWED = 'TradingNotAllowed',
+  RECOMMENDATION_REQUIRED = 'RecommendationRequired',
+  EMAIL_REQUIRED = 'EmailRequired',
 }

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -870,8 +870,11 @@ export class TransactionHelper implements OnModuleInit {
       user?.userData &&
       !user.userData.tradeApprovalDate &&
       !user.wallet.autoTradeApproval
-    )
-      return QuoteError.TRADING_NOT_ALLOWED;
+    ) {
+      return user.userData.kycLevel >= KycLevel.LEVEL_10
+        ? QuoteError.RECOMMENDATION_REQUIRED
+        : QuoteError.EMAIL_REQUIRED;
+    }
 
     if (isSell && ibanCountry && !to.isIbanCountryAllowed(ibanCountry)) return QuoteError.IBAN_CURRENCY_MISMATCH;
 


### PR DESCRIPTION
## Summary
- Split `TRADING_NOT_ALLOWED` into specific errors based on KYC level
- `RECOMMENDATION_REQUIRED`: KycLevel >= 10, missing tradeApprovalDate → user needs RECOMMENDATION step
- `EMAIL_REQUIRED`: KycLevel < 10 → user needs CONTACT_DATA step

This allows the frontend to redirect users to the appropriate KYC step instead of showing a generic error.

## Changes
- `quote-error.enum.ts`: Added new error types
- `transaction-helper.ts`: Return specific error based on kycLevel
- `payment-info.service.ts`: Throw specific exception based on kycLevel

## Related PRs
- packages: https://github.com/DFXswiss/packages/pull/121
- services: https://github.com/DFXswiss/services/pull/829

## Test plan
- [ ] User with KycLevel 0 (no email) gets `EMAIL_REQUIRED` error
- [ ] User with KycLevel 10+ (has email, no tradeApprovalDate) gets `RECOMMENDATION_REQUIRED` error
- [ ] User with tradeApprovalDate can trade normally
- [ ] User with autoTradeApproval wallet can trade normally