### PR TITLE
feat: add return from liquidity support for forwarded CryptoInputs

### DIFF
--- a/src/subdomains/supporting/payin/entities/crypto-input.entity.ts
+++ b/src/subdomains/supporting/payin/entities/crypto-input.entity.ts
@@ -39,6 +39,8 @@ export enum PayInStatus {
   TO_RETURN = 'ToReturn',
   RETURNED = 'Returned',
   RETURN_CONFIRMED = 'ReturnConfirmed',
+  TO_RETURN_FROM_LIQ = 'ToReturnFromLiq',
+  RETURN_FROM_LIQ_PENDING = 'ReturnFromLiqPending',
   ACKNOWLEDGED = 'Acknowledged',
   FORWARDED = 'Forwarded',
   FORWARD_CONFIRMED = 'ForwardConfirmed',
@@ -211,6 +213,29 @@ export class CryptoInput extends IEntity {
     this.action = PayInAction.RETURN;
     this.destinationAddress = returnAddress;
     this.chargebackAmount = chargebackAmount;
+
+    return this;
+  }
+
+  triggerReturnFromLiquidity(returnAddress: BlockchainAddress, chargebackAmount: number): this {
+    this.status = PayInStatus.TO_RETURN_FROM_LIQ;
+    this.action = PayInAction.RETURN;
+    this.destinationAddress = returnAddress;
+    this.chargebackAmount = chargebackAmount;
+
+    return this;
+  }
+
+  pendingReturnFromLiquidity(returnTxId: string): this {
+    this.returnTxId = returnTxId;
+    this.status = PayInStatus.RETURN_FROM_LIQ_PENDING;
+
+    return this;
+  }
+
+  rollbackReturnFromLiquidity(): this {
+    this.status = PayInStatus.TO_RETURN_FROM_LIQ;
+    this.returnTxId = null;
 
     return this;
   }

--- a/src/subdomains/supporting/payin/services/base/payin-evm.service.ts
+++ b/src/subdomains/supporting/payin/services/base/payin-evm.service.ts
@@ -23,6 +23,10 @@ export abstract class PayInEvmService {
     return this.#client.sendTokenFromAccount(account, addressTo, tokenName, amount);
   }
 
+  async sendTokenFromDex(addressTo: string, token: Asset, amount: number): Promise<string> {
+    return this.#client.sendTokenFromDex(addressTo, token, amount);
+  }
+
   async checkTransactionCompletion(txHash: string, minConfirmations: number): Promise<boolean> {
     return this.#client.isTxComplete(txHash, minConfirmations);
   }

--- a/src/subdomains/supporting/payin/services/payin-bitcoin.service.ts
+++ b/src/subdomains/supporting/payin/services/payin-bitcoin.service.ts
@@ -19,6 +19,7 @@ export class PayInBitcoinService extends PayInBitcoinBasedService {
   private readonly logger = new DfxLogger(PayInBitcoinService);
 
   private readonly client: BitcoinClient;
+  private readonly liqClient: BitcoinClient;
 
   // Limit parallel Bitcoin node calls to prevent overload
   private readonly nodeCallQueue = QueueHandler.createParallelQueueHandler(5);
@@ -30,6 +31,7 @@ export class PayInBitcoinService extends PayInBitcoinBasedService {
     super();
 
     this.client = bitcoinService.getDefaultClient(BitcoinNodeType.BTC_INPUT);
+    this.liqClient = bitcoinService.getDefaultClient(BitcoinNodeType.BTC_OUTPUT);
   }
 
   isAvailable(): boolean {
@@ -104,6 +106,11 @@ export class PayInBitcoinService extends PayInBitcoinBasedService {
       input.txSequence,
       await this.feeService.getRecommendedFeeRate(),
     );
+  }
+
+  async sendFromLiquidity(addressTo: string, amount: number): Promise<string> {
+    const feeRate = await this.feeService.getRecommendedFeeRate();
+    return this.liqClient.sendMany([{ addressTo, amount }], feeRate);
   }
 
   /**

--- a/src/subdomains/supporting/payin/services/payin-cardano.service.ts
+++ b/src/subdomains/supporting/payin/services/payin-cardano.service.ts
@@ -36,6 +36,10 @@ export class PayInCardanoService {
     return this.cardanoService.sendTokenFromAccount(account, addressTo, token, amount);
   }
 
+  async sendTokenFromDex(addressTo: string, token: Asset, amount: number): Promise<string> {
+    return this.cardanoService.sendTokenFromDex(addressTo, token, amount);
+  }
+
   async checkTransactionCompletion(txHash: string, minConfirmations: number): Promise<boolean> {
     return this.cardanoService.isTxComplete(txHash, minConfirmations);
   }

--- a/src/subdomains/supporting/payin/services/payin-solana.service.ts
+++ b/src/subdomains/supporting/payin/services/payin-solana.service.ts
@@ -39,6 +39,10 @@ export class PayInSolanaService {
     return this.solanaService.sendTokenFromAccount(account, addressTo, token, amount);
   }
 
+  async sendTokenFromDex(addressTo: string, token: Asset, amount: number): Promise<string> {
+    return this.solanaService.sendTokenFromDex(addressTo, token, amount);
+  }
+
   async checkTransactionCompletion(txHash: string, minConfirmations: number): Promise<boolean> {
     return this.solanaService.isTxComplete(txHash, minConfirmations);
   }

--- a/src/subdomains/supporting/payin/services/payin-tron.service.ts
+++ b/src/subdomains/supporting/payin/services/payin-tron.service.ts
@@ -35,6 +35,10 @@ export class PayInTronService {
     return this.tronService.sendTokenFromAccount(account, addressTo, token, amount);
   }
 
+  async sendTokenFromDex(addressTo: string, token: Asset, amount: number): Promise<string> {
+    return this.tronService.sendTokenFromDex(addressTo, token, amount);
+  }
+
   async checkTransactionCompletion(txHash: string, minConfirmations: number): Promise<boolean> {
     return this.tronService.isTxComplete(txHash, minConfirmations);
   }

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/bitcoin-based.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/bitcoin-based.strategy.ts
@@ -86,4 +86,29 @@ export abstract class BitcoinBasedStrategy extends SendStrategy {
       }
     }
   }
+
+  async doSendFromLiquidity(payIns: CryptoInput[], type: SendType): Promise<void> {
+    if (type !== SendType.RETURN) {
+      throw new Error('doSendFromLiquidity only supports RETURN type');
+    }
+
+    await this.payInService.checkHealthOrThrow();
+
+    for (const payIn of payIns) {
+      try {
+        const returnTxId = await this.sendReturnFromLiquidity(payIn);
+
+        payIn.pendingReturnFromLiquidity(returnTxId);
+        await this.payInRepo.save(payIn);
+
+        this.logger.verbose(`Returned pay-in ${payIn.id} from liquidity, txId: ${returnTxId}`);
+      } catch (e) {
+        this.logger.error(`Failed to return ${this.blockchain} pay-in ${payIn.id} from liquidity:`, e);
+        // Status remains TO_RETURN_FROM_LIQ, retry in next cron iteration
+        continue;
+      }
+    }
+  }
+
+  protected abstract sendReturnFromLiquidity(payIn: CryptoInput): Promise<string>;
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/cardano.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/cardano.strategy.ts
@@ -20,6 +20,7 @@ export abstract class CardanoStrategy extends SendStrategy {
   protected abstract checkPreparation(payIn: CryptoInput): Promise<boolean>;
   protected abstract prepareSend(payIn: CryptoInput, estimatedNativeFee: number): Promise<void>;
   protected abstract sendTransfer(payIn: CryptoInput, type: SendType): Promise<string>;
+  protected abstract sendReturnFromLiquidity(payIn: CryptoInput): Promise<string>;
 
   async doSend(payIns: CryptoInput[], type: SendType): Promise<void> {
     for (const payIn of payIns) {
@@ -81,6 +82,27 @@ export abstract class CardanoStrategy extends SendStrategy {
         }
       } catch (e) {
         this.logger.error(`Failed to check confirmations of ${this.blockchain} input ${payIn.id}:`, e);
+      }
+    }
+  }
+
+  async doSendFromLiquidity(payIns: CryptoInput[], type: SendType): Promise<void> {
+    if (type !== SendType.RETURN) {
+      throw new Error('doSendFromLiquidity only supports RETURN type');
+    }
+
+    for (const payIn of payIns) {
+      try {
+        const returnTxId = await this.sendReturnFromLiquidity(payIn);
+
+        payIn.pendingReturnFromLiquidity(returnTxId);
+        await this.payInRepo.save(payIn);
+
+        this.logger.verbose(`Returned pay-in ${payIn.id} from liquidity, txId: ${returnTxId}`);
+      } catch (e) {
+        this.logger.error(`Failed to return ${this.blockchain} pay-in ${payIn.id} from liquidity:`, e);
+        // Status remains TO_RETURN_FROM_LIQ, retry in next cron iteration
+        continue;
       }
     }
   }

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/evm-coin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/evm-coin.strategy.ts
@@ -1,6 +1,6 @@
 import { Config } from 'src/config/config';
 import { Util } from 'src/shared/utils/util';
-import { PayInStatus } from 'src/subdomains/supporting/payin/entities/crypto-input.entity';
+import { CryptoInput, PayInStatus } from 'src/subdomains/supporting/payin/entities/crypto-input.entity';
 import { PayInRepository } from 'src/subdomains/supporting/payin/repositories/payin.repository';
 import { PayInEvmService } from 'src/subdomains/supporting/payin/services/base/payin-evm.service';
 import { PriceCurrency, PriceValidity } from 'src/subdomains/supporting/pricing/services/pricing.service';
@@ -49,5 +49,9 @@ export abstract class EvmCoinStrategy extends EvmStrategy {
     const amount = type === SendType.FORWARD ? Util.round(groupAmount - estimatedNativeFee * 1.00001, 12) : groupAmount;
 
     return this.payInEvmService.sendNativeCoin(account, destinationAddress, amount);
+  }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInEvmService.sendNativeCoinFromDex(payIn.destinationAddress.address, payIn.chargebackAmount);
   }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/evm.token.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/evm.token.strategy.ts
@@ -129,4 +129,8 @@ export abstract class EvmTokenStrategy extends EvmStrategy {
       this.getTotalGroupAmount(payInGroup, type),
     );
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInEvmService.sendTokenFromDex(payIn.destinationAddress.address, payIn.asset, payIn.chargebackAmount);
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/send.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/send.strategy.ts
@@ -60,6 +60,7 @@ export abstract class SendStrategy implements OnModuleInit, OnModuleDestroy {
   abstract get forwardRequired(): boolean;
 
   abstract doSend(payIns: CryptoInput[], type: SendType): Promise<void>;
+  abstract doSendFromLiquidity(payIns: CryptoInput[], type: SendType): Promise<void>;
   abstract checkConfirmations(payIns: CryptoInput[], direction: PayInConfirmationType): Promise<void>;
 
   protected abstract getForwardAddress(): BlockchainAddress;

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/tron.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/tron.strategy.ts
@@ -20,6 +20,7 @@ export abstract class TronStrategy extends SendStrategy {
   protected abstract checkPreparation(payIn: CryptoInput): Promise<boolean>;
   protected abstract prepareSend(payIn: CryptoInput, estimatedNativeFee: number): Promise<void>;
   protected abstract sendTransfer(payIn: CryptoInput, type: SendType): Promise<string>;
+  protected abstract sendReturnFromLiquidity(payIn: CryptoInput): Promise<string>;
 
   async doSend(payIns: CryptoInput[], type: SendType): Promise<void> {
     for (const payIn of payIns) {
@@ -81,6 +82,27 @@ export abstract class TronStrategy extends SendStrategy {
         }
       } catch (e) {
         this.logger.error(`Failed to check confirmations of ${this.blockchain} input ${payIn.id}:`, e);
+      }
+    }
+  }
+
+  async doSendFromLiquidity(payIns: CryptoInput[], type: SendType): Promise<void> {
+    if (type !== SendType.RETURN) {
+      throw new Error('doSendFromLiquidity only supports RETURN type');
+    }
+
+    for (const payIn of payIns) {
+      try {
+        const returnTxId = await this.sendReturnFromLiquidity(payIn);
+
+        payIn.pendingReturnFromLiquidity(returnTxId);
+        await this.payInRepo.save(payIn);
+
+        this.logger.verbose(`Returned pay-in ${payIn.id} from liquidity, txId: ${returnTxId}`);
+      } catch (e) {
+        this.logger.error(`Failed to return ${this.blockchain} pay-in ${payIn.id} from liquidity:`, e);
+        // Status remains TO_RETURN_FROM_LIQ, retry in next cron iteration
+        continue;
       }
     }
   }

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/zano.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/zano.strategy.ts
@@ -58,4 +58,10 @@ export abstract class ZanoStrategy extends BitcoinBasedStrategy {
   async checkTransactionCompletion(txId: string, minConfirmations: number): Promise<boolean> {
     return this.payInZanoService.checkTransactionCompletion(txId, minConfirmations);
   }
+
+  protected sendReturnFromLiquidity(_payIn: CryptoInput): Promise<string> {
+    // Zano PayIns are never forwarded to liquidity (forwardRequired = false).
+    // This method should never be called.
+    throw new Error('Zano does not support return from liquidity');
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/binance-pay.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/binance-pay.strategy.ts
@@ -39,6 +39,12 @@ export class BinancePayStrategy extends SendStrategy {
     }
   }
 
+  async doSendFromLiquidity(_payIns: CryptoInput[], _type: SendType): Promise<void> {
+    // Binance Pay PayIns are never forwarded to liquidity (forwardRequired = false).
+    // This method should never be called.
+    throw new Error('Binance Pay does not support return from liquidity');
+  }
+
   protected getForwardAddress(): BlockchainAddress {
     throw new Error('Method not implemented.');
   }

--- a/src/subdomains/supporting/payin/strategies/send/impl/bitcoin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/bitcoin.strategy.ts
@@ -4,6 +4,7 @@ import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.e
 import { AssetType } from 'src/shared/models/asset/asset.entity';
 import { BlockchainAddress } from 'src/shared/models/blockchain-address';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
+import { CryptoInput } from '../../../entities/crypto-input.entity';
 import { PayInRepository } from '../../../repositories/payin.repository';
 import { PayInBitcoinService } from '../../../services/payin-bitcoin.service';
 import { BitcoinBasedStrategy } from './base/bitcoin-based.strategy';
@@ -37,5 +38,9 @@ export class BitcoinStrategy extends BitcoinBasedStrategy {
 
   async checkTransactionCompletion(txId: string, minConfirmations: number): Promise<boolean> {
     return this.bitcoinService.checkTransactionCompletion(txId, minConfirmations);
+  }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.bitcoinService.sendFromLiquidity(payIn.destinationAddress.address, payIn.chargebackAmount);
   }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/cardano-coin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/cardano-coin.strategy.ts
@@ -71,4 +71,8 @@ export class CardanoCoinStrategy extends CardanoStrategy {
 
     return Math.min(payIn.sendingAmount, balance) - payIn.forwardFeeAmount;
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInCardanoService.sendNativeCoinFromDex(payIn.destinationAddress.address, payIn.chargebackAmount);
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/cardano-token.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/cardano-token.strategy.ts
@@ -65,4 +65,12 @@ export class CardanoTokenStrategy extends CardanoStrategy {
       payIn.sendingAmount,
     );
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInCardanoService.sendTokenFromDex(
+      payIn.destinationAddress.address,
+      payIn.asset,
+      payIn.chargebackAmount,
+    );
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/kucoin-pay.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/kucoin-pay.strategy.ts
@@ -39,6 +39,12 @@ export class KucoinPayStrategy extends SendStrategy {
     }
   }
 
+  async doSendFromLiquidity(_payIns: CryptoInput[], _type: SendType): Promise<void> {
+    // Kucoin Pay PayIns are never forwarded to liquidity (forwardRequired = false).
+    // This method should never be called.
+    throw new Error('Kucoin Pay does not support return from liquidity');
+  }
+
   protected getForwardAddress(): BlockchainAddress {
     throw new Error('Method not implemented.');
   }

--- a/src/subdomains/supporting/payin/strategies/send/impl/lightning.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/lightning.strategy.ts
@@ -76,6 +76,19 @@ export class LightningStrategy extends SendStrategy {
     }
   }
 
+  async doSendFromLiquidity(payIns: CryptoInput[], type: SendType): Promise<void> {
+    // Lightning PayIns are never forwarded to liquidity (forwardRequired = false).
+    // This method should never be called. If it is, fall back to normal return flow.
+    for (const payIn of payIns) {
+      this.logger.warn(
+        `Lightning pay-in ${payIn.id} marked for return from liquidity - unexpected state. Using normal return flow.`,
+      );
+    }
+
+    // Fall back to normal return
+    await this.doSend(payIns, type);
+  }
+
   protected getForwardAddress(): BlockchainAddress {
     throw new Error('Method not implemented.');
   }

--- a/src/subdomains/supporting/payin/strategies/send/impl/monero.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/monero.strategy.ts
@@ -76,4 +76,10 @@ export class MoneroStrategy extends BitcoinBasedStrategy {
   async checkTransactionCompletion(txId: string, minConfirmations: number): Promise<boolean> {
     return this.moneroService.checkTransactionCompletion(txId, minConfirmations);
   }
+
+  protected sendReturnFromLiquidity(_payIn: CryptoInput): Promise<string> {
+    // Monero PayIns are never forwarded to liquidity (forwardRequired = false).
+    // This method should never be called.
+    throw new Error('Monero does not support return from liquidity');
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/solana-coin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/solana-coin.strategy.ts
@@ -71,4 +71,8 @@ export class SolanaCoinStrategy extends SolanaStrategy {
       Math.min(payIn.sendingAmount, balance - Config.blockchain.solana.createTokenAccountFee) - payIn.forwardFeeAmount
     );
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInSolanaService.sendNativeCoinFromDex(payIn.destinationAddress.address, payIn.chargebackAmount);
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/solana-token.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/solana-token.strategy.ts
@@ -67,4 +67,12 @@ export class SolanaTokenStrategy extends SolanaStrategy {
       payIn.sendingAmount,
     );
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInSolanaService.sendTokenFromDex(
+      payIn.destinationAddress.address,
+      payIn.asset,
+      payIn.chargebackAmount,
+    );
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/tron-coin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/tron-coin.strategy.ts
@@ -71,4 +71,8 @@ export class TronCoinStrategy extends TronStrategy {
 
     return Math.min(payIn.sendingAmount, balance) - payIn.forwardFeeAmount;
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInTronService.sendNativeCoinFromDex(payIn.destinationAddress.address, payIn.chargebackAmount);
+  }
 }

--- a/src/subdomains/supporting/payin/strategies/send/impl/tron-token.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/tron-token.strategy.ts
@@ -59,4 +59,12 @@ export class TronTokenStrategy extends TronStrategy {
 
     return this.payInTronService.sendToken(account, payIn.destinationAddress.address, payIn.asset, payIn.sendingAmount);
   }
+
+  protected sendReturnFromLiquidity(payIn: CryptoInput): Promise<string> {
+    return this.payInTronService.sendTokenFromDex(
+      payIn.destinationAddress.address,
+      payIn.asset,
+      payIn.chargebackAmount,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Enables automatic refunds for BuyFiat transactions when crypto was already forwarded to liquidity
- Adds new `TO_RETURN_FROM_LIQ` and `RETURN_FROM_LIQ_PENDING` PayIn statuses
- Implements `doSendFromLiquidity()` across all blockchain strategies (EVM, Solana, Cardano, Tron, Bitcoin)
- Intelligently chooses return method based on CryptoInput status in `refundBuyFiatInternal()`

## Problem

When a BuyFiat is reset via `resetAmlCheck()` and the new AML check results in "Fail", the automatic refund failed because:
- Funds were already forwarded to the liquidity address (status = FORWARDED/FORWARD_CONFIRMED)
- The existing `returnPayIn()` tried to send from the deposit address where funds no longer exist

## Solution

1. **Validation**: `returnPayIn()` now rejects forwarded PayIns with helpful error
2. **New method**: `returnPayInFromLiquidity()` for already-forwarded PayIns
3. **New cron jobs**: Process `TO_RETURN_FROM_LIQ` queue and check confirmations
4. **Strategy implementations**: Each blockchain strategy implements `doSendFromLiquidity()`:
   - EVM chains: `sendTokenFromDex()` / `sendNativeCoinFromDex()`
   - Solana/Cardano/Tron: Same pattern
   - Bitcoin: `sendFromLiquidity()` via BTC_OUTPUT node
   - Lightning/Monero/Zano: Stub (forwardRequired=false)
5. **Smart routing**: `buy-fiat.service.ts` checks status and calls appropriate method

## Test plan

- [ ] Unit tests pass (746 tests)
- [ ] Create BuyFiat with crypto forwarded to liq
- [ ] Reset AML check, set new check to "Fail"
- [ ] Verify automatic refund triggers return from liquidity
- [ ] Verify transaction completes on-chain