### PR TITLE
Remove conventional commits check from PR review bot

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -85,36 +85,6 @@ jobs:
           COUNT=$(wc -l < new-todos.txt | tr -d ' ')
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
-      - name: Check commit message format
-        id: commits-format
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const conventionalPattern = /^(feat|fix|refactor|test|ci|docs|chore|perf|style|build|revert)(\(.+\))?: .+/;
-
-            const commits = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            const badCommits = commits.data.filter(c => {
-              const firstLine = c.commit.message.split('\n')[0];
-              return !conventionalPattern.test(firstLine);
-            });
-
-            if (badCommits.length > 0) {
-              const list = badCommits.map(c =>
-                `- \`${c.sha.substring(0,7)}\` ${c.commit.message.split('\n')[0]}`
-              ).join('\n');
-
-              core.setOutput('invalid', 'true');
-              core.setOutput('invalid_list', list);
-              core.setOutput('invalid_count', badCommits.length);
-            } else {
-              core.setOutput('invalid', 'false');
-            }
-
       - name: Post PR comment
         uses: actions/github-script@v7
         env:
@@ -127,9 +97,6 @@ jobs:
           AUDIT_HIGH: ${{ steps.audit.outputs.high }}
           AUDIT_CRITICAL: ${{ steps.audit.outputs.critical }}
           TODO_COUNT: ${{ steps.todos.outputs.count }}
-          INVALID_COMMITS: ${{ steps.commits-format.outputs.invalid }}
-          INVALID_LIST: ${{ steps.commits-format.outputs.invalid_list }}
-          INVALID_COUNT: ${{ steps.commits-format.outputs.invalid_count }}
         with:
           script: |
             const fs = require('fs');
@@ -146,10 +113,6 @@ jobs:
             const auditCritical = parseInt(process.env.AUDIT_CRITICAL) || 0;
 
             const todoCount = parseInt(process.env.TODO_COUNT) || 0;
-
-            const invalidCommits = process.env.INVALID_COMMITS === 'true';
-            const invalidList = process.env.INVALID_LIST || '';
-            const invalidCount = process.env.INVALID_COUNT || '0';
 
             let comments = [];
 
@@ -175,18 +138,6 @@ jobs:
             git push --force-with-lease
             \`\`\`
             </details>`);
-            }
-
-            // Invalid commit message format
-            if (invalidCommits) {
-              comments.push(`## ⚠️ Non-Conventional Commits (${invalidCount})
-
-            The following commits don't follow conventional commit format:
-
-            ${invalidList}
-
-            Expected: \`type(scope): description\`
-            Types: feat, fix, refactor, test, ci, docs, chore, perf, style, build, revert`);
             }
 
             // ESLint warnings
@@ -235,7 +186,6 @@ jobs:
             const botComment = existingComments.data.find(c =>
               c.user?.login === 'github-actions[bot]' && (
                 c.body?.includes('Unverified Commits') ||
-                c.body?.includes('Non-Conventional Commits') ||
                 c.body?.includes('ESLint:') ||
                 c.body?.includes('TypeScript:') ||
                 c.body?.includes('Security:') ||


### PR DESCRIPTION
## Summary
- Remove the conventional commits format check from PR review bot
- This check was flagging PRs with non-conventional commit messages as warnings, which adds unnecessary noise

The bot still checks for:
- Unverified/unsigned commits
- ESLint errors/warnings
- TypeScript errors
- Critical security vulnerabilities
- New TODOs/FIXMEs