### PR TITLE
fix: round FiatOutput amount to 2 decimal places

### DIFF
--- a/src/subdomains/supporting/fiat-output/fiat-output.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Util } from 'src/shared/utils/util';
 import { BuyCrypto } from 'src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity';
 import { BuyCryptoRepository } from 'src/subdomains/core/buy-crypto/process/repositories/buy-crypto.repository';
 import { BuyFiat } from 'src/subdomains/core/sell-crypto/process/buy-fiat.entity';
@@ -47,6 +48,7 @@ export class FiatOutputService {
     }
 
     const entity = this.fiatOutputRepo.create(dto);
+    if (entity.amount != null) entity.amount = Util.round(entity.amount, 2);
 
     if (dto.buyFiatId) {
       entity.buyFiats = [await this.buyFiatRepo.findOneBy({ id: dto.buyFiatId })];
@@ -107,7 +109,10 @@ export class FiatOutputService {
 
         creditorData = {
           currency: buyFiats[0].outputAsset?.name,
-          amount: buyFiats.reduce((sum, bf) => sum + (bf.outputAmount ?? 0), 0),
+          amount: Util.round(
+            buyFiats.reduce((sum, bf) => sum + (bf.outputAmount ?? 0), 0),
+            2,
+          ),
           name: userData.completeName,
           address: userData.address.street,
           houseNumber: userData.address.houseNumber,
@@ -127,6 +132,8 @@ export class FiatOutputService {
       originEntityId,
       ...creditorData,
     });
+
+    if (entity.amount != null) entity.amount = Util.round(entity.amount, 2);
 
     // Validate creditor fields for all types - data comes from frontend or admin DTO
     this.validateRequiredCreditorFields(entity);
@@ -155,6 +162,8 @@ export class FiatOutputService {
       entity.bankTx = await this.bankTxService.getBankTxRepo().findOneBy({ id: dto.bankTxId });
       if (!entity.bankTx) throw new NotFoundException('BankTx not found');
     }
+
+    if (dto.amount != null) dto.amount = Util.round(dto.amount, 2);
 
     return this.fiatOutputRepo.save({ ...entity, ...dto });
   }


### PR DESCRIPTION
## Summary
- Add `Util.round(amount, 2)` when setting `FiatOutput.amount` to ensure fiat amounts are always rounded to 2 decimal places
- Affects `create()`, `createInternal()`, and `update()` methods in `FiatOutputService`

## Problem
FiatOutput amounts were stored without rounding, which could lead to values like `123.456789` instead of `123.46`. Bank transactions require exactly 2 decimal places.

## Solution
Use the existing `Util.round()` function to round amounts before saving:
- `create()`: after entity creation from DTO
- `createInternal()`: when calculating sum from buyFiats + defensive rounding before save
- `update()`: before saving DTO amount

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Format check passes
- [x] FiatOutput tests pass (8/8)