### PR TITLE
fix: add MEXC and XT to LiquidityManagementExchanges list

### DIFF
--- a/src/subdomains/core/liquidity-management/enums/index.ts
+++ b/src/subdomains/core/liquidity-management/enums/index.ts
@@ -53,6 +53,8 @@ export enum LiquidityOptimizationType {
 export const LiquidityManagementExchanges = [
   LiquidityManagementSystem.KRAKEN,
   LiquidityManagementSystem.BINANCE,
+  LiquidityManagementSystem.MEXC,
+  LiquidityManagementSystem.XT,
   LiquidityManagementSystem.SCRYPT,
   LiquidityManagementSystem.FRANKENCOIN,
   LiquidityManagementSystem.DEURO,


### PR DESCRIPTION
MEXC and XT were defined as LiquidityManagementSystem enums with full adapter implementations, but were missing from the LiquidityManagementExchanges array.

This caused pendingExchangeOrders to not include MEXC/XT transfers, leading to temporary balance dips in FinancialDataLog when funds were transferred between exchanges (e.g., Binance → MEXC).

### Release Checklist

#### Pre-Release

- [ ] Check migrations
  - No database related infos (sqldb-xxx)
  - Impact on GS (new/removed columns)
- [ ] Check for linter errors (in PR)
- [ ] Test basic user operations (on [DFX services](https://dev.app.dfx.swiss))
  - Login/logout
  - Buy/sell payment request
  - KYC page

#### Post-Release

- Test basic user operations
- Monitor application insights log
