### PR TITLE
fix: exclude 4xx client errors from Application Insights failures

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,9 +29,9 @@ async function bootstrap() {
 
     // Don't mark 4xx client errors as failures - only 5xx are real server errors
     AppInsights.defaultClient.addTelemetryProcessor((envelope) => {
-      const data = envelope.data as { baseType?: string; baseData?: { responseCode?: number; success?: boolean } };
-      if (data.baseType === 'RequestData' && data.baseData) {
-        const responseCode = data.baseData.responseCode ?? 0;
+      const data = envelope.data as { baseType?: string; baseData?: { responseCode?: string; success?: boolean } };
+      if (data.baseType === 'RequestData' && data.baseData?.responseCode) {
+        const responseCode = parseInt(data.baseData.responseCode, 10);
         if (responseCode >= 400 && responseCode < 500) {
           data.baseData.success = true;
         }


### PR DESCRIPTION
## Summary
- Add TelemetryProcessor to Application Insights configuration
- Mark 4xx responses as `success=true` so they don't appear in Failures dashboard
- Only 5xx server errors will now be counted as failures

## Problem
Azure Application Insights marks all responses with status >= 400 as "failed" by default. This means client errors like:
- `400 Bad Request` (invalid input)
- `401 Unauthorized` (missing/invalid token)
- `404 Not Found` (wrong URL)

...all show up in the Failures dashboard, creating noise and hiding real server errors.

## Solution
Add a TelemetryProcessor that sets `success=true` for 4xx responses. The requests are still logged, just not classified as failures.

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Deploy to DEV and verify 4xx errors no longer appear in `./scripts/log-debug.sh failures`