### PR TITLE
Add totalCustodyBalanceChfAuditPeriod column to UserData

### DIFF
--- a/migration/1770287692177-AddTotalCustodyBalanceChfAuditPeriod.js
+++ b/migration/1770287692177-AddTotalCustodyBalanceChfAuditPeriod.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddTotalCustodyBalanceChfAuditPeriod1770287692177 {
+    name = 'AddTotalCustodyBalanceChfAuditPeriod1770287692177'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user_data" ADD "totalCustodyBalanceChfAuditPeriod" float`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user_data" DROP COLUMN "totalCustodyBalanceChfAuditPeriod"`);
+    }
+}

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -94,6 +94,7 @@ export class KycFileListEntry {
   pep?: boolean;
   complexOrgStructure?: boolean;
   totalVolumeChfAuditPeriod?: number;
+  totalCustodyBalanceChfAuditPeriod?: number;
 }
 
 export class KycFileYearlyStats {

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -161,6 +161,7 @@ export class SupportService {
       pep: userData.pep,
       complexOrgStructure: userData.complexOrgStructure,
       totalVolumeChfAuditPeriod: userData.totalVolumeChfAuditPeriod,
+      totalCustodyBalanceChfAuditPeriod: userData.totalCustodyBalanceChfAuditPeriod,
     };
   }
 

--- a/src/subdomains/generic/user/models/user-data/dto/update-user-data.dto.ts
+++ b/src/subdomains/generic/user/models/user-data/dto/update-user-data.dto.ts
@@ -250,6 +250,10 @@ export class UpdateUserDataDto {
   totalVolumeChfAuditPeriod?: number;
 
   @IsOptional()
+  @IsNumber()
+  totalCustodyBalanceChfAuditPeriod?: number;
+
+  @IsOptional()
   @IsBoolean()
   olkypayAllowed?: boolean;
 

--- a/src/subdomains/generic/user/models/user-data/user-data.entity.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.entity.ts
@@ -138,6 +138,9 @@ export class UserData extends IEntity {
   @Column({ type: 'float', nullable: true })
   totalVolumeChfAuditPeriod?: number;
 
+  @Column({ type: 'float', nullable: true })
+  totalCustodyBalanceChfAuditPeriod?: number;
+
   // TODO remove
   @Column({ length: 256, nullable: true })
   allBeneficialOwnersName?: string;

--- a/src/subdomains/generic/user/models/user-data/user-data.service.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.service.ts
@@ -235,6 +235,7 @@ export class UserDataService {
         'userData.pep',
         'userData.complexOrgStructure',
         'userData.totalVolumeChfAuditPeriod',
+        'userData.totalCustodyBalanceChfAuditPeriod',
         'country.name',
       ])
       .where('userData.kycFileId > 0')


### PR DESCRIPTION
## Summary
- Add `totalCustodyBalanceChfAuditPeriod` float column to `user_data` table (analogous to `totalVolumeChfAuditPeriod`)
- Include field in entity, migration, update DTO, support DTO, query select, and service mapping
- Exposed via `support/kycFileList` endpoint for compliance KYC Files Details page

## Test plan
- [ ] Verify migration runs successfully against database
- [ ] Verify field appears in `GET /support/kycFileList` response
- [ ] Verify field can be updated via `PUT /userData` with `totalCustodyBalanceChfAuditPeriod` value