### PR TITLE
Update Citrea RPC and explorer URLs to citreascan.com

### DIFF
--- a/infrastructure/bicep/api/parameters/dev.json
+++ b/infrastructure/bicep/api/parameters/dev.json
@@ -276,7 +276,7 @@
       "value": "xxx"
     },
     "citreaTestnetGatewayUrl": {
-      "value": "https://rpc.testnet.citrea.xyz"
+      "value": "https://rpc.testnet.citreascan.com"
     },
     "citreaTestnetApiKey": {
       "value": "100"

--- a/infrastructure/bicep/api/parameters/loc.json
+++ b/infrastructure/bicep/api/parameters/loc.json
@@ -270,7 +270,7 @@
       "value": "xxx"
     },
     "citreaTestnetGatewayUrl": {
-      "value": "https://rpc.testnet.citrea.xyz"
+      "value": "https://rpc.testnet.citreascan.com"
     },
     "citreaTestnetApiKey": {
       "value": "100"

--- a/infrastructure/bicep/api/parameters/prd.json
+++ b/infrastructure/bicep/api/parameters/prd.json
@@ -270,7 +270,7 @@
       "value": "xxx"
     },
     "citreaTestnetGatewayUrl": {
-      "value": "https://rpc.testnet.citrea.xyz"
+      "value": "https://rpc.testnet.citreascan.com"
     },
     "citreaTestnetApiKey": {
       "value": "100"

--- a/infrastructure/citrea/citreascan/config/docker/docker-compose-citrea-testnet4.yml
+++ b/infrastructure/citrea/citreascan/config/docker/docker-compose-citrea-testnet4.yml
@@ -60,7 +60,7 @@ services:
       - RPC_BATCH_REQUESTS_LIMIT=100
       - RPC_ENABLE_SUBSCRIPTIONS=true
       - RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION=10
-      - SEQUENCER_CLIENT_URL=https://rpc.testnet.citrea.xyz
+      - SEQUENCER_CLIENT_URL=https://rpc.testnet.citreascan.com
       - INCLUDE_TX_BODY=false
       - SCAN_L1_START_HEIGHT=45496
       - SYNC_BLOCKS_COUNT=10


### PR DESCRIPTION
## Summary
- Update RPC URLs from citrea.xyz to citreascan.com
- Update explorer URLs to new citreascan.com domain

## Changes
| Old URL | New URL |
|---------|---------|
| `https://rpc.citrea.xyz` | `https://rpc.citreascan.com` |
| `https://rpc.testnet.citrea.xyz` | `https://rpc.testnet.citreascan.com` |
| `https://explorer.mainnet.citrea.xyz` | `https://citreascan.com` |
| `https://explorer.testnet.citrea.xyz` | `https://testnet.citreascan.com` |

## Test plan
- [ ] Verify infrastructure configs work correctly