### PR TITLE
feat(bitcoin): accept unconfirmed withdrawals for faster buy payouts

### DIFF
--- a/src/subdomains/supporting/dex/services/dex-bitcoin.service.ts
+++ b/src/subdomains/supporting/dex/services/dex-bitcoin.service.ts
@@ -34,7 +34,7 @@ export class DexBitcoinService {
   async checkTransferCompletion(transferTxId: string): Promise<boolean> {
     const transaction = await this.client.getTx(transferTxId);
 
-    return transaction && transaction.blockhash && transaction.confirmations > 0;
+    return transaction != null;
   }
 
   async getRecentHistory(txCount: number): Promise<TransactionHistory[]> {


### PR DESCRIPTION
## Summary
- Remove 1-confirmation requirement from `checkTransferCompletion()` for Bitcoin
- Exchange withdrawals (e.g., Binance) now complete as soon as TX is in mempool
- Buy payouts can be created immediately, potentially in the same block

## Why this works
All prerequisites are already in place:
- `getBalance()` includes `untrusted_pending` (unconfirmed external UTXOs)
- `sendMany()` uses `include_unsafe: true` for coin selection
- CPFP fee multiplier is active when spending unconfirmed UTXOs

## Expected improvement
~10-15 minutes faster buy payouts after exchange withdrawals.

Before: Withdrawal → wait for block → Pipeline Complete → next block → Payout
After: Withdrawal → Pipeline Complete → same block → Payout (CPFP effect)

## Test plan
- [ ] Monitor next Binance→Bitcoin withdrawal
- [ ] Verify `liquidity_management_order` completes immediately (before block confirmation)
- [ ] Verify buy payouts occur in same block as withdrawal on mempool.space