### PR TITLE
fix(bank-data): transform empty string names to null in DTOs

### DIFF
--- a/src/subdomains/generic/user/models/bank-data/dto/__tests__/bank-data-dto.spec.ts
+++ b/src/subdomains/generic/user/models/bank-data/dto/__tests__/bank-data-dto.spec.ts
@@ -1,0 +1,73 @@
+import { plainToInstance } from 'class-transformer';
+import { CreateBankDataDto } from '../create-bank-data.dto';
+import { UpdateBankDataDto } from '../update-bank-data.dto';
+
+describe('BankDataDto', () => {
+  describe('CreateBankDataDto', () => {
+    describe('name transform', () => {
+      it('should keep valid name unchanged', () => {
+        const dto = plainToInstance(CreateBankDataDto, { iban: 'CH123', name: 'Max Mustermann' });
+        expect(dto.name).toBe('Max Mustermann');
+      });
+
+      it('should trim whitespace from name', () => {
+        const dto = plainToInstance(CreateBankDataDto, { iban: 'CH123', name: '  Max Mustermann  ' });
+        expect(dto.name).toBe('Max Mustermann');
+      });
+
+      it('should transform empty string to null', () => {
+        const dto = plainToInstance(CreateBankDataDto, { iban: 'CH123', name: '' });
+        expect(dto.name).toBeUndefined();
+      });
+
+      it('should transform whitespace-only string to null', () => {
+        const dto = plainToInstance(CreateBankDataDto, { iban: 'CH123', name: '   ' });
+        expect(dto.name).toBeUndefined();
+      });
+
+      it('should transform undefined to null', () => {
+        const dto = plainToInstance(CreateBankDataDto, { iban: 'CH123', name: undefined });
+        expect(dto.name).toBeUndefined();
+      });
+
+      it('should transform null to null', () => {
+        const dto = plainToInstance(CreateBankDataDto, { iban: 'CH123', name: null });
+        expect(dto.name).toBeUndefined();
+      });
+    });
+  });
+
+  describe('UpdateBankDataDto', () => {
+    describe('name transform', () => {
+      it('should keep valid name unchanged', () => {
+        const dto = plainToInstance(UpdateBankDataDto, { name: 'Max Mustermann' });
+        expect(dto.name).toBe('Max Mustermann');
+      });
+
+      it('should trim whitespace from name', () => {
+        const dto = plainToInstance(UpdateBankDataDto, { name: '  Max Mustermann  ' });
+        expect(dto.name).toBe('Max Mustermann');
+      });
+
+      it('should transform empty string to null', () => {
+        const dto = plainToInstance(UpdateBankDataDto, { name: '' });
+        expect(dto.name).toBeUndefined();
+      });
+
+      it('should transform whitespace-only string to null', () => {
+        const dto = plainToInstance(UpdateBankDataDto, { name: '   ' });
+        expect(dto.name).toBeUndefined();
+      });
+
+      it('should transform undefined to null', () => {
+        const dto = plainToInstance(UpdateBankDataDto, { name: undefined });
+        expect(dto.name).toBeUndefined();
+      });
+
+      it('should transform null to null', () => {
+        const dto = plainToInstance(UpdateBankDataDto, { name: null });
+        expect(dto.name).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/subdomains/generic/user/models/bank-data/dto/create-bank-data.dto.ts
+++ b/src/subdomains/generic/user/models/bank-data/dto/create-bank-data.dto.ts
@@ -17,6 +17,7 @@ export class CreateBankDataDto {
 
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim() || undefined)
   name?: string;
 
   @IsOptional()

--- a/src/subdomains/generic/user/models/bank-data/dto/update-bank-data.dto.ts
+++ b/src/subdomains/generic/user/models/bank-data/dto/update-bank-data.dto.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer';
 import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 import { ReviewStatus } from 'src/subdomains/generic/kyc/enums/review-status.enum';
 import { UpdateBankAccountDto } from 'src/subdomains/supporting/bank/bank-account/dto/update-bank-account.dto';
@@ -6,6 +7,7 @@ import { BankDataType } from '../bank-data.entity';
 export class UpdateBankDataDto extends UpdateBankAccountDto {
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim() || undefined)
   name?: string;
 
   @IsOptional()


### PR DESCRIPTION
## Summary

- Add `@Transform` decorator to `name` field in `CreateBankDataDto` and `UpdateBankDataDto`
- Empty strings and whitespace-only strings are now converted to `undefined`
- Prevents empty strings from bypassing nullish coalescing (`??`) fallback logic in AML checks

## Problem

The nullish coalescing operator (`??`) treats empty strings as "present" values. When `bankData.name` is an empty string, the fallback to `userData.completeName` is skipped:

```typescript
// Given: verifiedName = undefined, bankData.name = "", completeName = "Max Mustermann"
const name = verifiedName ?? bankData.name ?? completeName;
// Result: "" (empty string) instead of "Max Mustermann"
```

## Solution

Transform empty strings to `undefined` at the DTO level (consistent with existing `Util.trim` pattern):

```typescript
@Transform(({ value }) => value?.trim() || undefined)
name?: string;
```

## Test plan

- [x] Added unit tests for the transform behavior (12 test cases)
- [x] All existing tests pass
- [x] Build successful
- [x] ESLint/TypeScript checks pass

Closes #2911