### PR TITLE
Reset KYC level for users with DfxApproval but no Ident renewal

### DIFF
--- a/migration/1769300000000-ResetExpiredAmlKycLevelNoIdent.js
+++ b/migration/1769300000000-ResetExpiredAmlKycLevelNoIdent.js
@@ -1,0 +1,90 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * Reset KYC level for users with DfxApproval after expiry but NO Ident renewal.
+ *
+ * These 13 users have:
+ * - amlListExpiredDate set (AML expired)
+ * - amlListReactivatedDate NULL
+ * - DfxApproval completed AFTER expiry
+ * - But NO Ident completed after expiry (last Ident from 2023-12-01)
+ *
+ * They received DfxApproval without re-verifying their identity, which is incorrect.
+ * Their KycLevel should be reset to 20 until they complete proper re-verification.
+ *
+ * Affected users: 13 (as of 2026-01-31)
+ *
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class ResetExpiredAmlKycLevelNoIdent1769300000000 {
+  name = 'ResetExpiredAmlKycLevelNoIdent1769300000000';
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async up(queryRunner) {
+    // First, log the affected users for verification
+    const users = await queryRunner.query(`
+      SELECT "id", "kycLevel"
+      FROM "dbo"."user_data"
+      WHERE "kycLevel" >= 30
+        AND "amlListExpiredDate" IS NOT NULL
+        AND "amlListReactivatedDate" IS NULL
+        AND EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step"
+          WHERE "userDataId" = "user_data"."id"
+            AND "name" = 'DfxApproval'
+            AND "status" = 'Completed'
+            AND "created" > "user_data"."amlListExpiredDate"
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step"
+          WHERE "userDataId" = "user_data"."id"
+            AND "name" = 'Ident'
+            AND "status" = 'Completed'
+            AND "created" > "user_data"."amlListExpiredDate"
+        )
+    `);
+
+    console.log(`Found ${users.length} users with DfxApproval but no Ident after expiry:`);
+    for (const user of users) {
+      console.log(`  - UserData ${user.id}: kycLevel ${user.kycLevel} -> 20`);
+    }
+
+    // Update KycLevel to 20 for affected users
+    await queryRunner.query(`
+      UPDATE "dbo"."user_data"
+      SET "kycLevel" = 20
+      WHERE "kycLevel" >= 30
+        AND "amlListExpiredDate" IS NOT NULL
+        AND "amlListReactivatedDate" IS NULL
+        AND EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step"
+          WHERE "userDataId" = "user_data"."id"
+            AND "name" = 'DfxApproval'
+            AND "status" = 'Completed'
+            AND "created" > "user_data"."amlListExpiredDate"
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step"
+          WHERE "userDataId" = "user_data"."id"
+            AND "name" = 'Ident'
+            AND "status" = 'Completed'
+            AND "created" > "user_data"."amlListExpiredDate"
+        )
+    `);
+
+    console.log(`Reset KycLevel to 20 for ${users.length} users`);
+  }
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async down(queryRunner) {
+    console.log('Down migration is a no-op - original KycLevel values are not preserved');
+  }
+};


### PR DESCRIPTION
## Summary

Adds migration to reset KycLevel to 20 for **13 users** who received DfxApproval after AML expiry **without re-verifying their identity**.

## Background

These users have:
- `amlListExpiredDate` = 2024-12-31 (AML expired)
- `amlListReactivatedDate` = NULL
- DfxApproval completed in 2025 (after expiry)
- Last Ident from **2023-12-01** (batch migration, before expiry)

They received DfxApproval without completing a new Ident step, which is incorrect.

## Affected Users

| userDataId | Last Ident | DfxApproval |
|------------|------------|-------------|
| 1129 | 2023-12-01 | 2025-06-12 |
| 1149 | 2023-12-01 | 2025-07-25 |
| 1383 | 2023-12-01 | 2025-07-29 |
| 3568 | 2023-12-01 | 2026-01-20 |
| 5266 | 2023-12-01 | 2025-04-22 |
| 7471 | 2023-12-01 | 2025-04-18 |
| 9315 | 2023-12-01 | 2025-07-16 |
| 9417 | 2023-12-01 | 2025-12-13 |
| 11522 | 2023-12-01 | 2025-02-02 |
| 181108 | 2023-12-01 | 2025-12-29 |
| 181705 | 2023-12-01 | 2025-04-14 |
| 182446 | 2023-12-01 | 2025-05-12 |
| 188574 | 2023-12-29 | 2025-01-19 |

## Changes

- `migration/1769300000000-ResetExpiredAmlKycLevelNoIdent.js`: Sets KycLevel to 20 for affected users

## Test plan

- [x] Verify query returns 13 users
- [ ] Run migration on staging
- [ ] Verify KycLevel is set to 20 for all 13 users