### PR TITLE
fix: prevent Spark SDK crash from killing API process

### DIFF
--- a/src/integration/blockchain/spark/spark-client.ts
+++ b/src/integration/blockchain/spark/spark-client.ts
@@ -148,18 +148,36 @@ export class SparkClient extends BlockchainClient {
 
   // --- WALLET INITIALIZATION --- //
 
-  private initializeWallet(): Promise<SparkWallet> {
-    return SparkWallet.initialize({
-      mnemonicOrSeed: GetConfig().blockchain.spark.sparkWalletSeed,
-      accountNumber: 0,
-      options: {
-        network: 'MAINNET',
-        tokenOptimizationOptions: { enabled: false },
-      },
-    }).then(({ wallet }) => {
-      wallet.on('stream:disconnected', () => this.reconnectWallet());
-      return this.syncLeaves(wallet);
-    });
+  private async initializeWallet(): Promise<SparkWallet> {
+    const maxRetries = 5;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const { wallet } = await SparkWallet.initialize({
+          mnemonicOrSeed: GetConfig().blockchain.spark.sparkWalletSeed,
+          accountNumber: 0,
+          options: {
+            network: 'MAINNET',
+            tokenOptimizationOptions: { enabled: false },
+          },
+        });
+
+        wallet.on('stream:disconnected', () => this.reconnectWallet());
+
+        return await this.syncLeaves(wallet);
+      } catch (e) {
+        const delay = Math.min(1000 * 2 ** attempt, 30_000);
+        this.logger.warn(
+          `Spark wallet initialization failed (attempt ${attempt}/${maxRetries}), retrying in ${delay / 1000}s: ${e.message}`,
+        );
+
+        if (attempt === maxRetries) throw e;
+
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    throw new Error('Spark wallet initialization failed after all retries');
   }
 
   private startTokenOptimization(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,18 @@ import {
 import { PaymentWebhookDto } from './subdomains/generic/user/services/webhook/dto/payment-webhook.dto';
 import { PricingService } from './subdomains/supporting/pricing/services/pricing.service';
 
+process.on('uncaughtException', (error) => {
+  const logger = new DfxLogger('UncaughtException');
+
+  if (error?.constructor?.name?.includes('Spark') || error?.message?.includes('Channel has been shut down')) {
+    logger.error('Spark SDK uncaught exception (process kept alive):', error);
+    return;
+  }
+
+  logger.error('Uncaught exception, shutting down:', error);
+  process.exit(1);
+});
+
 async function bootstrap() {
   if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
     AppInsights.setup().setAutoDependencyCorrelation(true).setAutoCollectConsole(true, true);


### PR DESCRIPTION
## Summary
- Add retry logic with exponential backoff (5 attempts, 2s–30s) to `SparkClient.initializeWallet()` so transient Spark network failures don't immediately propagate
- Add global `uncaughtException` handler in `main.ts` that catches Spark SDK WASM-layer crashes (`SparkAuthenticationError`) without terminating the Node.js process
- All non-Spark uncaught exceptions still terminate the process as before

## Context
PRD API crashed at 2026-04-09 20:22 UTC because the Spark gRPC server became unreachable (HTTP 526). The `@buildonspark/spark-sdk` threw a `SparkAuthenticationError` from its native WASM layer during wallet re-initialization, which bypassed all try/catch blocks and killed the Node.js process with exit code 7. Azure App Service then entered a restart loop because each cold start hit the same Spark failure within the 230s startup timeout.

## Test plan
- [ ] Verify API starts successfully even when Spark gRPC is unreachable
- [ ] Verify Spark operations return errors gracefully when Spark is down
- [ ] Verify API reconnects to Spark automatically once the gRPC server recovers
- [ ] Verify non-Spark uncaught exceptions still crash the process as expected