### PR TITLE
fix: handle null IBAN in country code extraction

### DIFF
--- a/src/subdomains/core/aml/services/aml.service.ts
+++ b/src/subdomains/core/aml/services/aml.service.ts
@@ -220,9 +220,10 @@ export class AmlService {
     if (entity instanceof BuyFiat) return this.countryService.getCountryWithSymbol(entity.sell.iban.substring(0, 2));
     if (entity.cryptoInput) return undefined;
 
-    return this.countryService.getCountryWithSymbol(
-      entity.checkoutTx?.cardIssuerCountry ?? entity.bankTx.iban.substring(0, 2),
-    );
+    const countryCode = entity.checkoutTx?.cardIssuerCountry ?? entity.bankTx?.iban?.substring(0, 2);
+    if (!countryCode) return undefined;
+
+    return this.countryService.getCountryWithSymbol(countryCode);
   }
 
   private async getBankData(entity: BuyFiat | BuyCrypto): Promise<BankData | undefined> {

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-preparation.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-preparation.service.ts
@@ -153,12 +153,10 @@ export class BuyCryptoPreparationService {
           referenceChfPrice,
         );
 
-        const ibanCountry =
-          entity.bankTx?.iban || entity.checkoutTx?.cardIssuerCountry
-            ? await this.countryService.getCountryWithSymbol(
-                entity.bankTx?.iban.substring(0, 2) ?? entity.checkoutTx.cardIssuerCountry,
-              )
-            : undefined;
+        const ibanCountryCode = entity.bankTx?.iban?.substring(0, 2) ?? entity.checkoutTx?.cardIssuerCountry;
+        const ibanCountry = ibanCountryCode
+          ? await this.countryService.getCountryWithSymbol(ibanCountryCode)
+          : undefined;
 
         const virtualIban = entity.bankTx?.virtualIban
           ? await this.virtualIbanService.getByIban(entity.bankTx.virtualIban)


### PR DESCRIPTION
## Summary
- Fix TypeError when `bankTx.iban` is null (e.g., AUTT automated transactions)
- `aml.service.ts`: Add null check before calling `substring()` on iban
- `buy-crypto-preparation.service.ts`: Use optional chaining for iban access

## Root Cause
Buy_crypto 110304 was permanently stuck because:
1. BankTx has `subFamilyCode = 'AUTT'` (automated transaction) with `iban = NULL`
2. User is new (no `verifiedCountry` set yet)
3. `getVerifiedCountry()` tried to call `null.substring(0, 2)` → TypeError
4. Exception caught but transaction skipped, causing permanent stuck state

## Test Plan
- [ ] Verify build passes
- [ ] Test with AUTT transactions (null IBAN)
- [ ] Manual fix for stuck transaction 110304 (reset amlCheck to trigger reprocessing)