### PR TITLE
fix: enable registration with different email when registration not completed

### DIFF
--- a/src/subdomains/supporting/realunit/controllers/realunit.controller.ts
+++ b/src/subdomains/supporting/realunit/controllers/realunit.controller.ts
@@ -339,7 +339,7 @@ export class RealUnitController {
     @GetJwt() jwt: JwtPayload,
     @Body() dto: RealUnitEmailRegistrationDto,
   ): Promise<RealUnitEmailRegistrationResponseDto> {
-    const status = await this.realunitService.registerEmail(jwt.account, dto);
+    const status = await this.realunitService.registerEmail(jwt.account, jwt.address, dto);
     return { status };
   }
 

--- a/src/subdomains/supporting/realunit/dto/realunit-registration.dto.ts
+++ b/src/subdomains/supporting/realunit/dto/realunit-registration.dto.ts
@@ -46,12 +46,6 @@ export class RealUnitEmailRegistrationDto {
   @IsLowercase()
   @Transform(Util.trim)
   email: string;
-
-  @ApiProperty({ description: 'Ethereum wallet address (0x...)' })
-  @IsNotEmpty()
-  @IsString()
-  @Matches(/^0x[a-fA-F0-9]{40}$/, { message: 'walletAddress must be a valid Ethereum address' })
-  walletAddress: string;
 }
 
 export class RealUnitEmailRegistrationResponseDto {

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -349,7 +349,11 @@ export class RealUnitService {
     return !success;
   }
 
-  async registerEmail(userDataId: number, dto: RealUnitEmailRegistrationDto): Promise<RealUnitEmailRegistrationStatus> {
+  async registerEmail(
+    userDataId: number,
+    walletAddress: string,
+    dto: RealUnitEmailRegistrationDto,
+  ): Promise<RealUnitEmailRegistrationStatus> {
     const userData = await this.userDataService.getUserData(userDataId, { users: true, kycSteps: true, wallet: true });
     if (!userData) throw new NotFoundException('User not found');
 
@@ -360,7 +364,7 @@ export class RealUnitService {
     const isNewEmail = !userData.mail || !Util.equalsIgnoreCase(dto.email, userData.mail);
 
     if (isNewEmail) {
-      if (userData.mail && this.hasRegistrationForWallet(userData, dto.walletAddress)) {
+      if (userData.mail && this.hasRegistrationForWallet(userData, walletAddress)) {
         throw new BadRequestException('Not allowed to register a new email for this address');
       }
 


### PR DESCRIPTION
- using another email is possible when registration was not completed
- added check that wallet has to be authenticated

### Release Checklist

#### Pre-Release

- [ ] Check migrations
  - No database related infos (sqldb-xxx)
  - Impact on GS (new/removed columns)
- [ ] Check for linter errors (in PR)
- [ ] Test basic user operations (on [DFX services](https://dev.app.dfx.swiss))
  - Login/logout
  - Buy/sell payment request
  - KYC page

#### Post-Release

- Test basic user operations
- Monitor application insights log
