### PR TITLE
Link chargeback to BankTxReturn 452 and fix types

### DIFF
--- a/migration/1768828142000-LinkBankTxReturnChargeback.js
+++ b/migration/1768828142000-LinkBankTxReturnChargeback.js
@@ -10,8 +10,11 @@
  * - Chargeback (bank_tx 185618): Outgoing refund to original sender (DBIT, 57399.75 EUR)
  * - Chargeback date: 2026-01-14 (booking date of bank_tx 185618)
  *
- * Note: The setFiatAmounts cron will NOT process this record because chargebackOutputId is NULL.
- * Therefore, we must set amountInEur/Chf/Usd directly in this migration.
+ * Fixes:
+ * 1. BankTxReturn 452: Set chargeback link and fiat amounts (cron won't process due to NULL chargebackOutputId)
+ * 2. bank_tx 185618: Fix type from 'Internal' to 'BankTxReturn-Chargeback'
+ * 3. transaction 295791: Fix type from 'Internal' to 'BankTxReturn-Chargeback'
+ *
  * Exchange rates from 2026-01-14: EUR/CHF=0.932, EUR/USD=1.161
  *
  * @class
@@ -59,6 +62,20 @@ module.exports = class LinkBankTxReturnChargeback1768828142000 {
     console.log(
       `Linked chargeback bank_tx 185618 to BankTxReturn 452 (bank_tx 186225): ${chargebackAmount} EUR, ${amountInChf} CHF, ${amountInUsd} USD`,
     );
+
+    // Fix bank_tx 185618 type: 'Internal' -> 'BankTxReturn-Chargeback'
+    await queryRunner.query(`UPDATE dbo.bank_tx SET type = @0 WHERE id = @1`, [
+      'BankTxReturn-Chargeback',
+      185618,
+    ]);
+    console.log('Fixed bank_tx 185618 type: Internal -> BankTxReturn-Chargeback');
+
+    // Fix transaction 295791 type: 'Internal' -> 'BankTxReturn-Chargeback'
+    await queryRunner.query(`UPDATE dbo.[transaction] SET type = @0 WHERE id = @1`, [
+      'BankTxReturn-Chargeback',
+      295791,
+    ]);
+    console.log('Fixed transaction 295791 type: Internal -> BankTxReturn-Chargeback');
   }
 
   /**
@@ -82,5 +99,13 @@ module.exports = class LinkBankTxReturnChargeback1768828142000 {
     );
 
     console.log('Unlinked chargeback and reset fiat amounts for BankTxReturn (bank_tx 186225)');
+
+    // Revert bank_tx 185618 type back to 'Internal'
+    await queryRunner.query(`UPDATE dbo.bank_tx SET type = @0 WHERE id = @1`, ['Internal', 185618]);
+    console.log('Reverted bank_tx 185618 type: BankTxReturn-Chargeback -> Internal');
+
+    // Revert transaction 295791 type back to 'Internal'
+    await queryRunner.query(`UPDATE dbo.[transaction] SET type = @0 WHERE id = @1`, ['Internal', 295791]);
+    console.log('Reverted transaction 295791 type: BankTxReturn-Chargeback -> Internal');
   }
 };


### PR DESCRIPTION
## Summary
- Link chargeback bank_tx 185618 to BankTxReturn 452 (bank_tx 186225)
- Set fiat amounts directly (cron won't process due to NULL chargebackOutputId)
- Fix bank_tx 185618 type: Internal → BankTxReturn-Chargeback
- Fix transaction 295791 type: Internal → BankTxReturn-Chargeback

## Context
This is a follow-up to PR #2974 which created the missing transaction for bank_tx 186225.

The chargeback (bank_tx 185618) was processed manually via bank statement without going through the normal fiat_output flow. Therefore:
- `chargebackOutputId` remains NULL
- Fiat amounts must be set directly in migration (cron requires chargebackOutputId)

## Changes
| Entity | Field | Before | After |
|--------|-------|--------|-------|
| BankTxReturn 452 | chargebackBankTxId | NULL | 185618 |
| BankTxReturn 452 | chargebackAmount | NULL | 57399.75 |
| BankTxReturn 452 | amountInEur | NULL | 57399.75 |
| BankTxReturn 452 | amountInChf | NULL | 53496.57 |
| BankTxReturn 452 | amountInUsd | NULL | 66641.11 |
| bank_tx 185618 | type | Internal | BankTxReturn-Chargeback |
| transaction 295791 | type | Internal | BankTxReturn-Chargeback |

## Test plan
- [ ] Verify migration runs without errors
- [ ] Verify BankTxReturn 452 has correct chargeback link and amounts
- [ ] Verify bank_tx 185618 and transaction 295791 have correct type