### PR TITLE
feat(lm): add Ethereum dEURO liquidity management rule

### DIFF
--- a/migration/1767725366000-AddEthereumDeuroBridgeInRule.js
+++ b/migration/1767725366000-AddEthereumDeuroBridgeInRule.js
@@ -4,20 +4,54 @@ module.exports = class AddEthereumDeuroBridgeInRule1767725366000 {
     name = 'AddEthereumDeuroBridgeInRule1767725366000'
 
     async up(queryRunner) {
-        // 1. Create new action for dEURO bridge-in with EURC as source
-        await queryRunner.query(`
-            INSERT INTO "dbo"."liquidity_management_action" ("system", "command", "params")
-            VALUES ('dEURO', 'bridge-in', '{"asset": "EURC"}')
+        // 1. Find Ethereum dEURO asset
+        const assetResult = await queryRunner.query(`
+            SELECT id FROM "dbo"."asset"
+            WHERE "name" = 'dEURO' AND "blockchain" = 'Ethereum' AND "type" = 'Token'
         `);
 
-        // 2. Get the newly created action ID
-        const result = await queryRunner.query(`
+        if (!assetResult || assetResult.length === 0) {
+            console.log('Ethereum dEURO asset not found - skipping migration');
+            return;
+        }
+        const assetId = assetResult[0].id;
+
+        // 2. Find the liquidity management rule for this asset
+        const ruleResult = await queryRunner.query(`
+            SELECT id FROM "dbo"."liquidity_management_rule"
+            WHERE "targetAssetId" = ${assetId}
+        `);
+
+        if (!ruleResult || ruleResult.length === 0) {
+            console.log('Liquidity management rule for Ethereum dEURO not found - skipping migration');
+            return;
+        }
+        const ruleId = ruleResult[0].id;
+
+        // 3. Check if bridge-in action already exists
+        const existingAction = await queryRunner.query(`
             SELECT id FROM "dbo"."liquidity_management_action"
             WHERE "system" = 'dEURO' AND "command" = 'bridge-in' AND "params" = '{"asset": "EURC"}'
         `);
-        const actionId = result[0].id;
 
-        // 3. Activate rule 259 (Ethereum dEURO) and link to the bridge-in action
+        let actionId;
+        if (existingAction && existingAction.length > 0) {
+            actionId = existingAction[0].id;
+        } else {
+            // 4. Create new action for dEURO bridge-in with EURC as source
+            await queryRunner.query(`
+                INSERT INTO "dbo"."liquidity_management_action" ("system", "command", "params")
+                VALUES ('dEURO', 'bridge-in', '{"asset": "EURC"}')
+            `);
+
+            const newActionResult = await queryRunner.query(`
+                SELECT id FROM "dbo"."liquidity_management_action"
+                WHERE "system" = 'dEURO' AND "command" = 'bridge-in' AND "params" = '{"asset": "EURC"}'
+            `);
+            actionId = newActionResult[0].id;
+        }
+
+        // 5. Activate rule and link to the bridge-in action
         await queryRunner.query(`
             UPDATE "dbo"."liquidity_management_rule"
             SET
@@ -26,12 +60,23 @@ module.exports = class AddEthereumDeuroBridgeInRule1767725366000 {
                 "optimal" = 5000,
                 "maximal" = 20000,
                 "deficitStartActionId" = ${actionId}
-            WHERE "id" = 259
+            WHERE "id" = ${ruleId}
         `);
     }
 
     async down(queryRunner) {
-        // 1. Reset rule 259 to inactive state
+        // 1. Find Ethereum dEURO asset
+        const assetResult = await queryRunner.query(`
+            SELECT id FROM "dbo"."asset"
+            WHERE "name" = 'dEURO' AND "blockchain" = 'Ethereum' AND "type" = 'Token'
+        `);
+
+        if (!assetResult || assetResult.length === 0) {
+            return;
+        }
+        const assetId = assetResult[0].id;
+
+        // 2. Reset the rule to inactive state
         await queryRunner.query(`
             UPDATE "dbo"."liquidity_management_rule"
             SET
@@ -40,10 +85,10 @@ module.exports = class AddEthereumDeuroBridgeInRule1767725366000 {
                 "optimal" = NULL,
                 "maximal" = NULL,
                 "deficitStartActionId" = NULL
-            WHERE "id" = 259
+            WHERE "targetAssetId" = ${assetId}
         `);
 
-        // 2. Delete the bridge-in action
+        // 3. Delete the bridge-in action
         await queryRunner.query(`
             DELETE FROM "dbo"."liquidity_management_action"
             WHERE "system" = 'dEURO' AND "command" = 'bridge-in' AND "params" = '{"asset": "EURC"}'


### PR DESCRIPTION
## Summary
- Add new `liquidity_management_action` for dEURO `bridge-in` with EURC as source asset
- Activate rule 259 (Ethereum dEURO) with minimal=1000, optimal=5000, maximal=20000
- Link rule to the new bridge-in action

## Background
When Ethereum dEURO balance drops below the minimal threshold, the system will automatically bridge EURC to dEURO using the `DEuroAdapter.bridgeIn()` method via the StablecoinBridge contract.

## Prerequisites
- Sufficient EURC balance on the Ethereum Liquidity Address
- dEURO StablecoinBridge must have remaining capacity

## Test plan
- [ ] Run migration locally
- [ ] Verify via debug endpoint:
  ```sql
  SELECT * FROM liquidity_management_rule WHERE id = 259
  SELECT * FROM liquidity_management_action WHERE system = 'dEURO' AND command = 'bridge-in'
  ```
- [ ] Test with low dEURO balance on Liquidity Address