### PR TITLE
fix: reset stuck Scrypt/EUR redundancy pipeline 59525

### DIFF
--- a/migration/1775743017000-ResetStuckScryptEurAndBtcPipelines.js
+++ b/migration/1775743017000-ResetStuckScryptEurAndBtcPipelines.js
@@ -1,22 +1,14 @@
 // Reset stuck Scrypt/EUR redundancy pipeline 59525 (rule 313).
-// Pipeline 59525: Order 120717 (EUR→USDT sell) trade completed on Scrypt, but order has
-// status 'Completed' instead of 'Complete' (typo from manual fix or external write).
-// checkRunningPipelines compares against enum 'Complete' — mismatch causes pipeline to
-// stay InProgress indefinitely, blocking all Scrypt/EUR redundancy since 2026-04-07.
+// Pipeline 59525: Order 120717 (EUR→USDT sell) completed on 2026-04-07 13:36, but pipeline
+// was never advanced to Complete — stuck InProgress since then, blocking all Scrypt/EUR redundancy.
 // Scrypt/EUR balance is 1.089M EUR vs max 1'000 EUR.
 // Bitcoin rule 79 (Paused) auto-reactivates via reactivationTime=10, no manual fix needed.
-// Root cause fix for the WS reconnect issue: PR #3549.
+// Once rule 313 is Active again, sell-if-deficit will pick up the pending BTC demand
+// (697k CHF from buy_crypto 119330) and sell EUR→BTC on Scrypt.
 module.exports = class ResetStuckScryptEurAndBtcPipelines1775743017000 {
   name = 'ResetStuckScryptEurAndBtcPipelines1775743017000';
 
   async up(queryRunner) {
-    // Fix order 120717: 'Completed' → 'Complete' (enum mismatch)
-    await queryRunner.query(`
-      UPDATE "dbo"."liquidity_management_order"
-      SET "status" = 'Complete', "updated" = GETDATE()
-      WHERE "id" = 120717 AND "status" = 'Completed'
-    `);
-
     // Complete the stuck Scrypt/EUR pipeline 59525
     await queryRunner.query(`
       UPDATE "dbo"."liquidity_management_pipeline"
@@ -37,9 +29,6 @@ module.exports = class ResetStuckScryptEurAndBtcPipelines1775743017000 {
   }
 
   async down(queryRunner) {
-    await queryRunner.query(
-      `UPDATE "dbo"."liquidity_management_order" SET "status" = 'Completed', "updated" = GETDATE() WHERE "id" = 120717`,
-    );
     await queryRunner.query(
       `UPDATE "dbo"."liquidity_management_pipeline" SET "status" = 'InProgress', "currentActionId" = 233, "previousActionId" = 261, "ordersProcessed" = 1, "updated" = GETDATE() WHERE "id" = 59525`,
     );

--- a/migration/1775743017000-ResetStuckScryptEurAndBtcPipelines.js
+++ b/migration/1775743017000-ResetStuckScryptEurAndBtcPipelines.js
@@ -1,0 +1,39 @@
+// Reset stuck Scrypt/EUR redundancy pipeline 59525 (rule 313).
+// Pipeline 59525: Order 120717 (EUR→USDT sell) completed on 2026-04-07 13:36, but pipeline
+// was never advanced to Complete — stuck InProgress since then, blocking all Scrypt/EUR redundancy.
+// Scrypt/EUR balance is 1.089M EUR vs max 1'000 EUR.
+// Bitcoin rule 79 (Paused) auto-reactivates via reactivationTime=10, no manual fix needed.
+// Once rule 313 is Active again, sell-if-deficit will pick up the pending BTC demand
+// (697k CHF from buy_crypto 119330) and sell EUR→BTC on Scrypt.
+module.exports = class ResetStuckScryptEurAndBtcPipelines1775743017000 {
+  name = 'ResetStuckScryptEurAndBtcPipelines1775743017000';
+
+  async up(queryRunner) {
+    // Complete the stuck Scrypt/EUR pipeline 59525
+    await queryRunner.query(`
+      UPDATE "dbo"."liquidity_management_pipeline"
+      SET "status" = 'Complete',
+          "currentActionId" = NULL,
+          "previousActionId" = 233,
+          "ordersProcessed" = 2,
+          "updated" = GETDATE()
+      WHERE "id" = 59525 AND "status" = 'InProgress'
+    `);
+
+    // Reactivate Scrypt/EUR rule 313 (Processing → Active)
+    await queryRunner.query(`
+      UPDATE "dbo"."liquidity_management_rule"
+      SET "status" = 'Active', "updated" = GETDATE()
+      WHERE "id" = 313 AND "status" = 'Processing'
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(
+      `UPDATE "dbo"."liquidity_management_pipeline" SET "status" = 'InProgress', "currentActionId" = 233, "previousActionId" = 261, "ordersProcessed" = 1, "updated" = GETDATE() WHERE "id" = 59525`,
+    );
+    await queryRunner.query(
+      `UPDATE "dbo"."liquidity_management_rule" SET "status" = 'Processing', "updated" = GETDATE() WHERE "id" = 313`,
+    );
+  }
+};

--- a/migration/1775743017000-ResetStuckScryptEurAndBtcPipelines.js
+++ b/migration/1775743017000-ResetStuckScryptEurAndBtcPipelines.js
@@ -1,14 +1,22 @@
 // Reset stuck Scrypt/EUR redundancy pipeline 59525 (rule 313).
-// Pipeline 59525: Order 120717 (EUR→USDT sell) completed on 2026-04-07 13:36, but pipeline
-// was never advanced to Complete — stuck InProgress since then, blocking all Scrypt/EUR redundancy.
+// Pipeline 59525: Order 120717 (EUR→USDT sell) trade completed on Scrypt, but order has
+// status 'Completed' instead of 'Complete' (typo from manual fix or external write).
+// checkRunningPipelines compares against enum 'Complete' — mismatch causes pipeline to
+// stay InProgress indefinitely, blocking all Scrypt/EUR redundancy since 2026-04-07.
 // Scrypt/EUR balance is 1.089M EUR vs max 1'000 EUR.
 // Bitcoin rule 79 (Paused) auto-reactivates via reactivationTime=10, no manual fix needed.
-// Once rule 313 is Active again, sell-if-deficit will pick up the pending BTC demand
-// (697k CHF from buy_crypto 119330) and sell EUR→BTC on Scrypt.
+// Root cause fix for the WS reconnect issue: PR #3549.
 module.exports = class ResetStuckScryptEurAndBtcPipelines1775743017000 {
   name = 'ResetStuckScryptEurAndBtcPipelines1775743017000';
 
   async up(queryRunner) {
+    // Fix order 120717: 'Completed' → 'Complete' (enum mismatch)
+    await queryRunner.query(`
+      UPDATE "dbo"."liquidity_management_order"
+      SET "status" = 'Complete', "updated" = GETDATE()
+      WHERE "id" = 120717 AND "status" = 'Completed'
+    `);
+
     // Complete the stuck Scrypt/EUR pipeline 59525
     await queryRunner.query(`
       UPDATE "dbo"."liquidity_management_pipeline"
@@ -29,6 +37,9 @@ module.exports = class ResetStuckScryptEurAndBtcPipelines1775743017000 {
   }
 
   async down(queryRunner) {
+    await queryRunner.query(
+      `UPDATE "dbo"."liquidity_management_order" SET "status" = 'Completed', "updated" = GETDATE() WHERE "id" = 120717`,
+    );
     await queryRunner.query(
       `UPDATE "dbo"."liquidity_management_pipeline" SET "status" = 'InProgress', "currentActionId" = 233, "previousActionId" = 261, "ordersProcessed" = 1, "updated" = GETDATE() WHERE "id" = 59525`,
     );


### PR DESCRIPTION
## Summary
- Pipeline 59525 (Scrypt/EUR rule 313): Order 120717 (EUR→USDT sell) completed on 2026-04-07 13:36 but pipeline was never advanced to Complete — stuck InProgress, blocking all Scrypt/EUR redundancy
- Scrypt/EUR balance: **1.089M EUR** vs max 1'000 EUR
- Sets pipeline to Complete and rule 313 to Active
- Unblocks sell-if-deficit flow to sell EUR→BTC on Scrypt for buy_crypto 119330 (755k EUR / ~12 BTC)
- Bitcoin rule 79 (Paused) auto-reactivates via `reactivationTime=10`, no manual fix needed

## Test plan
- [ ] Verify pipeline 59525 status changes to Complete
- [ ] Verify rule 313 status changes to Active
- [ ] Monitor that new Scrypt/EUR redundancy pipeline is created
- [ ] Monitor that sell-if-deficit detects BTC pending demand and sells EUR→BTC