### PR TITLE
fix: Allow EUR invoice generation without KYC Level 50

### DIFF
--- a/src/subdomains/core/buy-crypto/routes/buy/buy.controller.ts
+++ b/src/subdomains/core/buy-crypto/routes/buy/buy.controller.ts
@@ -178,6 +178,7 @@ export class BuyController {
       buy,
       buy.asset,
       user.wallet,
+      true,
     );
 
     if (!Config.invoice.currencies.includes(currency.name)) {

--- a/src/subdomains/core/buy-crypto/routes/buy/buy.service.ts
+++ b/src/subdomains/core/buy-crypto/routes/buy/buy.service.ts
@@ -355,6 +355,7 @@ export class BuyService {
     buy?: Buy,
     asset?: Asset,
     wallet?: Wallet,
+    forInvoice?: boolean,
   ): Promise<BankInfoDto & { isPersonalIban: boolean; reference?: string }> {
     // asset-specific personal IBAN
     if (
@@ -390,8 +391,8 @@ export class BuyService {
       return this.buildVirtualIbanResponse(virtualIban, selector.userData, buy?.bankUsage);
     }
 
-    // EUR: vIBAN is mandatory
-    if (selector.currency === 'EUR') {
+    // EUR: vIBAN is mandatory (except for invoice generation)
+    if (selector.currency === 'EUR' && !forInvoice) {
       throw new BadRequestException('KycRequired');
     }
 

--- a/src/subdomains/core/history/controllers/transaction.controller.ts
+++ b/src/subdomains/core/history/controllers/transaction.controller.ts
@@ -467,6 +467,7 @@ export class TransactionController {
           buy,
           buy?.asset,
           buy?.user?.wallet,
+          true,
         );
 
         return {

--- a/src/subdomains/supporting/payment/services/transaction-helper.ts
+++ b/src/subdomains/supporting/payment/services/transaction-helper.ts
@@ -540,6 +540,7 @@ export class TransactionHelper implements OnModuleInit {
           buy,
           buy?.asset,
           buy?.user?.wallet,
+          true,
         ));
 
       return {
@@ -601,6 +602,7 @@ export class TransactionHelper implements OnModuleInit {
       buy,
       buy?.asset,
       buy?.user?.wallet,
+      true,
     );
 
     return {


### PR DESCRIPTION
## Summary
- Add `forInvoice` parameter to `getBankInfo()` to bypass vIBAN requirement for invoice generation
- This allows users without KYC Level 50 to generate invoice PDFs for EUR transactions
- Previously, EUR invoice generation failed with `KycRequired` error if user didn't have a vIBAN

## Changes
- `buy.service.ts`: Add optional `forInvoice` parameter to `getBankInfo()`
- `buy.controller.ts`: Pass `forInvoice=true` for invoice endpoint
- `transaction.controller.ts`: Pass `forInvoice=true` for invoice endpoint
- `transaction-helper.ts`: Pass `forInvoice=true` for statement generation

## Test plan
- [ ] Test invoice generation for EUR transaction without KYC Level 50
- [ ] Verify existing functionality still works (vIBAN creation for KYC 50+ users)
- [ ] Verify CHF invoice generation still works