### PR TITLE
fix: add unhandledRejection handler and fix Polygon init crash

### DIFF
--- a/src/integration/blockchain/polygon/polygon-client.ts
+++ b/src/integration/blockchain/polygon/polygon-client.ts
@@ -33,7 +33,9 @@ export class PolygonClient extends EvmClient implements L2BridgeEvmClient {
     const { polygonWalletAddress } = GetConfig().blockchain.polygon;
 
     this.posClient = new POSClient();
-    void this.initPolygonNetwork(ethWalletAddress, polygonWalletAddress);
+    this.initPolygonNetwork(ethWalletAddress, polygonWalletAddress).catch((e) =>
+      this.logger.error('Polygon network initialization failed:', e),
+    );
 
     this.l2TxIdCache = new Set();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,14 @@ process.on('uncaughtException', (error) => {
   process.exit(1);
 });
 
+process.on('unhandledRejection', (reason) => {
+  const logger = new DfxLogger('UnhandledRejection');
+  logger.error(
+    'Unhandled promise rejection (process kept alive):',
+    reason instanceof Error ? reason : new Error(String(reason)),
+  );
+});
+
 async function bootstrap() {
   if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
     AppInsights.setup().setAutoDependencyCorrelation(true).setAutoCollectConsole(true, true);


### PR DESCRIPTION
## Summary
- Add global `unhandledRejection` handler in `main.ts` to prevent process crashes from escaped promise rejections (Node 22 defaults to `--unhandled-rejections=throw`)
- Fix Polygon `POSClient` fire-and-forget initialization (`void`) that would crash the process if the RPC endpoint is unreachable at startup

## Context
Follow-up to #3562 — after the Spark SDK crash, audit revealed two additional crash vectors from external SDKs:
1. **No `unhandledRejection` handler**: Any SDK that rejects a promise outside a `.catch()` chain kills the process
2. **Polygon `void` init**: `void this.initPolygonNetwork(...)` silently discards the promise, making any rejection unhandled

## Test plan
- [ ] Verify build passes
- [ ] Verify API starts correctly in DEV
- [ ] Check AppInsights for `UnhandledRejection` log entries after deploy