### PR TITLE
fix: increase refund data expiry from 30s to 300s

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -46,7 +46,7 @@ export class Configuration {
   kycVersion: Version = '2';
   defaultVersionString = `v${this.defaultVersion}`;
   defaultRef = '000-000';
-  transactionRefundExpirySeconds = 30;
+  transactionRefundExpirySeconds = 300; // 5 minutes - enough time to fill out the refund form
   refRewardManualCheckLimit = 3000; // EUR
   txRequestWaitingExpiryDays = 7;
   financeLogTotalBalanceChangeLimit = 5000;


### PR DESCRIPTION
## Summary
- Increase `transactionRefundExpirySeconds` from 30 to 300 seconds (5 minutes)

## Problem
Users were getting "Refund data request invalid" error when filling out the refund form because 30 seconds is not enough time to enter all required address details (street, house number, zip, city, country).

## Solution
Increased the timeout to 5 minutes, which gives users sufficient time to complete the refund form without the data expiring.

## Test plan
- [ ] Open refund form for a failed transaction
- [ ] Take more than 30 seconds to fill out address details
- [ ] Verify refund submission succeeds (no longer fails with "Refund data request invalid")