### PR TITLE
Reset KYC level for users with outdated Ident (before 2026)

### DIFF
--- a/migration/1769400000000-ResetExpiredAmlKycLevelOldIdent.js
+++ b/migration/1769400000000-ResetExpiredAmlKycLevelOldIdent.js
@@ -1,0 +1,106 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * Reset KYC level for users with Ident renewal before 2026.
+ *
+ * These 27 users have:
+ * - amlListExpiredDate set (AML expired)
+ * - amlListReactivatedDate NULL
+ * - DfxApproval completed AFTER expiry
+ * - Ident completed AFTER expiry but BEFORE 2026
+ *
+ * Their Ident verification is outdated (2024 or 2025).
+ * KycLevel should be reset to 20 until they complete a fresh Ident in 2026.
+ *
+ * Affected users: 27 (as of 2026-01-31)
+ * Excluded: 3 users with Ident in 2026 (1787, 3864, 9087)
+ *
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class ResetExpiredAmlKycLevelOldIdent1769400000000 {
+  name = 'ResetExpiredAmlKycLevelOldIdent1769400000000';
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async up(queryRunner) {
+    // First, log the affected users for verification
+    const users = await queryRunner.query(`
+      SELECT ud."id", ud."kycLevel",
+        (SELECT MIN(ks2."created") FROM "dbo"."kyc_step" ks2
+         WHERE ks2."userDataId" = ud."id"
+           AND ks2."name" = 'Ident'
+           AND ks2."status" = 'Completed'
+           AND ks2."created" > ud."amlListExpiredDate") as identDate
+      FROM "dbo"."user_data" ud
+      WHERE ud."kycLevel" >= 30
+        AND ud."amlListExpiredDate" IS NOT NULL
+        AND ud."amlListReactivatedDate" IS NULL
+        AND EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step" ks
+          WHERE ks."userDataId" = ud."id"
+            AND ks."name" = 'DfxApproval'
+            AND ks."status" = 'Completed'
+            AND ks."created" > ud."amlListExpiredDate"
+        )
+        AND EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step" ks2
+          WHERE ks2."userDataId" = ud."id"
+            AND ks2."name" = 'Ident'
+            AND ks2."status" = 'Completed'
+            AND ks2."created" > ud."amlListExpiredDate"
+        )
+        AND YEAR((SELECT MIN(ks3."created") FROM "dbo"."kyc_step" ks3
+                  WHERE ks3."userDataId" = ud."id"
+                    AND ks3."name" = 'Ident'
+                    AND ks3."status" = 'Completed'
+                    AND ks3."created" > ud."amlListExpiredDate")) < 2026
+    `);
+
+    console.log(`Found ${users.length} users with Ident before 2026:`);
+    for (const user of users) {
+      console.log(`  - UserData ${user.id}: kycLevel ${user.kycLevel} -> 20, Ident: ${user.identDate}`);
+    }
+
+    // Update KycLevel to 20 for affected users
+    await queryRunner.query(`
+      UPDATE "dbo"."user_data"
+      SET "kycLevel" = 20
+      WHERE "kycLevel" >= 30
+        AND "amlListExpiredDate" IS NOT NULL
+        AND "amlListReactivatedDate" IS NULL
+        AND EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step" ks
+          WHERE ks."userDataId" = "user_data"."id"
+            AND ks."name" = 'DfxApproval'
+            AND ks."status" = 'Completed'
+            AND ks."created" > "user_data"."amlListExpiredDate"
+        )
+        AND EXISTS (
+          SELECT 1 FROM "dbo"."kyc_step" ks2
+          WHERE ks2."userDataId" = "user_data"."id"
+            AND ks2."name" = 'Ident'
+            AND ks2."status" = 'Completed'
+            AND ks2."created" > "user_data"."amlListExpiredDate"
+        )
+        AND YEAR((SELECT MIN(ks3."created") FROM "dbo"."kyc_step" ks3
+                  WHERE ks3."userDataId" = "user_data"."id"
+                    AND ks3."name" = 'Ident'
+                    AND ks3."status" = 'Completed'
+                    AND ks3."created" > "user_data"."amlListExpiredDate")) < 2026
+    `);
+
+    console.log(`Reset KycLevel to 20 for ${users.length} users`);
+  }
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async down(queryRunner) {
+    console.log('Down migration is a no-op - original KycLevel values are not preserved');
+  }
+};


### PR DESCRIPTION
## Summary

Adds migration to reset KycLevel to 20 for **27 users** who have Ident verification from 2024/2025 (outdated).

## Background

These users have:
- `amlListExpiredDate` set (AML expired)
- `amlListReactivatedDate` = NULL
- DfxApproval completed after expiry
- Ident completed after expiry but **before 2026**

Their Ident verification is outdated and needs to be refreshed.

## Affected Users (27)

| userDataId | Ident Date |
|------------|------------|
| 937 | 2024-10-17 |
| 953 | 2025-08-26 |
| 1042 | 2024-12-11 |
| 1334 | 2024-09-06 |
| 1585 | 2025-05-19 |
| 2017 | 2024-12-03 |
| 2414 | 2025-07-11 |
| 2644 | 2024-08-21 |
| 2822 | 2025-01-21 |
| 2888 | 2024-06-03 |
| 4011 | 2024-01-31 |
| 4312 | 2024-10-30 |
| 5048 | 2024-07-10 |
| 5521 | 2025-12-02 |
| 6578 | 2024-02-19 |
| 6637 | 2025-06-18 |
| 6690 | 2025-03-31 |
| 7008 | 2024-11-09 |
| 7309 | 2024-02-27 |
| 7642 | 2024-08-25 |
| 7876 | 2024-02-15 |
| 8250 | 2025-01-05 |
| 8498 | 2024-07-10 |
| 9274 | 2024-11-04 |
| 9549 | 2024-04-22 |
| 10681 | 2024-10-10 |
| 182544 | 2025-09-02 |

## Excluded Users (3) - Ident in 2026

| userDataId | Ident Date |
|------------|------------|
| 1787 | 2026-01-20 |
| 3864 | 2026-01-28 |
| 9087 | 2026-01-19 |

## Changes

- `migration/1769400000000-ResetExpiredAmlKycLevelOldIdent.js`: Sets KycLevel to 20 for affected users

## Test plan

- [x] Verify query returns 27 users
- [ ] Run migration on staging
- [ ] Verify KycLevel is set to 20 for all 27 users
- [ ] Verify 3 users with Ident in 2026 are NOT affected