### PR TITLE
feat: mock Aktionariat API in DEV/LOC environment

### DIFF
--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -692,9 +692,11 @@ export class RealUnitService {
         countryAndTINs: dto.countryAndTINs,
       };
 
-      await this.http.post(`${api.url}/registerUser`, payload, {
-        headers: { 'x-api-key': api.key },
-      });
+      if (![Environment.DEV, Environment.LOC].includes(Config.environment)) {
+        await this.http.post(`${api.url}/registerUser`, payload, {
+          headers: { 'x-api-key': api.key },
+        });
+      }
 
       await this.kycService.saveKycStepUpdate(kycStep.complete());
 


### PR DESCRIPTION
## Summary
- Skip `requestPaymentInstructions` Aktionariat API call in DEV/LOC environments to avoid HTTP 400 errors
- Return a mock response with a generated reference instead
- Follows the existing pattern used in `confirmPaymentReceived()`

## Test plan
- [ ] Deploy to DEV environment
- [ ] Trigger buy flow in the app → "Bestätigen" should succeed without 500 error
- [ ] Verify mock reference is stored correctly in transaction request