### PR TITLE
fix(pimlico): use zero address instead of empty hex for initial paymaster

### DIFF
--- a/src/integration/blockchain/shared/evm/paymaster/pimlico-bundler.service.ts
+++ b/src/integration/blockchain/shared/evm/paymaster/pimlico-bundler.service.ts
@@ -347,7 +347,7 @@ export class PimlicoBundlerService {
       preVerificationGas: toHex(100000n),
       maxFeePerGas: toHex(gasPrice.maxFeePerGas),
       maxPriorityFeePerGas: toHex(gasPrice.maxPriorityFeePerGas),
-      paymaster: '0x' as Address,
+      paymaster: '0x0000000000000000000000000000000000000000' as Address,
       paymasterVerificationGasLimit: toHex(0n),
       paymasterPostOpGasLimit: toHex(0n),
       paymasterData: '0x' as Hex,


### PR DESCRIPTION
## Summary

Fix gasless transaction (EIP-7702 + ERC-4337) by using proper zero address for initial paymaster field.

**Problem:** Pimlico's `pm_sponsorUserOperation` validates the paymaster field and rejects `'0x'` as an invalid hex address with:
```
Validation error: Not a valid hex address at "params[0].userOp.paymaster"
```

**Solution:** Use `'0x0000000000000000000000000000000000000000'` instead of `'0x'` for the initial paymaster value. The sponsorship response will overwrite this with the actual paymaster address.

## Test plan

- [ ] Run gasless sell test with wallet that has 0 ETH balance
- [ ] Verify pm_sponsorUserOperation succeeds
- [ ] Verify full gasless transaction flow works