### PR TITLE
fix: add NameCheck folder to name check search prefixes

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -485,7 +485,7 @@ export class Configuration {
         {
           prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`, `user/${userData.id}/NameCheck`],
           fileTypes: [ContentType.PDF],
-          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-namecheck'),
+          filter: (file: KycFileBlob) => file.name.toLowerCase().includes('-NameCheck'.toLowerCase()),
         },
         {
           name: () => 'Dilisense Screening Report',


### PR DESCRIPTION
## Summary
- The first NameCheck file config only searched in `UserNotes/`, but auto-generated Dilisense reports are stored in `NameCheck/`
- This caused 10 false `FileMissing` errors for users without a manual NameCheck upload in UserNotes

## Test plan
- [ ] Run file download export for previously affected UserDataIds
- [ ] Verify NameCheck files are now found in the ZIP