### PR TITLE
fix: remove accidentally set BTC liquidity limit

### DIFF
--- a/migration/1768893600000-RemoveBtcLiquidityLimit.js
+++ b/migration/1768893600000-RemoveBtcLiquidityLimit.js
@@ -1,19 +1,42 @@
 /**
  * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
  */
 
 /**
+ * Remove accidentally set BTC liquidity limit.
+ *
+ * On 2026-01-19 at 16:09 UTC, the limit field on the BTC liquidity_management_rule
+ * was accidentally set to 0.8863205, causing BuyFiat transactions over ~0.78 BTC
+ * to fail with LIQUIDITY_LIMIT_EXCEEDED (e.g., transaction 296735).
+ *
+ * This migration sets the limit back to NULL (no limit) for BTC.
+ *
  * @class
  * @implements {MigrationInterface}
  */
 module.exports = class RemoveBtcLiquidityLimit1768893600000 {
-    name = 'RemoveBtcLiquidityLimit1768893600000'
+  name = 'RemoveBtcLiquidityLimit1768893600000';
 
-    async up(queryRunner) {
-        await queryRunner.query(`UPDATE "liquidity_management_rule" SET "limit" = NULL WHERE "id" = 79`);
-    }
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async up(queryRunner) {
+    await queryRunner.query(`
+      UPDATE "dbo"."liquidity_management_rule"
+      SET "limit" = NULL
+      WHERE "id" = 79 AND "context" = 'Bitcoin'
+    `);
+  }
 
-    async down(queryRunner) {
-        await queryRunner.query(`UPDATE "liquidity_management_rule" SET "limit" = 0.8863205 WHERE "id" = 79`);
-    }
-}
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async down(queryRunner) {
+    await queryRunner.query(`
+      UPDATE "dbo"."liquidity_management_rule"
+      SET "limit" = 0.8863205
+      WHERE "id" = 79 AND "context" = 'Bitcoin'
+    `);
+  }
+};


### PR DESCRIPTION
## Summary
- Removes the accidentally set `limit` (0.8863205) on BTC liquidity_management_rule (id=79)
- Sets the limit back to `NULL` (no limit) for BTC
- Fixes LIQUIDITY_LIMIT_EXCEEDED errors for BuyFiat transactions > ~0.78 BTC

## Context
On 2026-01-19 at 16:09 UTC, the limit field was set to 0.8863205 BTC, causing transaction 296735 (1 BTC BuyFiat) to fail ~4 hours later.

## Test plan
- [ ] Run migration on DEV
- [ ] Verify BTC rule 79 has `limit = NULL`
- [ ] Test BuyFiat with > 0.8 BTC works again