### PR TITLE
fix: prevent array mutation in downloadUserData

### DIFF
--- a/src/subdomains/generic/user/models/user-data/user-data.service.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.service.ts
@@ -350,7 +350,7 @@ export class UserDataService {
   async downloadUserData(userDataIds: number[], checkOnly = false): Promise<Buffer> {
     let count = userDataIds.length;
     const zip = new JSZip();
-    const downloadTargets = Config.fileDownloadConfig.reverse();
+    const downloadTargets = [...Config.fileDownloadConfig].reverse();
     const errors: { userDataId: number; errorType: string; folder: string; details: string }[] = [];
 
     const escapeCsvValue = (value: string): string => {
@@ -360,7 +360,7 @@ export class UserDataService {
       return value;
     };
 
-    for (const userDataId of userDataIds.reverse()) {
+    for (const userDataId of [...userDataIds].reverse()) {
       const userData = await this.getUserData(userDataId, { kycSteps: true });
 
       if (!userData) {


### PR DESCRIPTION
## Summary
- `.reverse()` mutates the original array in place
- `Config.fileDownloadConfig.reverse()` mutated the shared config object, causing folder order to flip on every call
- `userDataIds.reverse()` mutated the caller's input parameter
- Fixed by using `[...array].reverse()` to create a copy before reversing

## Test plan
- [ ] Run file download export multiple times in sequence
- [ ] Verify folder ordering in ZIP is consistent across calls