### PR TITLE
fix: add MEXC and XT to LiquidityManagementExchanges list

### DIFF
--- a/src/subdomains/core/liquidity-management/enums/index.ts
+++ b/src/subdomains/core/liquidity-management/enums/index.ts
@@ -53,6 +53,8 @@ export enum LiquidityOptimizationType {
 export const LiquidityManagementExchanges = [
   LiquidityManagementSystem.KRAKEN,
   LiquidityManagementSystem.BINANCE,
+  LiquidityManagementSystem.MEXC,
+  LiquidityManagementSystem.XT,
   LiquidityManagementSystem.SCRYPT,
   LiquidityManagementSystem.FRANKENCOIN,
   LiquidityManagementSystem.DEURO,


### PR DESCRIPTION
## Summary
- Add `MEXC` and `XT` to `LiquidityManagementExchanges` array
- Both systems had full adapter implementations but were missing from the exchanges list

## Problem
When funds are transferred between exchanges (e.g., Binance → MEXC), the `pendingExchangeOrders` filter in `log-job.service.ts` checks against `LiquidityManagementExchanges`. Since MEXC was not in this list, transfers to MEXC were not recognized as pending, causing temporary balance dips in FinancialDataLog until the destination exchange balance was synchronized.

## Root Cause Analysis
Found via FinancialDataLog analysis:
- Binance/USDT dropped from 103,871 → 42,486 (withdrawals to MEXC)
- MEXC/USDT showed 10,000 → 60,000 with ~50s delay
- During the delay, USD total balance showed a 50k dip (marked as `valid=false`)

## Test plan
- [ ] Verify MEXC and XT transfers are now included in `pendingExchangeOrders`
- [ ] Monitor FinancialDataLog for similar balance dips after deployment