### PR TITLE
fix: exclude pending deposits from Kraken balance calculation

### DIFF
--- a/src/subdomains/supporting/log/log-job.service.ts
+++ b/src/subdomains/supporting/log/log-job.service.ts
@@ -330,6 +330,7 @@ export class LogJobService {
     const chfReceiverExchangeTx = recentKrakenExchangeTx.filter(
       (k) =>
         k.type === ExchangeTxType.DEPOSIT &&
+        k.status !== 'pending' &&
         k.method === 'Bank Frick (SIC) International' &&
         k.address === yapealChfBank.bic.padEnd(11, 'XXX'),
     );
@@ -341,6 +342,7 @@ export class LogJobService {
     const eurReceiverExchangeTx = recentKrakenExchangeTx.filter(
       (k) =>
         k.type === ExchangeTxType.DEPOSIT &&
+        k.status !== 'pending' &&
         k.method === 'Bank Frick (SEPA) International' &&
         k.address === yapealEurBank.bic.padEnd(11, 'XXX'),
     );


### PR DESCRIPTION
## Summary
- Kraken deposits with `status='pending'` (On Hold) were incorrectly counted as "arrived" in the toKraken pending balance calculation
- This caused the total CHF balance to show ~117k CHF less than actual (~274k CHF total discrepancy with other issues)
- Add `status !== 'pending'` filter to both CHF and EUR receiver exchange_tx filters

## Root Cause
The `chfReceiverExchangeTx` and `eurReceiverExchangeTx` filters in `getFinancialDataLog()` only checked for:
- `type === ExchangeTxType.DEPOSIT`
- `method` (Bank Frick SIC/SEPA)
- `address` (BIC)

They did NOT check the `status` field. Deposits with `status='pending'` are "On Hold" at Kraken and have not been credited yet.

## Affected Deposits (as of today)
- exchange_tx 115628: 50k CHF, status='pending'
- exchange_tx 115629: 30k CHF, status='pending'
- exchange_tx 115630: 40k EUR (~37k CHF), status='pending'

Total: ~117k CHF incorrectly subtracted from pending-to-Kraken amount.

## Test plan
- [x] Lint passes
- [x] Prettier passes
- [x] Build passes
- [ ] Monitor FinancialDataLog after deployment - toKraken pending should increase by ~117k CHF