### PR TITLE
fix: correct TxAudit filter year from 2025 to 2026

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -474,7 +474,7 @@ export class Configuration {
         {
           prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`],
           fileTypes: [ContentType.PDF],
-          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-txaudit2026'),
+          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-TxAudit2026'.toLowerCase()),
         },
       ],
     },


### PR DESCRIPTION
## Summary
- The file download export searched for `-TxAudit2025` in filenames, but the 40 existing files are named with `-TxAudit2026`
- This caused 40 false `FileMissing` errors in the export error log

## Test plan
- [ ] Run file download export for previously affected UserDataIds
- [ ] Verify TxAudit files are now found in the ZIP