### PR TITLE
fix: load wallet relation for autoTradeApproval check in mail login

### DIFF
--- a/src/subdomains/generic/user/models/auth/auth.service.ts
+++ b/src/subdomains/generic/user/models/auth/auth.service.ts
@@ -299,7 +299,7 @@ export class AuthService {
       const entry = this.mailKeyList.get(code);
       if (!this.isMailKeyValid(entry)) throw new Error('Login link expired');
 
-      const account = await this.userDataService.getUserData(entry.userDataId, { users: true });
+      const account = await this.userDataService.getUserData(entry.userDataId, { users: true, wallet: true });
 
       const ipLog = await this.ipLogService.create(ip, entry.loginUrl, entry.mail, undefined, account);
       if (!ipLog.result) throw new Error('The country of IP address is not allowed');
@@ -311,7 +311,7 @@ export class AuthService {
       if (account.isDeactivated)
         await this.userDataService.updateUserDataInternal(account, account.reactivateUserData());
 
-      if (!account.tradeApprovalDate) await this.checkPendingRecommendation(account);
+      if (!account.tradeApprovalDate) await this.checkPendingRecommendation(account, account.wallet);
 
       const url = new URL(entry.redirectUri ?? `${Config.frontend.services}/account`);
       url.searchParams.set('session', token);


### PR DESCRIPTION
## Summary

Fix bug where `autoTradeApproval` check fails for mail-login users because the `wallet` relation is not loaded.

### Problem

In `completeSignInByMail()`, the wallet relation was not loaded:

```typescript
// Before (broken):
const account = await this.userDataService.getUserData(entry.userDataId, { users: true });
// ...
if (!account.tradeApprovalDate) await this.checkPendingRecommendation(account);
```

This caused `checkPendingRecommendation()` to fail the `autoTradeApproval` check:

```typescript
if (userData.wallet?.autoTradeApproval || userWallet?.autoTradeApproval)
  // userData.wallet is undefined, userWallet is undefined
  // → condition always false!
```

### Fix

```typescript
// After (fixed):
const account = await this.userDataService.getUserData(entry.userDataId, { users: true, wallet: true });
// ...
if (!account.tradeApprovalDate) await this.checkPendingRecommendation(account, account.wallet);
```

This aligns mail-login with wallet-login behavior where the wallet is properly passed.

### Impact

- **Affected users in production:** 1 (ID: 242230, CakeWallet)
- **Reason for low impact:** Default wallet (DFX Wallet) has `autoTradeApproval = false`
- Users with wallets that have `autoTradeApproval = true` (e.g., CakeWallet, OnRamper) will now get `tradeApprovalDate` set automatically on mail-login

### Related

Discovered during review of PR #2903

## Test plan

- [ ] Mail-login with wallet that has `autoTradeApproval = true` → `tradeApprovalDate` should be set
- [ ] Mail-login with default wallet → behavior unchanged (still needs recommendation)