### PR TITLE
fix: add receipt status check for EVM TX-ID payments

### DIFF
--- a/src/subdomains/core/payment-link/services/payment-quote.service.ts
+++ b/src/subdomains/core/payment-link/services/payment-quote.service.ts
@@ -418,6 +418,12 @@ export class PaymentQuoteService {
         for (let i = 0; i < tryCount; i++) {
           const tx = await client.getTx(transferInfo.tx);
           if (tx?.confirmations > 0) {
+            const receipt = await client.getTxReceipt(transferInfo.tx);
+            if (!receipt?.status) {
+              quote.txFailed(`Transaction ${transferInfo.tx} has been reverted`);
+              return;
+            }
+
             const error = this.validateEvmTx(quote, method, expectedRecipient, tx);
             if (error) {
               quote.txFailed(`Transaction validation failed: ${error}`);


### PR DESCRIPTION
## Summary
- Adds transaction receipt status check in the EVM TX-ID payment path (`doEvmHexPayment`)
- Prevents reverted transactions (receipt `status === 0`) from being accepted as valid payments
- Without this check, a reverted TX with correct inputs (recipient, amount, asset) would pass `validateEvmTx` and mark the payment as completed, even though no funds were actually transferred

## Context
Introduced by #3209 — replacing `isTxComplete` (which checks receipt status) with `getTx` (which doesn't) removed the implicit revert detection.

## Test plan
- [ ] Submit a valid EVM TX-ID payment → should be accepted as before
- [ ] Submit a reverted EVM TX-ID → should be rejected with "has been reverted" error
- [ ] HEX payment path remains unaffected (server broadcasts, revert not possible pre-broadcast)