### PR TITLE
fix: cleanup fiat_output entries without amount

### DIFF
--- a/migration/1767734994504-CleanupFiatOutputWithoutAmount.js
+++ b/migration/1767734994504-CleanupFiatOutputWithoutAmount.js
@@ -15,7 +15,8 @@ module.exports = class CleanupFiatOutputWithoutAmount1767734994504 {
    */
   async up(queryRunner) {
     // Reset chargebackAllowedDate and chargebackOutputId in buy_crypto
-    // so the chargebackTx job can recreate fiat_output with correct amount
+    // Customers must manually restart the refund process with address data
+    // (automatic job will fail due to missing creditor fields)
     await queryRunner.query(`
             UPDATE buy_crypto
             SET chargebackOutputId = NULL, chargebackAllowedDate = NULL
@@ -25,7 +26,7 @@ module.exports = class CleanupFiatOutputWithoutAmount1767734994504 {
         `);
 
     // Reset chargebackAllowedDate and chargebackOutputId in bank_tx_return
-    // so the chargeback job can recreate fiat_output with correct amount
+    // Customers must manually restart the refund process with address data
     await queryRunner.query(`
             UPDATE bank_tx_return
             SET chargebackOutputId = NULL, chargebackAllowedDate = NULL
@@ -35,7 +36,7 @@ module.exports = class CleanupFiatOutputWithoutAmount1767734994504 {
         `);
 
     // Reset chargebackAllowedDate and chargebackOutputId in bank_tx_repeat
-    // so the chargeback job can recreate fiat_output with correct amount
+    // (included for completeness, currently 0 affected entries)
     await queryRunner.query(`
             UPDATE bank_tx_repeat
             SET chargebackOutputId = NULL, chargebackAllowedDate = NULL


### PR DESCRIPTION
## Summary
- Remove orphaned fiat_output entries that were created without amount due to a previous bug
- Reset `chargebackOutputId` AND `chargebackAllowedDate` in buy_crypto, bank_tx_return, bank_tx_repeat
- Delete fiat_output entries where amount IS NULL and isComplete = 0

## Why reset chargebackAllowedDate?
Resetting this field alone is NOT sufficient for automatic processing. The affected entries are missing creditor data (name, address, zip, city, country) which is now required by `validateRequiredCreditorFields()`.

## ⚠️ IMPORTANT: Manual customer notification required!

**ALL 40 affected entries require manual intervention:**

The automatic `chargebackTx` jobs will find the entries but will FAIL with:
```
BadRequestException: Missing required creditor fields: name, address, zip, city, country
```

### Why automatic processing won't work:
1. **buy_crypto (34 entries):** `chargebackCreditorData` is empty/null - customers never provided address data
2. **bank_tx_return (6 entries):** `transaction.userId = NULL` - job query requires user status check

### Required manual steps AFTER migration:

1. **Send manual emails to 38 affected customers** (userDataIds listed below)
2. Customers must restart the refund process and provide their address data
3. After customers complete the process, fiat_output will be created correctly

## Affected userDataIds for manual email

**buy_crypto customers (33 unique):**
```
188972, 230597, 299613, 302473, 302850, 312439, 315157, 315816, 316750, 318479, 
320211, 322582, 328324, 338046, 341616, 347788, 353100, 354863, 357011, 357107, 
357130, 357619, 357862, 358512, 359631, 360235, 360567, 360824, 360826, 360832, 
361180, 361355, 362408
```

**bank_tx_return customers (5 unique):**
```
299185, 307373, 355067, 355531, 355733
```

## Migration steps (in order)
1. `UPDATE buy_crypto SET chargebackOutputId = NULL, chargebackAllowedDate = NULL WHERE ...`
2. `UPDATE bank_tx_return SET chargebackOutputId = NULL, chargebackAllowedDate = NULL WHERE ...`
3. `UPDATE bank_tx_repeat SET chargebackOutputId = NULL, chargebackAllowedDate = NULL WHERE ...`
4. `DELETE FROM fiat_output WHERE amount IS NULL AND isComplete = 0`

## Test plan
- [ ] Migration runs successfully on dev
- [ ] Verify 40 fiat_output entries are deleted
- [ ] Verify affected buy_crypto/bank_tx_return have `chargebackOutputId = NULL` and `chargebackAllowedDate = NULL`
- [ ] **Send manual emails to 38 customers (userDataIds above)**
- [ ] Customers restart refund process with address data
- [ ] Verify new fiat_output entries have correct amount after customer action