### PR TITLE
Add kycFileId to transaction list endpoint

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -84,6 +84,7 @@ export class TransactionListEntry {
   id: number;
   type?: string;
   accountId?: number;
+  kycFileId?: number;
   name?: string;
   domicile?: string;
   created?: Date;

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -174,6 +174,7 @@ export class SupportService {
       id: tx.id,
       type: tx.type,
       accountId: tx.userData?.id,
+      kycFileId: tx.userData?.kycFileId,
       name: tx.userData?.verifiedName,
       domicile: tx.userData?.country?.name,
       created: tx.created,


### PR DESCRIPTION
## Summary
- Add `kycFileId` field to `TransactionListEntry` DTO and mapping
- Enables frontend to display and filter transactions by KYC file assignment

## Related
- Services PR: DFXswiss/services#953

## Test plan
- [ ] Verify transaction list endpoint returns `kycFileId` for transactions with associated userData
- [ ] Verify `kycFileId` is `undefined` for transactions without userData