### PR TITLE
fix: add missing SellRepository to FiatOutputModule

### DIFF
--- a/src/subdomains/supporting/fiat-output/fiat-output.module.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output.module.ts
@@ -5,6 +5,7 @@ import { SharedModule } from 'src/shared/shared.module';
 import { BuyCryptoRepository } from 'src/subdomains/core/buy-crypto/process/repositories/buy-crypto.repository';
 import { LiquidityManagementModule } from 'src/subdomains/core/liquidity-management/liquidity-management.module';
 import { BuyFiatRepository } from 'src/subdomains/core/sell-crypto/process/buy-fiat.repository';
+import { SellRepository } from 'src/subdomains/core/sell-crypto/route/sell.repository';
 import { BankTxModule } from '../bank-tx/bank-tx.module';
 import { BankModule } from '../bank/bank.module';
 import { FiatOutputController } from '../fiat-output/fiat-output.controller';
@@ -31,6 +32,7 @@ import { FiatOutputJobService } from './fiat-output-job.service';
     FiatOutputRepository,
     BuyFiatRepository,
     BuyCryptoRepository,
+    SellRepository,
     FiatOutputService,
     Ep2ReportService,
     FiatOutputJobService,


### PR DESCRIPTION
## Summary
- Add `SellRepository` as provider to `FiatOutputModule`
- Fixes API crash on startup (dependency resolution error)

## Root Cause
Commit e3f815bf8 (PR #2824) added `SellRepository` injection to `FiatOutputService` but forgot to add it as a provider in `FiatOutputModule`.

## Error Before Fix
```
Nest can't resolve dependencies of the FiatOutputService 
(FiatOutputRepository, BuyFiatRepository, BankTxService, BuyCryptoRepository, 
BankTxReturnService, BankTxRepeatService, BankService, ?). 
Please make sure that the argument SellRepository at index [7] is available 
in the FiatOutputModule context.
```

## Test plan
- [x] Build succeeds
- [x] Server starts without dependency errors
- [ ] Deploy to dev and verify API is responsive