### PR TITLE
Reset EUR fiat_output transactions

### DIFF
--- a/migration/1737392400000-ResetEurFiatOutputTransactions.js
+++ b/migration/1737392400000-ResetEurFiatOutputTransactions.js
@@ -1,0 +1,54 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * Reset EUR fiat_output transactions that were processed before EUR blocking was enabled.
+ *
+ * These 8 transactions were transmitted via Yapeal and need to be reset
+ * so they can be reprocessed when EUR payouts are re-enabled.
+ *
+ * Affected transactions:
+ * - ID 79157: BuyFiat, 392.39 EUR
+ * - ID 79158: BuyFiat, 205.03 EUR
+ * - ID 79161: BuyFiat, 99.46 EUR
+ * - ID 79162: BuyCryptoFail, 2994.61 EUR
+ * - ID 79163: BuyCryptoFail, 47.79 EUR
+ * - ID 79164: BuyCryptoFail, 115.71 EUR
+ * - ID 79165: BuyFiat, 16.17 EUR
+ * - ID 79166: BuyFiat, 364.72 EUR
+ *
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class ResetEurFiatOutputTransactions1737392400000 {
+  name = 'ResetEurFiatOutputTransactions1737392400000';
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async up(queryRunner) {
+    const result = await queryRunner.query(`
+      UPDATE "dbo"."fiat_output"
+      SET "isReadyDate" = NULL,
+          "isTransmittedDate" = NULL,
+          "isApprovedDate" = NULL,
+          "yapealMsgId" = NULL,
+          "endToEndId" = NULL
+      WHERE "id" IN (79157, 79158, 79161, 79162, 79163, 79164, 79165, 79166)
+        AND "currency" = 'EUR'
+        AND "isComplete" = 0
+    `);
+
+    console.log('Reset EUR fiat_output transactions:', result);
+  }
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async down(queryRunner) {
+    // Cannot restore original timestamps - manual intervention required
+    console.log('Down migration not supported - original timestamps cannot be restored');
+  }
+};


### PR DESCRIPTION
## Summary
- Reset 8 EUR transactions that were processed via Yapeal before EUR blocking was enabled
- Clears: `isReadyDate`, `isTransmittedDate`, `isApprovedDate`, `yapealMsgId`, `endToEndId`
- Transactions can be reprocessed when EUR payouts are re-enabled

## Affected Transactions
| ID | Type | Amount (EUR) |
|----|------|-------------|
| 79157 | BuyFiat | 392.39 |
| 79158 | BuyFiat | 205.03 |
| 79161 | BuyFiat | 99.46 |
| 79162 | BuyCryptoFail | 2,994.61 |
| 79163 | BuyCryptoFail | 47.79 |
| 79164 | BuyCryptoFail | 115.71 |
| 79165 | BuyFiat | 16.17 |
| 79166 | BuyFiat | 364.72 |

**Total: 4,236.08 EUR**

## Test plan
- [ ] Verify migration runs successfully
- [ ] Verify all 8 transactions have NULL values for reset fields