### PR TITLE
fix: remove incorrect VIDEO_IDENT_REQUIRED check for organizations

### DIFF
--- a/src/subdomains/supporting/payment/dto/transaction-helper/quote-error.enum.ts
+++ b/src/subdomains/supporting/payment/dto/transaction-helper/quote-error.enum.ts
@@ -9,7 +9,6 @@ export enum QuoteError {
   LIMIT_EXCEEDED = 'LimitExceeded',
   NATIONALITY_NOT_ALLOWED = 'NationalityNotAllowed',
   NAME_REQUIRED = 'NameRequired',
-  VIDEO_IDENT_REQUIRED = 'VideoIdentRequired',
   IBAN_CURRENCY_MISMATCH = 'IbanCurrencyMismatch',
   RECOMMENDATION_REQUIRED = 'RecommendationRequired',
   EMAIL_REQUIRED = 'EmailRequired',

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -25,8 +25,6 @@ import { BuyService } from 'src/subdomains/core/buy-crypto/routes/buy/buy.servic
 import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
 import { BuyFiat } from 'src/subdomains/core/sell-crypto/process/buy-fiat.entity';
 import { BuyFiatService } from 'src/subdomains/core/sell-crypto/process/services/buy-fiat.service';
-import { AccountType } from 'src/subdomains/generic/user/models/user-data/account-type.enum';
-import { KycIdentificationType } from 'src/subdomains/generic/user/models/user-data/kyc-identification-type.enum';
 import { UserData } from 'src/subdomains/generic/user/models/user-data/user-data.entity';
 import { KycLevel, UserDataStatus } from 'src/subdomains/generic/user/models/user-data/user-data.enum';
 import { User } from 'src/subdomains/generic/user/models/user/user.entity';
@@ -927,13 +925,6 @@ export class TransactionHelper implements OnModuleInit {
       !user.userData.verifiedName
     )
       return QuoteError.NAME_REQUIRED;
-
-    if (
-      txAmountChf > Config.tradingLimits.monthlyDefaultWoKyc &&
-      user?.userData?.accountType === AccountType.ORGANIZATION &&
-      user?.userData?.identificationType === KycIdentificationType.ONLINE_ID
-    )
-      return QuoteError.VIDEO_IDENT_REQUIRED;
 
     if (
       ((isSell && to.name !== 'CHF') || paymentMethodIn === FiatPaymentMethod.CARD || isSwap) &&


### PR DESCRIPTION
## Summary
Remove the Organization-specific VIDEO_IDENT_REQUIRED rule that was incorrectly blocking Organizations with OnlineId even when they had valid BankTxVerification.

## Problem
userData 244115 (Organization, OnlineId, bankTransactionVerification=Pass) was blocked from trading with error `VideoIdentRequired`, despite having valid bank transaction verification.

The faulty rule:
```typescript
if (
  txAmountChf > 1000 &&
  accountType === ORGANIZATION &&
  identificationType === ONLINE_ID
)
  return VIDEO_IDENT_REQUIRED;  // ← Ignores BankTxVerification!
```

## Solution
Remove the Organization-specific VIDEO_IDENT_REQUIRED check entirely. The existing `BANK_TRANSACTION_OR_VIDEO_MISSING` rule already handles all cases correctly:

| Case | Condition | Error |
|------|-----------|-------|
| Sell (not CHF) > 1000 CHF | !hasBankTxVerification | BANK_TX_OR_VIDEO_MISSING |
| Card payment > 1000 CHF | !hasBankTxVerification | BANK_TX_OR_VIDEO_MISSING |
| Swap > 1000 CHF | !hasBankTxVerification | BANK_TX_OR_VIDEO_MISSING |
| Sell to CHF > 1000 CHF | - | Allowed |

## Changes
- Remove `VIDEO_IDENT_REQUIRED` from QuoteError enum
- Remove Organization-specific VIDEO_IDENT_REQUIRED check from transaction-helper.ts
- Remove unused `KycIdentificationType` import

## Test plan
- [ ] userData 244115 (Organization, OnlineId, BankTxVerification=Pass) can now trade
- [ ] User without BankTxVerification trying to sell > 1000 CHF (not CHF) → BANK_TX_OR_VIDEO_MISSING
- [ ] User without BankTxVerification trying to sell > 1000 CHF to CHF → Allowed
- [ ] User with BankTxVerification trying to sell > 1000 CHF → Allowed