### PR TITLE
feat: add isCompleted field to transaction support info

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -65,6 +65,7 @@ export class TransactionSupportInfo {
   amlCheck?: string;
   chargebackDate?: Date;
   amlReason?: string;
+  isCompleted: boolean;
   created: Date;
 }
 

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -402,6 +402,7 @@ export class SupportService {
         tx.bankTxReturn?.chargebackDate ??
         tx.bankTxRepeat?.chargebackDate,
       amlReason: tx.buyCrypto?.amlReason ?? tx.buyFiat?.amlReason,
+      isCompleted: !!tx.completionDate,
       created: tx.created,
     };
   }


### PR DESCRIPTION
## Summary
- Add `isCompleted` boolean field to `TransactionSupportInfo` DTO
- Map field from `tx.completionDate` in support service

## Test plan
- [ ] Verify transactions endpoint returns `isCompleted` field
- [ ] Confirm completed transactions show `true`, pending ones `false`