### PR TITLE
fix: filter pending company onboardings by kycLevel and merged status

### DIFF
--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -1840,6 +1840,8 @@ export class KycService {
       .andWhere('userData.accountType IN (:...accountTypes)', {
         accountTypes: [AccountType.ORGANIZATION, AccountType.SOLE_PROPRIETORSHIP],
       })
+      .andWhere('userData.kycLevel >= :minLevel', { minLevel: KycLevel.LEVEL_30 })
+      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
       .andWhere(
         `step.userDataId NOT IN (
           SELECT s2.userDataId FROM kyc_step s2


### PR DESCRIPTION
## Summary
- Add `kycLevel >= 30` filter to `getPendingCompanyOnboardings` query — only show companies that have completed ident
- Exclude merged userData entries (`status != Merged`)
- Aligns API behavior with the existing Google Sheet monitoring logic

## Context
The compliance pending onboardings list was showing too many entries compared to the Google Sheet. The GS filters by `ManualReview`, `kycLevel >= 30`, and `status != Merged`, but the API query was missing the last two conditions.

## Test plan
- [ ] Verify pending onboardings count matches Google Sheet monitoring
- [ ] Confirm companies with kycLevel < 30 no longer appear in pending list
- [ ] Confirm merged userData entries no longer appear in pending list