### PR TITLE
fix: allow KYC status 'Check' for automatic chargeback processing

### DIFF
--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-preparation.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-preparation.service.ts
@@ -455,7 +455,7 @@ export class BuyCryptoPreparationService {
       isComplete: false,
       transaction: {
         userData: {
-          kycStatus: In([KycStatus.NA, KycStatus.COMPLETED]),
+          kycStatus: In([KycStatus.NA, KycStatus.CHECK, KycStatus.COMPLETED]),
           status: Not(UserDataStatus.BLOCKED),
           riskStatus: In([RiskStatus.NA, RiskStatus.RELEASED]),
         },


### PR DESCRIPTION
## Summary
- Add `KycStatus.CHECK` to allowed statuses in `chargebackTx()` cronjob
- Fixes bug where users with kycStatus='Check' were excluded from automatic refunds
- Affected transactions were stuck in 'Refund pending' state

## Root Cause
The `chargebackTx()` method only allowed `KycStatus.NA` and `KycStatus.COMPLETED`, but users in `KycStatus.CHECK` (KYC verification in progress) should also be eligible for automatic chargeback processing.

## Test plan
- [ ] Verify transaction 290743 (buy_crypto 109812) gets processed by the cronjob
- [ ] Confirm other transactions with kycStatus='Check' are now included