### PR TITLE
fix: remove broken user status check from BankTxReturn auto-refund cronjob

### DIFF
--- a/src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service.ts
@@ -8,7 +8,6 @@ import { Util } from 'src/shared/utils/util';
 import { BankTxRefund, RefundInternalDto } from 'src/subdomains/core/history/dto/refund-internal.dto';
 import { TransactionUtilService } from 'src/subdomains/core/transaction/transaction-util.service';
 import { KycStatus, RiskStatus, UserDataStatus } from 'src/subdomains/generic/user/models/user-data/user-data.enum';
-import { UserStatus } from 'src/subdomains/generic/user/models/user/user.enum';
 import { In, IsNull, Not } from 'typeorm';
 import { FiatOutputType } from '../../fiat-output/fiat-output.entity';
 import { FiatOutputService } from '../../fiat-output/fiat-output.service';
@@ -50,16 +49,13 @@ export class BankTxReturnService {
         chargebackAmount: Not(IsNull()),
         chargebackIban: Not(IsNull()),
         chargebackOutput: IsNull(),
-        transaction: {
-          user: { status: In([UserStatus.NA, UserStatus.ACTIVE]) },
-        },
         userData: {
           kycStatus: In([KycStatus.NA, KycStatus.COMPLETED]),
           status: Not(UserDataStatus.BLOCKED),
           riskStatus: In([RiskStatus.NA, RiskStatus.RELEASED]),
         },
       },
-      relations: { bankTx: true, userData: true, transaction: { user: true } },
+      relations: { bankTx: true, userData: true },
     });
 
     for (const entity of entities) {


### PR DESCRIPTION
## Summary
- Remove `transaction.user.status` check from `chargebackTx()` cronjob
- BankTxReturn transactions never have a `userId`, so this check always failed
- The `userData` validation (kycStatus, status, riskStatus) is sufficient

## Problem
The auto-refund cronjob for BankTxReturn was never processing any entries because it checked:
```typescript
transaction: {
  user: { status: In([UserStatus.NA, UserStatus.ACTIVE]) },
}
```
But `transaction.userId` is always `null` for BankTxReturn, so no records were ever found.

## Test plan
- [ ] Create a BankTxReturn refund request with valid userData
- [ ] Verify cronjob now picks up and processes the refund automatically