### PR TITLE
fix: correct ownership check for unassigned transaction refunds

### DIFF
--- a/src/subdomains/core/history/controllers/transaction.controller.ts
+++ b/src/subdomains/core/history/controllers/transaction.controller.ts
@@ -323,8 +323,15 @@ export class TransactionController {
     if (transaction.refundTargetEntity instanceof BankTx) {
       // Unassigned transaction
       if (!BankTxTypeUnassigned(transaction.bankTx.type)) throw new NotFoundException('Transaction not found');
-      const txOwner = await this.bankTxService.getUserDataForBankTx(transaction.bankTx, jwt.account);
-      if (txOwner?.id !== jwt.account) throw new ForbiddenException('You can only refund your own transaction');
+
+      // Check ownership (consistent with requestRefund logic)
+      if (transaction.userData && jwt.account !== transaction.userData.id)
+        throw new ForbiddenException('You can only refund your own transaction');
+      if (!transaction.userData) {
+        const txOwner = await this.bankTxService.getUserDataForBankTx(transaction.bankTx, jwt.account);
+        if (txOwner?.id !== jwt.account) throw new ForbiddenException('You can only refund your own transaction');
+      }
+
       if (transaction.refundTargetEntity.bankTxReturn)
         throw new BadRequestException('You can only refund a transaction once');
 


### PR DESCRIPTION
## Summary
- Fix bug where users couldn't refund their own unassigned transactions
- Align ownership validation between `getTransactionRefund` and `requestRefund`
- Add null-safety to prevent potential TypeError crash

## Root Cause
The ownership check in `getTransactionRefund` used `||` (OR) logic:
```typescript
if (jwt.account !== transaction.userData?.id || txOwner.id !== jwt.account)
```

For unassigned transactions, `transaction.userData` is `null`, so:
- `transaction.userData?.id` → `undefined`
- `jwt.account !== undefined` → always `true`
- Exception thrown before `txOwner` check could run

## Solution

### Consistent ownership validation (matching `requestRefund` pattern):
```typescript
// 1. Check userData first (protects existing refund session)
if (transaction.userData && jwt.account !== transaction.userData.id)
  throw new ForbiddenException('You can only refund your own transaction');

// 2. Check txOwner only for fresh unassigned transactions
if (!transaction.userData) {
  const txOwner = await this.bankTxService.getUserDataForBankTx(...);
  if (txOwner?.id !== jwt.account) 
    throw new ForbiddenException('You can only refund your own transaction');
}
```

### Why this is better than just `txOwner?.id !== jwt.account`:
| Scenario | Simple fix | This fix |
|----------|-----------|----------|
| Fresh unassigned tx | ✅ Works | ✅ Works |
| User A starts, User B (same IBAN) tries to continue | ✅ Passes getTransactionRefund | ❌ Blocked early |
| Consistency with requestRefund | ❌ Inconsistent | ✅ Same logic |

### Additional fix in `requestRefund`:
Added null-safety (`?.`) to prevent TypeError when `txOwner` is undefined.

## Test plan
- [ ] Fresh unassigned tx: User with matching IBAN can request refund
- [ ] Fresh unassigned tx: User without matching IBAN cannot request refund
- [ ] Existing session: Original user can continue refund
- [ ] Existing session: Other user (even with same IBAN) is blocked
- [ ] Assigned transactions still work correctly
- [ ] No crash when txOwner is undefined