### PR TITLE
chore: remove footer text from PR Review Bot

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -233,7 +233,14 @@ jobs:
             });
 
             const botComment = existingComments.data.find(c =>
-              c.user?.login === 'github-actions[bot]' && (c.body?.includes('Unverified Commits') || c.body?.includes('ESLint:') || c.body?.includes('Security:'))
+              c.user?.login === 'github-actions[bot]' && (
+                c.body?.includes('Unverified Commits') ||
+                c.body?.includes('Non-Conventional Commits') ||
+                c.body?.includes('ESLint:') ||
+                c.body?.includes('TypeScript:') ||
+                c.body?.includes('Security:') ||
+                c.body?.includes('TODOs/FIXMEs')
+              )
             );
 
             if (botComment) {


### PR DESCRIPTION
## Summary
- Remove header and footer from PR Review Bot comments
- Comments now show only the relevant warnings without decoration
- Fix bot comment detection to recognize all 6 comment types