### PR TITLE
feat: export IdentDoc images from latest Ident step

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -311,9 +311,15 @@ export class Configuration {
           fileTypes: [ContentType.PDF],
         },
         {
-          name: (file: KycFileBlob) => `IdentDoc_${file.name.split('/').pop()?.split('.')[0] ?? 'unknown'}`,
+          name: (file: KycFileBlob) => file.name.split('/').pop()?.split('.')[0] ?? 'IdentDoc',
           prefixes: (userData: UserData) => [`user/${userData.id}/Identification`],
           fileTypes: [ContentType.PNG, ContentType.JPEG, ContentType.JPG],
+          filter: (file: KycFileBlob, userData: UserData) => {
+            const latestIdent = userData.kycSteps
+              .filter((s) => s.name === KycStepName.IDENT && s.isCompleted && s.transactionId)
+              .sort((a, b) => b.id - a.id)[0];
+            return latestIdent ? file.name.includes(latestIdent.transactionId) : false;
+          },
           selectAll: true,
           handleFileNotFound: () => true,
         },


### PR DESCRIPTION
## Summary
- Exports IdentDoc images (PNG/JPEG) in folder `02_Identifikationsdokument` alongside the existing IdentReport PDF
- Filters by `kycStep.transactionId` to only include images from the **newest completed Ident step**, preventing export of blurry/failed images from earlier attempts
- Adds `selectAll` option to file download config to support exporting multiple matching files per entry

## Test plan
- [ ] Download user data for userData 304545 (URS MEYER) — verify only IdentDocs from the latest Ident step (kycStepId 60677) are included, not from the older step (60672)
- [ ] Download user data for userData 303950 — verify only IdentDocs from kycStepId 61199 are included
- [ ] Verify IdentReport PDF is still exported as before
- [ ] Verify users without IdentDoc images don't get a FileMissing error