### PR TITLE
fix: persist Yapeal API errors to fiat_output.info column

### DIFF
--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -358,6 +358,7 @@ export class FiatOutputJobService {
           endToEndId,
           isTransmittedDate: new Date(),
           isApprovedDate: new Date(),
+          ...(entity.info?.startsWith('YAPEAL error') && { info: null }),
         });
       } catch (e) {
         this.logger.error(`Failed to transmit YAPEAL payment for fiat output ${entity.id}:`, e);


### PR DESCRIPTION
## Summary
- Store Yapeal API error messages in the `info` column when payment transmission fails
- Only write error if `info` is empty (avoid unnecessary DB updates on every cron run)
- Clear error from `info` on successful transmission (only if it starts with "YAPEAL error")
- Error message is truncated to 256 characters (column length limit)

## Behavior

| Scenario | Action |
|----------|--------|
| First failure | Write error to `info` |
| Subsequent failures | Only log, no DB update |
| Success after failure | Clear `info` (if YAPEAL error) |
| Success (no prior failure) | No change to `info` |

## Context
Found during debugging of fiat_output 78827 which had `isReadyDate` set but was not being transmitted, while later entries (78829) were successfully processed. Without the error stored in DB, the root cause could not be determined.

## Test plan
- [ ] Deploy to dev
- [ ] Trigger a Yapeal payment failure (e.g., invalid IBAN)
- [ ] Verify error message is stored in `info` column
- [ ] Verify no repeated writes on subsequent cron runs
- [ ] Fix the issue and verify `info` is cleared on success