### PR TITLE
fix: restore MAERKI_BAUMANN mapping in blockchainToBankName

### DIFF
--- a/src/subdomains/supporting/bank/bank/bank.service.ts
+++ b/src/subdomains/supporting/bank/bank/bank.service.ts
@@ -107,6 +107,8 @@ export class BankService implements OnModuleInit {
 
   private static blockchainToBankName(blockchain: Blockchain): IbanBankName | undefined {
     switch (blockchain) {
+      case Blockchain.MAERKI_BAUMANN:
+        return IbanBankName.MAERKI;
       case Blockchain.OLKYPAY:
         return IbanBankName.OLKY;
       case Blockchain.YAPEAL:


### PR DESCRIPTION
## Summary
- Restore the `MAERKI_BAUMANN` case in `blockchainToBankName()` that was accidentally removed in PR #2747
- This fixes the FinancialDataLog balance calculation being ~208k CHF too high

## Problem
PR #2747 removed the Maerki Baumann integration but also removed the `blockchainToBankName` mapping. This caused `isBankMatching()` to always return `false` for Maerki Baumann assets.

As a result, pending transactions (bankTxPending, bankTxRepeat, bankTxReturn, buyCrypto) for Maerki Baumann assets were no longer counted in `minusBalance`, inflating the reported total balance by ~208k CHF.

**Before fix (wrong):** totalBalanceChf = ~316k CHF
**After fix (correct):** totalBalanceChf = ~108k CHF

## Root Cause Analysis
- Logs before 10:14 UTC showed correct balance with MB-EUR=137,942 and MB-CHF=80,102 in minusBalance
- Logs after 10:14 UTC showed inflated balance with MB-EUR=0 and MB-CHF=0
- The deploy of PR #2747 happened at ~10:14 UTC

## Test plan
- [ ] Verify FinancialDataLog shows correct totalBalanceChf (~108k instead of ~316k)
- [ ] Verify Maerki Baumann pending transactions appear in minusBalance again