### PR TITLE
feat: EIP-7702 gasless via Pimlico ERC-4337 (all chains)

### DIFF
--- a/src/integration/blockchain/shared/evm/evm-chain.config.ts
+++ b/src/integration/blockchain/shared/evm/evm-chain.config.ts
@@ -1,0 +1,51 @@
+import { Chain, parseAbi } from 'viem';
+import { mainnet, arbitrum, optimism, polygon, base, bsc, gnosis, sepolia } from 'viem/chains';
+import { GetConfig } from 'src/config/config';
+import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
+
+// ERC20 ABI - common across all EVM services
+export const ERC20_ABI = parseAbi([
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function balanceOf(address account) view returns (uint256)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+]);
+
+// Chain configuration mapping
+export interface EvmChainConfig {
+  chain: Chain;
+  configKey: string;
+  prefix: string;
+  pimlicoName?: string;
+}
+
+export const EVM_CHAIN_CONFIG: Partial<Record<Blockchain, EvmChainConfig>> = {
+  [Blockchain.ETHEREUM]: { chain: mainnet, configKey: 'ethereum', prefix: 'eth', pimlicoName: 'ethereum' },
+  [Blockchain.ARBITRUM]: { chain: arbitrum, configKey: 'arbitrum', prefix: 'arbitrum', pimlicoName: 'arbitrum' },
+  [Blockchain.OPTIMISM]: { chain: optimism, configKey: 'optimism', prefix: 'optimism', pimlicoName: 'optimism' },
+  [Blockchain.POLYGON]: { chain: polygon, configKey: 'polygon', prefix: 'polygon', pimlicoName: 'polygon' },
+  [Blockchain.BASE]: { chain: base, configKey: 'base', prefix: 'base', pimlicoName: 'base' },
+  [Blockchain.BINANCE_SMART_CHAIN]: { chain: bsc, configKey: 'bsc', prefix: 'bsc', pimlicoName: 'binance' },
+  [Blockchain.GNOSIS]: { chain: gnosis, configKey: 'gnosis', prefix: 'gnosis', pimlicoName: 'gnosis' },
+  [Blockchain.SEPOLIA]: { chain: sepolia, configKey: 'sepolia', prefix: 'sepolia', pimlicoName: 'sepolia' },
+};
+
+/**
+ * Get full chain configuration including RPC URL
+ */
+export function getEvmChainConfig(blockchain: Blockchain): { chain: Chain; rpcUrl: string } | undefined {
+  const config = EVM_CHAIN_CONFIG[blockchain];
+  if (!config) return undefined;
+
+  const blockchainConfig = GetConfig().blockchain;
+  const chainConfig = blockchainConfig[config.configKey];
+  const rpcUrl = `${chainConfig[`${config.prefix}GatewayUrl`]}/${chainConfig[`${config.prefix}ApiKey`] ?? ''}`;
+
+  return { chain: config.chain, rpcUrl };
+}
+
+/**
+ * Check if a blockchain is supported for EVM operations
+ */
+export function isEvmBlockchainSupported(blockchain: Blockchain): boolean {
+  return EVM_CHAIN_CONFIG[blockchain] !== undefined;
+}


### PR DESCRIPTION
## Summary

Implements EIP-7702 gasless transactions using Pimlico's ERC-4337 infrastructure, enabling gasless transfers on **all EVM chains** (not just Sepolia).

### Key Changes

| Before | After |
|--------|-------|
| SimpleDelegation `0x824ee1df...` | MetaMask Delegator `0x63c0c19a...` |
| Only deployed on Sepolia | Deployed on **all major EVM chains** |
| DFX Relayer sends TX directly | UserOperation via Pimlico Bundler |
| Relayer wallet pays gas | Pimlico Paymaster sponsors gas |

### Flow

```
1. User signs EIP-7702 authorization for MetaMask Delegator
2. Backend creates ERC-4337 UserOperation with factory=0x7702
3. Pimlico Paymaster sponsors gas (pm_sponsorUserOperation)
4. Pimlico Bundler submits (eth_sendUserOperation)
5. EntryPoint v0.7 validates and calls execute() on user's EOA
6. Token transfer executes FROM user's address
```

### Supported Chains

- Ethereum Mainnet
- Arbitrum
- Optimism
- Polygon
- Base
- BSC
- Gnosis
- Sepolia

### Technical Details

- Uses MetaMask's `EIP7702StatelessDeleGator` contract which has `onlyEntryPointOrSelf` modifier
- EntryPoint v0.7: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
- EIP-7702 factory marker: `0x0000000000000000000000000000000000007702`

## Test plan

- [x] Build compiles successfully
- [x] Unit tests for encoding functions pass
- [ ] Integration test on Sepolia (requires Pimlico API key)
- [ ] Test on mainnet chain

## Related

- Supersedes approach from PR #2830 (SimpleDelegation)