### PR TITLE
Fix SEPA parser: fallback to Ntry-level AmtDtls

### DIFF
--- a/src/subdomains/supporting/bank-tx/bank-tx/dto/sepa-entry.dto.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/dto/sepa-entry.dto.ts
@@ -83,5 +83,18 @@ export interface SepaEntry {
       AddtlTxInf: string;
     };
   };
+  AmtDtls: {
+    InstdAmt: {
+      Amt: SepaAmount;
+    };
+    TxAmt: {
+      Amt: SepaAmount;
+      CcyXchg: {
+        SrcCcy: string;
+        TrgtCcy: string;
+        XchgRate: string;
+      };
+    };
+  };
   AddtlNtryInf: string;
 }

--- a/src/subdomains/supporting/bank-tx/bank-tx/services/sepa-parser.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/services/sepa-parser.service.ts
@@ -80,6 +80,9 @@ export class SepaParser {
 
       let data: Partial<BankTx> = {};
       try {
+        // AmtDtls can be at TxDtls level or Ntry level depending on the bank
+        const amtDtls = entry?.NtryDtls?.TxDtls?.AmtDtls ?? entry?.AmtDtls;
+
         data = {
           bookingDate: new Date(entry?.BookgDt?.Dt),
           valueDate: new Date(entry?.ValDt?.Dt),
@@ -90,13 +93,13 @@ export class SepaParser {
           amount: +entry?.NtryDtls?.TxDtls?.Amt?.['#text'],
           currency,
           creditDebitIndicator,
-          instructedAmount: +entry?.NtryDtls?.TxDtls?.AmtDtls?.InstdAmt?.Amt?.['#text'],
-          instructedCurrency: this.toString(entry?.NtryDtls?.TxDtls?.AmtDtls?.InstdAmt?.Amt?.['@_Ccy']),
-          txAmount: +entry?.NtryDtls?.TxDtls?.AmtDtls?.TxAmt?.Amt?.['#text'],
-          txCurrency: this.toString(entry?.NtryDtls?.TxDtls?.AmtDtls?.TxAmt?.Amt?.['@_Ccy']),
-          exchangeSourceCurrency: this.toString(entry?.NtryDtls?.TxDtls?.AmtDtls?.TxAmt?.CcyXchg?.SrcCcy),
-          exchangeTargetCurrency: this.toString(entry?.NtryDtls?.TxDtls?.AmtDtls?.TxAmt?.CcyXchg?.TrgtCcy),
-          exchangeRate: +entry?.NtryDtls?.TxDtls?.AmtDtls?.TxAmt?.CcyXchg?.XchgRate,
+          instructedAmount: +amtDtls?.InstdAmt?.Amt?.['#text'],
+          instructedCurrency: this.toString(amtDtls?.InstdAmt?.Amt?.['@_Ccy']),
+          txAmount: +amtDtls?.TxAmt?.Amt?.['#text'],
+          txCurrency: this.toString(amtDtls?.TxAmt?.Amt?.['@_Ccy']),
+          exchangeSourceCurrency: this.toString(amtDtls?.TxAmt?.CcyXchg?.SrcCcy),
+          exchangeTargetCurrency: this.toString(amtDtls?.TxAmt?.CcyXchg?.TrgtCcy),
+          exchangeRate: +amtDtls?.TxAmt?.CcyXchg?.XchgRate,
           ...(await this.getTotalCharge(
             creditDebitIndicator === SepaCdi.CREDIT ? entry?.NtryDtls?.TxDtls?.Chrgs?.Rcrd : entry?.Chrgs?.Rcrd,
             currency,


### PR DESCRIPTION
## Summary
- SEPA parser only read `AmtDtls` from `NtryDtls.TxDtls` level
- Some banks (e.g. Raiffeisen) place `AmtDtls` at the `Ntry` level instead
- This caused `txAmount`/`txCurrency` to be NULL, breaking automatic BUY_CRYPTO assignment with a TypeError in `getAndCompleteTxRequest`
- Fix: use `NtryDtls.TxDtls.AmtDtls` with fallback to `Ntry.AmtDtls`

## Changes
- `sepa-parser.service.ts`: extract `amtDtls` variable with fallback, use it for all AmtDtls-derived fields
- `sepa-entry.dto.ts`: add `AmtDtls` to `SepaEntry` interface (Ntry level)

## Test plan
- [ ] Upload a Raiffeisen CAMT.053 file where `AmtDtls` is at Ntry level → `txAmount`/`txCurrency` should be populated
- [ ] Upload a standard CAMT.053 file where `AmtDtls` is at TxDtls level → still works as before
- [ ] Verify automatic BUY_CRYPTO assignment works for both cases