### PR TITLE
Allow concurrent buy-crypto batches per asset

### DIFF
--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-batch.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-batch.service.ts
@@ -208,7 +208,7 @@ export class BuyCryptoBatchService {
 
       const existingBatch = await this.buyCryptoBatchRepo.findOneBy({
         outputAsset: { id: outputAsset.id },
-        status: Not(BuyCryptoBatchStatus.COMPLETE),
+        status: Not(In([BuyCryptoBatchStatus.PAYING_OUT, BuyCryptoBatchStatus.COMPLETE])),
       });
       const newBatch = filteredBatches.find((b) => b.outputAsset.id === outputAsset.id);
 


### PR DESCRIPTION
## Summary

- Stop blocking new batch creation when an existing batch is in `PAYING_OUT` status
- Only block while batches are in pre-payout states (`CREATED`, `SECURED`, `PENDING_LIQUIDITY`) where UTXO selection is still in progress
- Once a TX is broadcast (`PAYING_OUT`), UTXOs are committed and change outputs are available for spending

## Motivation

A BTC batch in `PAYING_OUT` status (TX broadcast, waiting for confirmation) blocks all new BTC transactions from being batched. Bitcoin confirmations take ~10 minutes on average, creating unnecessary delays. Since Bitcoin supports spending unconfirmed UTXOs (transaction chaining), there's no technical need to wait.

## Changes

**`buy-crypto-batch.service.ts`** — `filterOutExistingBatches()`

```diff
- status: Not(BuyCryptoBatchStatus.COMPLETE),
+ status: Not(In([BuyCryptoBatchStatus.PAYING_OUT, BuyCryptoBatchStatus.COMPLETE])),
```

## Why this is safe

1. **Bitcoin**: Unconfirmed change UTXOs are spendable (transaction chaining). Bitcoin Core handles this natively.
2. **EVM chains**: Use nonces, not UTXOs. Transactions are independent.
3. **Race conditions**: The cron job runs `batchAndOptimizeTransactions()` → `secureLiquidity()` → `payoutTransactions()` sequentially. By the time a new batch is created, the previous batch's TX has already been broadcast.
4. **Batch lifecycle**: `PAYING_OUT` is only set AFTER `SECURED`, when payout processing begins. All UTXO selection happens before this point.

## Test plan

- [ ] Verify new BTC batches are created while previous batch is in `PAYING_OUT`
- [ ] Verify no double-spend errors occur
- [ ] Verify batch completion still works correctly