### PR TITLE
feat: add Special ZCHF 0.5% fee for userData 363001

### DIFF
--- a/migration/1767886374776-AddSpecialZchfFeeUserData363001.js
+++ b/migration/1767886374776-AddSpecialZchfFeeUserData363001.js
@@ -4,14 +4,14 @@ module.exports = class AddSpecialZchfFeeUserData3630011767886374776 {
     name = 'AddSpecialZchfFeeUserData3630011767886374776'
 
     async up(queryRunner) {
-        // 1. Create Special ZCHF 0.5% fee
+        // 1. Create Special ZCHF 0.5% fee (consistent with Fee 67, 111)
         await queryRunner.query(`
             INSERT INTO "dbo"."fee" (
                 "label", "type", "rate", "fixed", "assets", "active",
-                "blockchainFactor", "payoutRefBonus", "usages", "txUsages"
+                "blockchainFactor", "payoutRefBonus", "usages", "txUsages", "financialTypes"
             ) VALUES (
-                'Special ZCHF 0.5%', 'Special', 0.005, 0, '251;253;255;256;258;259', 1,
-                1, 1, 0, 0
+                'Special ZCHF 0.5% UserData 363001', 'Special', 0.005, 0, '251;253;255;256;258;259', 1,
+                0, 1, 0, 0, 'CHF'
             )
         `);
 
@@ -20,26 +20,30 @@ module.exports = class AddSpecialZchfFeeUserData3630011767886374776 {
             UPDATE "dbo"."user_data"
             SET "individualFees" = CASE
                 WHEN "individualFees" IS NULL OR "individualFees" = ''
-                    THEN CAST((SELECT MAX(id) FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5%') AS VARCHAR)
-                ELSE "individualFees" + ';' + CAST((SELECT MAX(id) FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5%') AS VARCHAR)
+                    THEN CAST((SELECT id FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5% UserData 363001') AS VARCHAR)
+                ELSE "individualFees" + ';' + CAST((SELECT id FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5% UserData 363001') AS VARCHAR)
             END
             WHERE "id" = 363001
         `);
     }
 
     async down(queryRunner) {
-        // 1. Remove fee from userData 363001
-        const feeIdResult = await queryRunner.query(`SELECT id FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5%'`);
-        if (feeIdResult.length > 0) {
-            const feeId = feeIdResult[0].id;
+        // 1. Get the fee ID
+        const feeIdResult = await queryRunner.query(`
+            SELECT id FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5% UserData 363001'
+        `);
 
-            // Remove fee ID from individualFees (handles both single and multiple fee scenarios)
+        if (feeIdResult.length > 0) {
+            const feeId = feeIdResult[0].id.toString();
+
+            // 2. Remove fee ID from userData 363001 individualFees
+            // Handle all cases: only fee, first fee, last fee, middle fee
             await queryRunner.query(`
                 UPDATE "dbo"."user_data"
                 SET "individualFees" = CASE
                     WHEN "individualFees" = '${feeId}' THEN NULL
-                    WHEN "individualFees" LIKE '${feeId};%' THEN SUBSTRING("individualFees", ${String(feeId).length + 2}, LEN("individualFees"))
-                    WHEN "individualFees" LIKE '%;${feeId}' THEN SUBSTRING("individualFees", 1, LEN("individualFees") - ${String(feeId).length + 1})
+                    WHEN "individualFees" LIKE '${feeId};%' THEN STUFF("individualFees", 1, LEN('${feeId};'), '')
+                    WHEN "individualFees" LIKE '%;${feeId}' THEN LEFT("individualFees", LEN("individualFees") - LEN(';${feeId}'))
                     WHEN "individualFees" LIKE '%;${feeId};%' THEN REPLACE("individualFees", ';${feeId};', ';')
                     ELSE "individualFees"
                 END
@@ -47,7 +51,9 @@ module.exports = class AddSpecialZchfFeeUserData3630011767886374776 {
             `);
         }
 
-        // 2. Delete the fee
-        await queryRunner.query(`DELETE FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5%'`);
+        // 3. Delete the fee
+        await queryRunner.query(`
+            DELETE FROM "dbo"."fee" WHERE "label" = 'Special ZCHF 0.5% UserData 363001'
+        `);
     }
 }


### PR DESCRIPTION
## Summary
- Add migration to create `Special ZCHF 0.5%` fee for userData 363001
- Fee applies to all ZCHF chains (Ethereum, Polygon, Arbitrum, Optimism, BSC, Base)
- Reduces fee from standard Organization rate (1.99%-2.49%) to 0.5% for all ZCHF transactions

## Details
| Field | Value |
|-------|-------|
| UserData ID | 363001 |
| Fee Type | Special |
| Fee Rate | 0.5% |
| Assets | ZCHF (251, 253, 255, 256, 258, 259) |
| Applies to | Buy, Sell, Swap |

## Migration
- **up()**: Creates fee + assigns to userData via `individualFees`
- **down()**: Removes fee from userData + deletes fee

## Test plan
- [ ] Run migration on dev/test environment
- [ ] Verify fee exists: `SELECT * FROM fee WHERE label = 'Special ZCHF 0.5%'`
- [ ] Verify userData assignment: `SELECT individualFees FROM user_data WHERE id = 363001`
- [ ] Test ZCHF transaction shows 0.5% fee for user