### PR TITLE
fix: skip input mail for Bitcoin purchases with txId

### DIFF
--- a/src/subdomains/supporting/payment/services/transaction-notification.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction-notification.service.ts
@@ -60,10 +60,7 @@ export class TransactionNotificationService {
           continue;
 
         // Skip input mail for Bitcoin purchases that already have txId (will receive BuyCryptoCompleted mail directly)
-        if (
-          entity.buyCrypto?.txId &&
-          entity.buyCrypto?.buy?.asset?.uniqueName === 'Bitcoin/BTC'
-        ) {
+        if (entity.buyCrypto?.txId && entity.buyCrypto?.buy?.asset?.uniqueName === 'Bitcoin/BTC') {
           await this.repo.update(...entity.mailSent());
           continue;
         }


### PR DESCRIPTION
## Summary
- Skip the "Einzahlung eingetroffen" (input received) mail for Bitcoin purchases when `txId` is already set
- User will only receive the "BuyCryptoCompleted" mail directly

## Motivation
For fast Bitcoin transactions where the payout is already executed by the time the mail cronjob runs, users were receiving two mails in quick succession:
1. "Einzahlung eingetroffen" (input received)
2. "Krypto-Asset verschickt" (crypto sent)

This change skips the first mail when `buyCrypto.txId` is set and the asset is `Bitcoin/BTC`.

## Changes
- Load `buy.asset` relation in `txAssigned()` query
- Add condition to skip input mail when `txId` is set and asset is Bitcoin/BTC
- Still mark `mailSendDate` to prevent re-processing

## Test plan
- [ ] Verify Bitcoin purchase with fast payout only receives BuyCryptoCompleted mail
- [ ] Verify non-Bitcoin purchases still receive both mails
- [ ] Verify Bitcoin purchases without txId still receive input mail