### PR TITLE
fix: correct file download filters for TxAudit and NameCheck

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -474,7 +474,7 @@ export class Configuration {
         {
           prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`],
           fileTypes: [ContentType.PDF],
-          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-TxAudit2025'.toLowerCase()),
+          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-txaudit2026'),
         },
       ],
     },
@@ -483,9 +483,9 @@ export class Configuration {
       name: 'Name Check',
       files: [
         {
-          prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`],
+          prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`, `user/${userData.id}/NameCheck`],
           fileTypes: [ContentType.PDF],
-          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-NameCheck'.toLowerCase()),
+          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-namecheck'),
         },
         {
           name: () => 'Dilisense Screening Report',

--- a/src/subdomains/generic/user/models/user-data/user-data.service.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.service.ts
@@ -350,7 +350,7 @@ export class UserDataService {
   async downloadUserData(userDataIds: number[], checkOnly = false): Promise<Buffer> {
     let count = userDataIds.length;
     const zip = new JSZip();
-    const downloadTargets = Config.fileDownloadConfig.reverse();
+    const downloadTargets = [...Config.fileDownloadConfig].reverse();
     const errors: { userDataId: number; errorType: string; folder: string; details: string }[] = [];
 
     const escapeCsvValue = (value: string): string => {
@@ -360,7 +360,7 @@ export class UserDataService {
       return value;
     };
 
-    for (const userDataId of userDataIds.reverse()) {
+    for (const userDataId of [...userDataIds].reverse()) {
       const userData = await this.getUserData(userDataId, { kycSteps: true });
 
       if (!userData) {


### PR DESCRIPTION
## Summary
- **TxAudit filter**: Changed from `-TxAudit2025` to `-TxAudit2026` — 40 files exist in storage but were not matched due to wrong year in filter
- **NameCheck prefix**: Added `NameCheck/` folder to search prefixes so auto-generated Dilisense reports are also found by the first file config entry (10 files affected)
- **Array mutation bug**: Used `[...array].reverse()` instead of `array.reverse()` to prevent mutating `Config.fileDownloadConfig` and the input `userDataIds` parameter across multiple calls

## Test plan
- [ ] Run file download export for previously affected UserDataIds
- [ ] Verify TxAudit files are now found (40 previously missing)
- [ ] Verify NameCheck files are now found (10 previously missing)
- [ ] Verify no duplicate or incorrect files in export ZIP
- [ ] Verify error_log.csv only shows genuinely missing files (23 remaining)