### PR TITLE
feat: add automatic chargeback processing for bank_tx_return

### DIFF
--- a/src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service.ts
@@ -8,6 +8,7 @@ import { Util } from 'src/shared/utils/util';
 import { BankTxRefund, RefundInternalDto } from 'src/subdomains/core/history/dto/refund-internal.dto';
 import { TransactionUtilService } from 'src/subdomains/core/transaction/transaction-util.service';
 import { KycStatus, RiskStatus, UserDataStatus } from 'src/subdomains/generic/user/models/user-data/user-data.enum';
+import { UserStatus } from 'src/subdomains/generic/user/models/user/user.enum';
 import { In, IsNull, Not } from 'typeorm';
 import { FiatOutputType } from '../../fiat-output/fiat-output.entity';
 import { FiatOutputService } from '../../fiat-output/fiat-output.service';
@@ -49,13 +50,16 @@ export class BankTxReturnService {
         chargebackAmount: Not(IsNull()),
         chargebackIban: Not(IsNull()),
         chargebackOutput: IsNull(),
+        transaction: {
+          user: { status: In([UserStatus.NA, UserStatus.ACTIVE]) },
+        },
         userData: {
           kycStatus: In([KycStatus.NA, KycStatus.COMPLETED]),
           status: Not(UserDataStatus.BLOCKED),
           riskStatus: In([RiskStatus.NA, RiskStatus.RELEASED]),
         },
       },
-      relations: { bankTx: true, userData: true },
+      relations: { bankTx: true, userData: true, transaction: { user: true } },
     });
 
     for (const entity of entities) {


### PR DESCRIPTION
## Summary

Add automatic refund processing for `bank_tx_return`, aligning it with `buy_crypto` and `buy_fiat` behavior.

## Problem

Previously, `bank_tx_return` refunds required **manual admin approval** via `POST /bankTxReturn/:id/refund`, while `buy_crypto` and `buy_fiat` had automatic processing via `chargebackTx()` cronjobs.

## Solution

Add `chargebackTx()` method to `BankTxReturnService` that runs every 5 minutes and automatically approves refunds when:

- ✅ User has confirmed (`chargebackAllowedDateUser` is set)
- ✅ Amount is set (`chargebackAmount`)
- ✅ IBAN is set (`chargebackIban`)
- ✅ No output created yet (`chargebackOutput` is null)
- ✅ User status is OK (not blocked, valid KYC/risk status)

## Code Changes

```typescript
async chargebackTx(): Promise<void> {
  const entities = await this.bankTxReturnRepo.find({
    where: {
      chargebackAllowedDate: IsNull(),
      chargebackAllowedDateUser: Not(IsNull()),
      chargebackAmount: Not(IsNull()),
      chargebackIban: Not(IsNull()),
      chargebackOutput: IsNull(),
      userData: {
        kycStatus: In([KycStatus.NA, KycStatus.COMPLETED]),
        status: Not(UserDataStatus.BLOCKED),
        riskStatus: In([RiskStatus.NA, RiskStatus.RELEASED]),
      },
    },
    relations: { bankTx: true, userData: true },
  });

  for (const entity of entities) {
    await this.refundBankTx(entity, {
      chargebackAllowedDate: new Date(),
      chargebackAllowedBy: 'API',
    });
  }
}
```

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Test with existing bank_tx_return that has user confirmation but no admin approval