### PR TITLE
fix: remove hardcoded year from audit folder name

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -469,7 +469,7 @@ export class Configuration {
     },
     {
       id: 13,
-      name: 'Transaktionsliste Auditperiode 2025',
+      name: 'Transaktionsliste Auditperiode',
       files: [
         {
           prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`],


### PR DESCRIPTION
## Summary
- Removes the hardcoded year `2025` from the audit export folder name `13_Transaktionsliste Auditperiode 2025` → `13_Transaktionsliste Auditperiode`
- The folder name is now year-agnostic and won't need updating each year

## Test plan
- [ ] Trigger a user data download via `/file/download` and verify the ZIP folder is named `13_Transaktionsliste Auditperiode`
- [ ] Verify `error_log.csv` references the updated folder name