### PR TITLE
Allow invoice generation for pending transactions via uid

### DIFF
--- a/src/subdomains/core/history/controllers/transaction.controller.ts
+++ b/src/subdomains/core/history/controllers/transaction.controller.ts
@@ -435,9 +435,10 @@ export class TransactionController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.ACCOUNT), IpGuard, UserActiveGuard())
   @ApiOkResponse({ type: PdfDto })
   async generateInvoiceFromTransaction(@GetJwt() jwt: JwtPayload, @Param('id') id: string): Promise<PdfDto> {
+    const txIdOrUid = isNaN(+id) ? id : +id;
     const txStatementDetails = await this.transactionHelper.getTxStatementDetails(
       jwt.account,
-      +id,
+      txIdOrUid,
       TxStatementType.INVOICE,
     );
 
@@ -453,9 +454,10 @@ export class TransactionController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.ACCOUNT), IpGuard, UserActiveGuard())
   @ApiOkResponse({ type: PdfDto })
   async generateReceiptFromTransaction(@GetJwt() jwt: JwtPayload, @Param('id') id: string): Promise<PdfDto> {
+    const txIdOrUid = isNaN(+id) ? id : +id;
     const txStatementDetails = await this.transactionHelper.getTxStatementDetails(
       jwt.account,
-      +id,
+      txIdOrUid,
       TxStatementType.RECEIPT,
     );
 


### PR DESCRIPTION
## Summary
- Extend `getTxStatementDetails` to accept both numeric `id` and string `uid`
- Remove `isComplete` check for INVOICE (keep for RECEIPT only)
- Update transaction controller to detect id vs uid parameter

## Why
Users should be able to download invoices for transactions that are still pending (e.g., "Warten auf Zahlung"), not just completed ones.

## Changes
- `transaction-helper.ts`: Modified signature to `txIdOrUid: number | string`, uses `getTransactionById` for numbers and `getTransactionByUid` for strings
- `transaction.controller.ts`: Added `isNaN(+id)` check to determine whether to pass id as number or string

## Test plan
- [x] Lint passes
- [x] Format check passes  
- [x] Build passes
- [x] Tests pass (788 passed)
- [ ] Manual test: Call `PUT /transaction/{uid}/invoice` with a pending transaction uid