### PR TITLE
fix: prettier formatting in fiat-output-job.service.spec.ts

### DIFF
--- a/src/subdomains/supporting/fiat-output/__tests__/fiat-output-job.service.spec.ts
+++ b/src/subdomains/supporting/fiat-output/__tests__/fiat-output-job.service.spec.ts
@@ -117,9 +117,7 @@ describe('FiatOutputJobService', () => {
         }),
       ]);
 
-      jest
-        .spyOn(countryService, 'getCountryWithSymbol')
-        .mockResolvedValue(createCustomCountry({ yapealEnable: true }));
+      jest.spyOn(countryService, 'getCountryWithSymbol').mockResolvedValue(createCustomCountry({ yapealEnable: true }));
 
       jest.spyOn(bankService, 'getSenderBank').mockResolvedValue(yapealEUR);
 
@@ -145,9 +143,7 @@ describe('FiatOutputJobService', () => {
         }),
       ]);
 
-      jest
-        .spyOn(countryService, 'getCountryWithSymbol')
-        .mockResolvedValue(createCustomCountry({ yapealEnable: true }));
+      jest.spyOn(countryService, 'getCountryWithSymbol').mockResolvedValue(createCustomCountry({ yapealEnable: true }));
 
       // Mock virtual IBAN for user
       jest
@@ -173,9 +169,7 @@ describe('FiatOutputJobService', () => {
         }),
       ]);
 
-      jest
-        .spyOn(countryService, 'getCountryWithSymbol')
-        .mockResolvedValue(createCustomCountry({ yapealEnable: true }));
+      jest.spyOn(countryService, 'getCountryWithSymbol').mockResolvedValue(createCustomCountry({ yapealEnable: true }));
 
       // Mock virtual IBAN for user
       jest


### PR DESCRIPTION
## Summary
- Fix prettier formatting issues in fiat-output-job.service.spec.ts

## Test plan
- [x] `npm run format:check` passes