### PR TITLE
fix: add timeout and recovery to Spark wallet initialization

### DIFF
--- a/src/integration/blockchain/spark/spark-client.ts
+++ b/src/integration/blockchain/spark/spark-client.ts
@@ -44,6 +44,8 @@ export interface SparkFeeEstimate {
 }
 
 export class SparkClient extends BlockchainClient {
+  private static readonly INIT_TIMEOUT_MS = 60_000;
+
   private readonly logger = new DfxLogger(SparkClient);
 
   private wallet: AsyncField<SparkWallet>;
@@ -57,6 +59,13 @@ export class SparkClient extends BlockchainClient {
     this.wallet = new AsyncField(() => this.initializeWallet(), true);
     this.cachedAddress = new AsyncField(() => this.wallet.then((w) => w.getSparkAddress()), true);
     this.startTokenOptimization();
+  }
+
+  resetWallet(): void {
+    this.logger.warn('Spark wallet reset triggered externally');
+    this.wallet.reset();
+    this.cachedAddress.reset();
+    this.reconnectWallet();
   }
 
   private async call<T>(operation: (wallet: SparkWallet) => Promise<T>): Promise<T> {
@@ -153,14 +162,7 @@ export class SparkClient extends BlockchainClient {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        const { wallet } = await SparkWallet.initialize({
-          mnemonicOrSeed: GetConfig().blockchain.spark.sparkWalletSeed,
-          accountNumber: 0,
-          options: {
-            network: 'MAINNET',
-            tokenOptimizationOptions: { enabled: false },
-          },
-        });
+        const wallet = await this.initializeWithTimeout();
 
         wallet.on('stream:disconnected', () => this.reconnectWallet());
 
@@ -178,6 +180,32 @@ export class SparkClient extends BlockchainClient {
     }
 
     throw new Error('Spark wallet initialization failed after all retries');
+  }
+
+  private initializeWithTimeout(): Promise<SparkWallet> {
+    return new Promise<SparkWallet>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`Spark wallet initialization timed out after ${SparkClient.INIT_TIMEOUT_MS / 1000}s`)),
+        SparkClient.INIT_TIMEOUT_MS,
+      );
+
+      SparkWallet.initialize({
+        mnemonicOrSeed: GetConfig().blockchain.spark.sparkWalletSeed,
+        accountNumber: 0,
+        options: {
+          network: 'MAINNET',
+          tokenOptimizationOptions: { enabled: false },
+        },
+      })
+        .then(({ wallet }) => {
+          clearTimeout(timer);
+          resolve(wallet);
+        })
+        .catch((e) => {
+          clearTimeout(timer);
+          reject(e);
+        });
+    });
   }
 
   private startTokenOptimization(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,10 @@ import { PricingService } from './subdomains/supporting/pricing/services/pricing
 process.on('uncaughtException', (error) => {
   const logger = new DfxLogger('UncaughtException');
 
-  if (error?.constructor?.name?.includes('Spark') || error?.message?.includes('Channel has been shut down')) {
+  const isSparkError =
+    error?.constructor?.name?.includes('Spark') || error?.message?.includes('Channel has been shut down');
+
+  if (isSparkError) {
     logger.error('Spark SDK uncaught exception (process kept alive):', error);
     return;
   }


### PR DESCRIPTION
## Summary
- Add 60s timeout per `SparkWallet.initialize()` attempt — if the SDK promise hangs due to a WASM-layer crash, the timeout rejects and the retry loop continues
- Extract `initializeWithTimeout()` to race SDK initialization against a timer
- Add `resetWallet()` method for external recovery (e.g. from uncaughtException handler)
- Minor readability improvement to uncaughtException handler

## Context
Follow-up to #3561. The Spark SDK can throw `SparkAuthenticationError` from a gRPC timer callback (outside the Promise chain), which the `uncaughtException` handler catches. However, `SparkWallet.initialize()` remains as an unresolved promise, causing all subsequent `await this.wallet` calls to hang forever. The timeout ensures the retry loop can recover from this state.

## Test plan
- [ ] Verify API starts when Spark is unreachable (wallet retries with timeout, API serves other endpoints)
- [ ] Verify Spark reconnects automatically once gRPC server recovers
- [ ] Verify `resetWallet()` triggers re-initialization