### PR TITLE
fix: reset chargebackAmount for stuck refunds

### DIFF
--- a/migration/1767795194463-ResetStuckRefundChargebackAmount.js
+++ b/migration/1767795194463-ResetStuckRefundChargebackAmount.js
@@ -1,0 +1,51 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * Reset chargebackAmount for stuck refunds so users can re-initiate the refund flow.
+ *
+ * Problem: 42 transactions have chargebackDate set but chargebackAllowedDate is NULL,
+ * causing them to be stuck in "Refund pending" state. The API endpoint blocks re-refund
+ * when chargebackAmount is set.
+ *
+ * Solution: Reset chargebackAmount to NULL so users can request refund again via API.
+ *
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class ResetStuckRefundChargebackAmount1767795194463 {
+  name = 'ResetStuckRefundChargebackAmount1767795194463';
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async up(queryRunner) {
+    // Reset chargebackAmount for stuck BuyCrypto refunds (36 entries, ~12,645 EUR)
+    await queryRunner.query(`
+      UPDATE buy_crypto
+      SET chargebackAmount = NULL
+      WHERE chargebackDate IS NOT NULL
+        AND chargebackAllowedDate IS NULL
+        AND isComplete = 0
+    `);
+
+    // Reset chargebackAmount for stuck BankTxReturn refunds (6 entries, ~292 EUR)
+    await queryRunner.query(`
+      UPDATE bank_tx_return
+      SET chargebackAmount = NULL
+      WHERE chargebackDate IS NOT NULL
+        AND chargebackAllowedDate IS NULL
+        AND chargebackOutputId IS NULL
+    `);
+  }
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async down(queryRunner) {
+    // Cannot restore original chargebackAmount values - this is a one-way migration
+    // The values will be re-set when users re-initiate the refund flow
+  }
+};


### PR DESCRIPTION
## Summary
- Reset `chargebackAmount` to NULL for 42 stuck refund transactions
- Allows users to re-initiate the refund flow via the existing API endpoint

## Problem
42 transactions are stuck in "Refund pending" state:
- `chargebackDate` is set but `chargebackAllowedDate` is NULL
- The API endpoint (`PUT /transaction/:id/refund`) blocks when `chargebackAmount` is already set
- Users cannot re-request the refund

## Affected Transactions
| Table | Count | Total Amount |
|-------|-------|--------------|
| buy_crypto | 36 | ~12,645 EUR |
| bank_tx_return | 6 | ~292 EUR |

## Solution
Migration resets `chargebackAmount = NULL` so:
1. API endpoint no longer blocks
2. Users can re-request refund via Frontend
3. Cronjob will then process correctly

## ⚠️ Manual Handling Required (2 Transactions)
After migration, **2 transactions will NOT be auto-processed** due to user/risk status:

| ID | Problem | Required Action |
|---|---|---|
| 108641 | `userStatus = "Deleted"` | Admin must fix user status or set `chargebackAllowedDate` manually |
| 108909 | `riskStatus = "Blocked"` | Admin must release risk status or set `chargebackAllowedDate` manually |

The cronjob requires `user.status IN ('NA', 'Active')` and `userData.riskStatus IN ('NA', 'Released')`.

## Manual Fix (Alternative)
If you need to fix individual transactions manually via DB:

```sql
-- For a specific BuyCrypto transaction
UPDATE buy_crypto
SET chargebackAmount = NULL
WHERE id = <ID>

-- For a specific BankTxReturn transaction
UPDATE bank_tx_return
SET chargebackAmount = NULL
WHERE id = <ID>
```

After the reset, the user must re-request the refund via the Frontend (`PUT /transaction/:id/refund`) and provide name/address for the creditor data.

## Test plan
- [ ] Verify migration runs without errors
- [ ] Verify affected transactions can be refunded again via API
- [ ] Verify cronjob picks up re-requested refunds
- [ ] Handle transactions 108641 and 108909 manually (user/risk status issues)