### PR TITLE
fix: round amount to asset decimals in bridgeToDeuro

### DIFF
--- a/src/integration/blockchain/deuro/deuro-client.ts
+++ b/src/integration/blockchain/deuro/deuro-client.ts
@@ -9,6 +9,7 @@ import {
 } from '@deuro/eurocoin';
 import { Contract, ethers } from 'ethers';
 import { gql, request } from 'graphql-request';
+import { EvmUtil } from '../shared/evm/evm.util';
 import { Config } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { EvmClient } from '../shared/evm/evm-client';
@@ -209,7 +210,7 @@ export class DEuroClient {
     if (!asset.decimals) throw new Error(`Asset ${asset.name} has no decimals`);
     if (!asset.chainId) throw new Error(`Asset ${asset.name} has no chainId`);
 
-    const weiAmount = ethers.utils.parseUnits(amount.toString(), asset.decimals);
+    const weiAmount = EvmUtil.toWeiAmount(amount, asset.decimals);
 
     const remainingCapacity = await this.getBridgeRemainingCapacity(asset.name);
     if (remainingCapacity.lt(weiAmount)) {


### PR DESCRIPTION
## Summary
- Fix NUMERIC_FAULT underflow error in dEURO bridge operations
- EURC has only 6 decimal places, but liquidity balance amounts can have more (e.g. 12)
- Use `EvmUtil.toWeiAmount()` which correctly rounds to asset decimals before `parseUnits`

## Root Cause
```typescript
// Before: crashes when amount has more decimals than asset.decimals
const weiAmount = ethers.utils.parseUnits(amount.toString(), asset.decimals);

// After: rounds correctly before parsing
const weiAmount = EvmUtil.toWeiAmount(amount, asset.decimals);
```

## Error that was occurring
```
fractional component exceeds decimals (fault="underflow", operation="parseFixed", code=NUMERIC_FAULT)
```

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Test dEURO bridge-in liquidity management order