### PR TITLE
feat(buy): add automatic VIBAN for CHF users with KYC 50+

### DIFF
--- a/src/subdomains/core/buy-crypto/routes/buy/buy.service.ts
+++ b/src/subdomains/core/buy-crypto/routes/buy/buy.service.ts
@@ -393,6 +393,17 @@ export class BuyService {
       return this.buildVirtualIbanResponse(virtualIban, selector.userData, buy?.bankUsage);
     }
 
+    // CHF: VIBAN for KYC 50+
+    if (selector.currency === 'CHF' && selector.userData.kycLevel >= KycLevel.LEVEL_50) {
+      let virtualIban = await this.virtualIbanService.getActiveForUserAndCurrency(selector.userData, selector.currency);
+
+      if (!virtualIban) {
+        virtualIban = await this.virtualIbanService.createForUser(selector.userData, selector.currency);
+      }
+
+      return this.buildVirtualIbanResponse(virtualIban, selector.userData, buy?.bankUsage);
+    }
+
     // user-level personal IBAN
     const virtualIban = await this.virtualIbanService.getActiveForUserAndCurrency(selector.userData, selector.currency);
 


### PR DESCRIPTION
## Summary
- CHF users with KYC level 50+ now automatically get a VIBAN created/displayed
- CHF users below KYC 50 continue using normal bank selection (no error)
- EUR rules remain unchanged (VIBAN mandatory, KYC 50+ required or error)

## Rules Overview

| Currency | KYC < 50 | KYC ≥ 50 |
|----------|----------|----------|
| **EUR** | `KycRequired` Error | VIBAN (auto) |
| **CHF** | Normal bank selection | VIBAN (auto) |

## Test plan
- [ ] Test CHF buy with KYC 50+ user → should get VIBAN
- [ ] Test CHF buy with KYC < 50 user → should get normal bank details
- [ ] Test EUR buy still works as before