### PR TITLE
perf: reduce addFiatOutputs interval from 10min to 1min

### DIFF
--- a/src/subdomains/core/sell-crypto/process/services/buy-fiat-job.service.ts
+++ b/src/subdomains/core/sell-crypto/process/services/buy-fiat-job.service.ts
@@ -26,7 +26,7 @@ export class BuyFiatJobService {
     await this.buyFiatPreparationService.chargebackTx();
   }
 
-  @DfxCron(CronExpression.EVERY_10_MINUTES, { process: Process.BUY_FIAT, timeout: 7200 })
+  @DfxCron(CronExpression.EVERY_MINUTE, { process: Process.BUY_FIAT, timeout: 7200 })
   async addFiatOutputs(): Promise<void> {
     await this.buyFiatPreparationService.addFiatOutputs();
   }


### PR DESCRIPTION
## Summary
- Reduce `addFiatOutputs` cronjob interval from `EVERY_10_MINUTES` to `EVERY_MINUTE`

## Problem
FiatOutput creation for BuyFiat (sell) transactions could take up to 10 minutes due to the cronjob interval, causing slow transaction processing.

## Solution
Reduce the interval to 1 minute, cutting the maximum wait time by 90%.

## Test plan
- [ ] Verify addFiatOutputs runs every minute
- [ ] Monitor FiatOutput creation timing for sell transactions