### PR TITLE
Add TransactionRequest support to invoice endpoint

### DIFF
--- a/src/subdomains/core/history/controllers/transaction.controller.ts
+++ b/src/subdomains/core/history/controllers/transaction.controller.ts
@@ -46,6 +46,7 @@ import { BankService } from 'src/subdomains/supporting/bank/bank/bank.service';
 import { CardBankName } from 'src/subdomains/supporting/bank/bank/dto/bank.dto';
 import { VirtualIbanService } from 'src/subdomains/supporting/bank/virtual-iban/virtual-iban.service';
 import { PayInType } from 'src/subdomains/supporting/payin/entities/crypto-input.entity';
+import { FiatPaymentMethod } from 'src/subdomains/supporting/payment/dto/payment-method.enum';
 import { TxStatementType } from 'src/subdomains/supporting/payment/dto/transaction-helper/tx-statement-details.dto';
 import { TransactionRequest } from 'src/subdomains/supporting/payment/entities/transaction-request.entity';
 import { Transaction, TransactionTypeInternal } from 'src/subdomains/supporting/payment/entities/transaction.entity';
@@ -436,6 +437,52 @@ export class TransactionController {
   @ApiOkResponse({ type: PdfDto })
   async generateInvoiceFromTransaction(@GetJwt() jwt: JwtPayload, @Param('id') id: string): Promise<PdfDto> {
     const txIdOrUid = isNaN(+id) ? id : +id;
+
+    // For string UIDs, first try to find a TransactionRequest (for pending transactions)
+    if (typeof txIdOrUid === 'string') {
+      const request = await this.transactionRequestService.getTransactionRequestByUid(txIdOrUid, {
+        user: { userData: { organization: true }, wallet: true },
+      });
+
+      if (request) {
+        // Validate ownership and state
+        if (request.user.userData.id !== jwt.account)
+          throw new ForbiddenException('Not your transaction request');
+        if (!request.userData.isDataComplete) throw new BadRequestException('User data is not complete');
+        if (!request.isValid) throw new BadRequestException('Transaction request is not valid');
+
+        // Generate invoice from request (pending transaction)
+        const currency = await this.fiatService.getFiat(request.sourceId);
+        if (!Config.invoice.currencies.includes(currency.name)) {
+          throw new Error('PDF invoice is only available for CHF and EUR transactions');
+        }
+
+        const buy = await this.buyService.get(jwt.account, request.routeId);
+        const bankInfo = await this.buyService.getBankInfo(
+          {
+            amount: request.amount,
+            currency: currency.name,
+            paymentMethod: request.sourcePaymentMethod as FiatPaymentMethod,
+            userData: request.userData,
+          },
+          buy,
+          buy?.asset,
+          buy?.user?.wallet,
+        );
+
+        return {
+          pdfData: await this.swissQrService.createInvoiceFromRequest(
+            request.amount,
+            currency.name,
+            bankInfo.reference,
+            bankInfo,
+            request,
+          ),
+        };
+      }
+    }
+
+    // Try to find a completed Transaction
     const txStatementDetails = await this.transactionHelper.getTxStatementDetails(
       jwt.account,
       txIdOrUid,


### PR DESCRIPTION
## Summary
- For pending transactions (WaitingForPayment), the frontend sends a `TransactionRequest.uid` instead of a `Transaction.uid`
- Added fallback logic to first check for a `TransactionRequest` with the given uid
- If found, generates invoice using existing `createInvoiceFromRequest` method
- If not found, falls back to normal `Transaction` lookup

## Problem
When clicking "RECHNUNG ÖFFNEN" on a pending transaction:
1. Frontend sends `getTransactionInvoice(tx.uid)` where `tx.uid` = `TransactionRequest.uid`
2. Backend tried to find `Transaction.uid` which doesn't exist for pending transactions
3. Result: "Transaction not found" error

## Solution
Check for `TransactionRequest.uid` first for string UIDs, then fall back to `Transaction` lookup.

## Test plan
- [ ] Create a buy transaction and don't complete the payment (status: WaitingForPayment)
- [ ] Navigate to `/tx` and click "RECHNUNG ÖFFNEN" (Open Invoice)
- [ ] Verify invoice PDF is generated successfully
- [ ] Verify completed transactions still generate invoices correctly