### PR TITLE
fix: add Cardano to payment request broadcast hint

### DIFF
--- a/src/subdomains/core/payment-link/dto/payment-request.mapper.ts
+++ b/src/subdomains/core/payment-link/dto/payment-request.mapper.ts
@@ -45,7 +45,9 @@ export class PaymentRequestMapper {
   ): PaymentLinkEvmPaymentDto {
     const infoUrl = `${Config.url()}/lnurlp/tx/${paymentActivation.payment.uniqueId}`;
 
-    const hint = [Blockchain.MONERO, Blockchain.ZANO, Blockchain.SOLANA, Blockchain.TRON, Blockchain.CARDANO].includes(method)
+    const hint = [Blockchain.MONERO, Blockchain.ZANO, Blockchain.SOLANA, Blockchain.TRON, Blockchain.CARDANO].includes(
+      method,
+    )
       ? `Use this data to create a transaction and sign it. Broadcast the signed transaction to the blockchain and send the transaction hash back via the endpoint ${infoUrl}`
       : `Use this data to create a transaction and sign it. Send the signed transaction back as HEX via the endpoint ${infoUrl}. We check the transferred HEX and broadcast the transaction to the blockchain.`;
 


### PR DESCRIPTION
## Summary
- Add `Blockchain.CARDANO` to the list of blockchains that receive the broadcast-style hint in payment request responses (alongside Monero, Zano, Solana, and Tron)

## Test plan
- [ ] Verify Cardano payment requests return the correct broadcast hint
- [ ] Verify other blockchains are unaffected