### PR TITLE
fix: correct EIP-7702 transaction structure for gasless transfers

### DIFF
--- a/src/integration/blockchain/shared/evm/evm-chain.config.ts
+++ b/src/integration/blockchain/shared/evm/evm-chain.config.ts
@@ -1,0 +1,65 @@
+import { Chain, Hex, Address, parseAbi } from 'viem';
+import { mainnet, arbitrum, optimism, polygon, base, bsc, gnosis, sepolia } from 'viem/chains';
+import { GetConfig } from 'src/config/config';
+import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
+
+// ERC20 ABI - common across all EVM services
+export const ERC20_ABI = parseAbi([
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function balanceOf(address account) view returns (uint256)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+]);
+
+// Chain configuration mapping
+export interface EvmChainConfig {
+  chain: Chain;
+  configKey: string;
+  prefix: string;
+  pimlicoName?: string;
+}
+
+export const EVM_CHAIN_CONFIG: Partial<Record<Blockchain, EvmChainConfig>> = {
+  [Blockchain.ETHEREUM]: { chain: mainnet, configKey: 'ethereum', prefix: 'eth', pimlicoName: 'ethereum' },
+  [Blockchain.ARBITRUM]: { chain: arbitrum, configKey: 'arbitrum', prefix: 'arbitrum', pimlicoName: 'arbitrum' },
+  [Blockchain.OPTIMISM]: { chain: optimism, configKey: 'optimism', prefix: 'optimism', pimlicoName: 'optimism' },
+  [Blockchain.POLYGON]: { chain: polygon, configKey: 'polygon', prefix: 'polygon', pimlicoName: 'polygon' },
+  [Blockchain.BASE]: { chain: base, configKey: 'base', prefix: 'base', pimlicoName: 'base' },
+  [Blockchain.BINANCE_SMART_CHAIN]: { chain: bsc, configKey: 'bsc', prefix: 'bsc', pimlicoName: 'binance' },
+  [Blockchain.GNOSIS]: { chain: gnosis, configKey: 'gnosis', prefix: 'gnosis', pimlicoName: 'gnosis' },
+  [Blockchain.SEPOLIA]: { chain: sepolia, configKey: 'sepolia', prefix: 'sepolia', pimlicoName: 'sepolia' },
+};
+
+/**
+ * Get full chain configuration including RPC URL
+ */
+export function getEvmChainConfig(blockchain: Blockchain): { chain: Chain; rpcUrl: string } | undefined {
+  const config = EVM_CHAIN_CONFIG[blockchain];
+  if (!config) return undefined;
+
+  const blockchainConfig = GetConfig().blockchain;
+  const chainConfig = blockchainConfig[config.configKey];
+  const rpcUrl = `${chainConfig[`${config.prefix}GatewayUrl`]}/${chainConfig[`${config.prefix}ApiKey`] ?? ''}`;
+
+  return { chain: config.chain, rpcUrl };
+}
+
+/**
+ * Get relayer private key for the blockchain
+ */
+export function getRelayerPrivateKey(blockchain: Blockchain): Hex {
+  const config = EVM_CHAIN_CONFIG[blockchain];
+  if (!config) throw new Error(`No config found for ${blockchain}`);
+
+  const blockchainConfig = GetConfig().blockchain;
+  const key = blockchainConfig[config.configKey][`${config.prefix}WalletPrivateKey`];
+  if (!key) throw new Error(`No relayer private key configured for ${blockchain}`);
+
+  return (key.startsWith('0x') ? key : `0x${key}`) as Hex;
+}
+
+/**
+ * Check if a blockchain is supported for EVM operations
+ */
+export function isEvmBlockchainSupported(blockchain: Blockchain): boolean {
+  return EVM_CHAIN_CONFIG[blockchain] !== undefined;
+}


### PR DESCRIPTION
## Summary

**CRITICAL BUG FIX**: The previous EIP-7702 implementation was fundamentally incorrect.

### The Bug
The transaction was sending to the **token contract** instead of the **user's EOA**, causing:
- Transfers came from the **relayer wallet** instead of the user
- User's token balance remained unchanged
- The `authorizationList` had no effect

### Evidence
Sepolia TX `0xe75275ff28019c4aabaf21b134531122fd868b521969012e77e46b6dd2416f5c`:
- Transfer was FROM relayer `0x02a38f29bea81fdd3887891be013c5f348f76c5d`
- User's USDT balance (10,000) was unchanged

### The Fix
| Field | Before (Wrong) | After (Correct) |
|-------|---------------|-----------------|
| `to` | Token contract | User's EOA |
| `data` | `transfer(recipient, amount)` | `execute([{to: token, data: transfer(...)}])` |
| Contract | `SIMPLE_ACCOUNT_FACTORY` (Factory!) | `SimpleDelegation` (BatchExecutor) |

### Correct EIP-7702 Flow
1. User signs authorization delegating `SimpleDelegation` contract to their EOA
2. Relayer sends TX to **USER's EOA** (not token!)
3. Delegated contract's `execute()` runs in EOA context
4. Token transfer happens **FROM the user's EOA**

### SimpleDelegation Contract
- Deployed on Sepolia: `0x824ee1dffe5220dc4dc7c3b82a31c1e86bafd37a`
- TX: https://sepolia.etherscan.io/tx/0x9c5e30f97bfb244da8550732e227b63a4ee71c6e3b3993d4543a4c2f9792fded
- Minimal BatchExecutor without access control (security provided by EIP-7702 authorization signature)

## Test plan
- [ ] Deploy to DEV environment
- [ ] Test gasless sell flow on Sepolia with USDT
- [ ] Verify ERC20 transfer is FROM user's EOA (not relayer)
- [ ] Deploy SimpleDelegation contract on mainnet before production use