### PR TITLE
Update XT/DEURO liquidity minimum to 10000

### DIFF
--- a/migration/1768315830503-UpdateXtDeuroLiquidityMinimum.js
+++ b/migration/1768315830503-UpdateXtDeuroLiquidityMinimum.js
@@ -1,0 +1,36 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class UpdateXtDeuroLiquidityMinimum1768315830503 {
+    name = 'UpdateXtDeuroLiquidityMinimum1768315830503'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        // Update XT/DEURO liquidity rule minimum from 4300 to 10000
+        await queryRunner.query(`
+            UPDATE "dbo"."liquidity_management_rule"
+            SET "minimal" = 10000
+            WHERE "id" = 295
+        `);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        // Revert XT/DEURO liquidity rule minimum back to 4300
+        await queryRunner.query(`
+            UPDATE "dbo"."liquidity_management_rule"
+            SET "minimal" = 4300
+            WHERE "id" = 295
+        `);
+    }
+}


### PR DESCRIPTION
## Summary
- Updates the XT/DEURO liquidity management rule minimum threshold from 4300 to 10000

## Changes
- Migration script to update `liquidity_management_rule` table (id=295)
- Previous minimum: 4300
- New minimum: 10000

## Test plan
- [ ] Verify migration runs successfully on dev environment
- [ ] Confirm liquidity rule reflects new minimum value