### PR TITLE
feat: activate Scrypt/USDT liquidity rule

### DIFF
--- a/migration/1768479555000-ActivateScryptUsdtLiquidityRule.js
+++ b/migration/1768479555000-ActivateScryptUsdtLiquidityRule.js
@@ -20,15 +20,15 @@ module.exports = class ActivateScryptUsdtLiquidityRule1768479555000 {
         const actionId = result[0].actionId;
 
         // Update Scrypt/USDT rule (ID 315) with thresholds and activate it
-        // - optimal: 25,000 USDT (target balance)
+        // - optimal: 100 USDT (target balance after withdrawal)
         // - maximal: 50,000 USDT (trigger withdrawal when exceeded)
         await queryRunner.query(`
             UPDATE liquidity_management_rule
-            SET optimal = 25000,
+            SET optimal = 100,
                 maximal = 50000,
                 redundancyStartActionId = ${actionId},
                 status = 'Active',
-                reactivationTime = 60
+                reactivationTime = 5
             WHERE id = 315
         `);
     }


### PR DESCRIPTION
## Summary
- Activate Scrypt/USDT liquidity management rule (ID 315)
- Create withdrawal action: Scrypt → ETH_WALLET_ADDRESS (Ethereum)
- Auto-withdraw when balance > 50,000 USDT

## Configuration
| Parameter | Value |
|-----------|-------|
| optimal | 100 USDT |
| maximal | 50,000 USDT |
| reactivationTime | 5 min |
| destination | ETH_WALLET_ADDRESS (Ethereum) |

## Current State
- **Scrypt/USDT Balance:** ~126,334 USDT
- **Rule Status:** Inactive → Active

## Behavior
When Scrypt USDT balance exceeds 50,000:
1. Triggers redundancy action
2. Scrypt withdraws ~49,900 USDT (balance - optimal) to DFX ETH liquidity wallet
3. Rule reactivates after 5 minutes

## Test plan
- [ ] Verify migration runs successfully on DEV
- [ ] Check that rule 315 is active with correct thresholds
- [ ] Verify withdrawal action is created with correct params
- [ ] Monitor first automatic withdrawal execution