### PR TITLE
Fix null pointer in KYC ident review for personal accounts

### DIFF
--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -1471,7 +1471,7 @@ export class KycService {
     // Country & verifiedName check
     const userCountry =
       identStep.userData.organizationCountry ??
-      identStep.userData.organization.country ??
+      identStep.userData.organization?.country ??
       identStep.userData.verifiedCountry ??
       identStep.userData.country;
 


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of null (reading 'country')` in `getIdentCheckErrors()`
- Add optional chaining (`?.`) for `organization.country` access which crashes when `userData.organization` is null (personal accounts)
- At least 5 KYC ident steps (744189, 744188, 744180, 744163, 743958) are stuck in `InternalReview` and crash every minute due to this bug

## Test plan
- [ ] Verify affected KYC steps transition out of `InternalReview` after deploy
- [ ] Confirm no regression for organization/sole-proprietorship accounts