### PR TITLE
fix(gs): allow debug access to accountIban column

### DIFF
--- a/src/subdomains/generic/gs/dto/gs.dto.ts
+++ b/src/subdomains/generic/gs/dto/gs.dto.ts
@@ -60,7 +60,6 @@ export const DebugBlockedCols: Record<string, string[]> = {
     'ultimateName',
     'iban',
     'country',
-    'accountIban',
     'senderAccount',
     'bic',
     'addressLine1',
@@ -79,7 +78,6 @@ export const DebugBlockedCols: Record<string, string[]> = {
   fiat_output: [
     'name',
     'iban',
-    'accountIban',
     'accountNumber',
     'bic',
     'aba',


### PR DESCRIPTION
## Summary
- Remove `accountIban` from `DebugBlockedCols` for `bank_tx` table
- Remove `accountIban` from `DebugBlockedCols` for `fiat_output` table

This enables debugging of bank account routing issues via the `/gs/debug` endpoint.

## Test plan
- [ ] Verify debug query `SELECT TOP 5 id, accountIban FROM bank_tx` returns actual values instead of `[RESTRICTED:SET]`