### PR TITLE
feat: export TMER files in user data download

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -525,6 +525,7 @@ export class Configuration {
       name: 'TMER',
       files: [
         {
+          name: (file: KycFileBlob) => file.name.split('/').pop()?.split('.')[0] ?? 'TMER',
           prefixes: (userData: UserData) => [`user/${userData.id}/UserNotes`],
           fileTypes: [ContentType.PDF],
           filter: (file: KycFileBlob) => file.name.includes('-TMER-'),


### PR DESCRIPTION
## Summary
- Adds new folder `16_TMER` to the ZIP export containing all TMER transaction PDF files
- Filters for files matching `-TMER-` in the filename from `UserNotes`
- Uses `selectAll` to export all matching TMER files (not just the newest)
- Optional folder — no error if no TMER files exist for a user

## Test plan
- [ ] Download user data for userData 303950 and verify `16_TMER` folder contains the TMER PDFs
- [ ] Download user data for a user without TMER files and verify no error in error_log.csv