### PR TITLE
fix: improve refund flow validation and error handling

### DIFF
--- a/src/subdomains/core/history/dto/refund-internal.dto.ts
+++ b/src/subdomains/core/history/dto/refund-internal.dto.ts
@@ -1,5 +1,5 @@
 import { Transform, Type } from 'class-transformer';
-import { IsDate, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsDate, IsIBAN, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { CheckoutReverse } from 'src/integration/checkout/services/checkout.service';
 import { EntityDto } from 'src/shared/dto/entity.dto';
 import { Util } from 'src/shared/utils/util';
@@ -14,6 +14,7 @@ export class RefundInternalDto {
 
   @IsOptional()
   @IsString()
+  @IsIBAN()
   @Transform(Util.trimAll)
   refundIban: string;
 

--- a/src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.entity.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.entity.ts
@@ -87,7 +87,12 @@ export class BankTxReturn extends IEntity {
   }
 
   get creditorData(): CreditorData | undefined {
-    return this.chargebackCreditorData ? JSON.parse(this.chargebackCreditorData) : undefined;
+    if (!this.chargebackCreditorData) return undefined;
+    try {
+      return JSON.parse(this.chargebackCreditorData);
+    } catch {
+      return undefined;
+    }
   }
 
   get paymentMethodIn(): PaymentMethod {

--- a/src/subdomains/supporting/fiat-output/fiat-output.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output.service.ts
@@ -128,10 +128,8 @@ export class FiatOutputService {
       ...creditorData,
     });
 
-    // TODO: BANK_TX_RETURN should also require creditor fields - admin must provide them via DTO
-    if (type !== FiatOutputType.BANK_TX_RETURN) {
-      this.validateRequiredCreditorFields(entity);
-    }
+    // Validate creditor fields for all types - data comes from frontend or admin DTO
+    this.validateRequiredCreditorFields(entity);
 
     if (createReport) entity.reportCreated = false;
 


### PR DESCRIPTION
## Summary
- Enable BANK_TX_RETURN validation in FiatOutput (was previously skipped with TODO comment)
- Add JSON.parse error handling for creditorData in BankTxReturn entity
- Add @IsIBAN validation to refundIban in RefundInternalDto

## Changes
1. **fiat-output.service.ts**: Remove the `if (type !== FiatOutputType.BANK_TX_RETURN)` condition that was skipping validation for BANK_TX_RETURN. All FiatOutput types now require creditor field validation.

2. **bank-tx-return.entity.ts**: Wrap JSON.parse in try-catch to handle malformed creditorData gracefully.

3. **refund-internal.dto.ts**: Add @IsIBAN decorator to validate IBAN format on refundIban field.

## Test plan
- [ ] Test BANK_TX_RETURN refund flow with valid creditor data
- [ ] Test that malformed JSON in creditorData doesn't cause errors
- [ ] Test that invalid IBAN format is rejected with proper validation error