### PR TITLE
Cap Scrypt fiat buy orders at 200k for CHF/EUR

### DIFF
--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -157,7 +157,8 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     const maxSellAmount = Util.floor(order.maxAmount * price, 6);
 
     const availableBalance = await this.getAvailableTradeBalance(tradeAsset, targetAssetEntity.dexName);
-    const effectiveMax = Math.min(maxSellAmount, availableBalance);
+    const fiatOrderCap = ['CHF', 'EUR'].includes(tradeAsset) ? 200_000 : Infinity;
+    const effectiveMax = Math.min(maxSellAmount, availableBalance, fiatOrderCap);
 
     if (effectiveMax < minSellAmount) {
       throw new OrderNotProcessableException(


### PR DESCRIPTION
## Summary
- Limits individual Scrypt buy order size to 200,000 when the trade asset is CHF or EUR
- Remaining amounts are automatically processed in subsequent liquidity management cycles (rule check runs every minute)
- Only affects the `buy` command — `sell` and `sell-if-deficit` are unchanged

## Test plan
- [ ] Verify buy orders with CHF/EUR > 200k are capped at 200k
- [ ] Verify buy orders with CHF/EUR <= 200k are unaffected
- [ ] Verify buy orders with other trade assets (e.g. USDT) are unaffected
- [ ] Verify remaining deficit is picked up in the next LM cycle