### PR TITLE
Allow kycFileId column in debug endpoint

### DIFF
--- a/src/subdomains/generic/gs/dto/gs.dto.ts
+++ b/src/subdomains/generic/gs/dto/gs.dto.ts
@@ -43,7 +43,6 @@ export const DebugBlockedCols: Record<string, string[]> = {
     'legalEntity',
     'signatoryPower',
     'kycHash',
-    'kycFileId',
     'apiKeyCT',
     'totpSecret',
     'internalAmlNote',


### PR DESCRIPTION
## Summary
- Remove `kycFileId` from `DebugBlockedCols` to enable querying `user_data.kycFileId` via the debug SQL endpoint

## Test plan
- [ ] Query `SELECT COUNT(*) FROM user_data WHERE kycFileId > 0` via debug endpoint
- [ ] Verify other blocked columns remain inaccessible