### PR TITLE
feat: add Starknet blockchain integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "rxjs": "^7.8.2",
         "sanitize-html": "^2.17.0",
         "secp256k1": "^5.0.1",
+        "starknet": "^9.4.2",
         "swagger-ui-express": "^4.6.3",
         "swissqrbill": "^4.2.0",
         "transliteration": "^2.3.5",
@@ -7886,6 +7887,58 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/starknet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-1.1.0.tgz",
+      "integrity": "sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
@@ -9074,6 +9127,67 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
+      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/ox": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
+      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@starknet-io/starknet-types-010": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
+      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-09": {
+      "name": "@starknet-io/types-js",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.9.2.tgz",
+      "integrity": "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
       "license": "MIT"
     },
     "node_modules/@stricahq/bip32ed25519": {
@@ -10819,6 +10933,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
+      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -11099,6 +11234,53 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "license": "ISC"
+    },
+    "node_modules/abi-wan-kanabi": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz",
+      "integrity": "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==",
+      "license": "ISC",
+      "dependencies": {
+        "ansicolors": "^0.3.2",
+        "cardinal": "^2.1.1",
+        "fs-extra": "^10.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/abi-wan-kanabi/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/abi-wan-kanabi/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/abitype": {
       "version": "1.1.0",
@@ -11470,6 +11652,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "license": "MIT"
     },
     "node_modules/ansis": {
       "version": "3.17.0",
@@ -13297,6 +13485,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
     },
     "node_modules/case-anything": {
       "version": "2.1.13",
@@ -17093,7 +17294,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -21581,6 +21781,12 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lossless-json": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
+      "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -25257,6 +25463,28 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/redeyed/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
@@ -27376,6 +27604,73 @@
         "node": ">=8"
       }
     },
+    "node_modules/starknet": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.4.2.tgz",
+      "integrity": "sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1",
+        "@scure/starknet": "1.1.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "abi-wan-kanabi": "2.2.4",
+        "lossless-json": "^4.2.0",
+        "pako": "^2.0.4",
+        "ts-mixer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/starknet/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/starknet/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/stats-lite": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
@@ -29042,6 +29337,12 @@
         "typescript": "*",
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "rxjs": "^7.8.2",
     "sanitize-html": "^2.17.0",
     "secp256k1": "^5.0.1",
+    "starknet": "^9.4.2",
     "swagger-ui-express": "^4.6.3",
     "swissqrbill": "^4.2.0",
     "transliteration": "^2.3.5",

--- a/scripts/deploy-starknet-account.ts
+++ b/scripts/deploy-starknet-account.ts
@@ -61,7 +61,6 @@ async function deployAccount() {
 
   console.log('Deploying account at:', address);
 
-  // Check balance before deployment
   const account = new Account({ provider, address, signer: privateKey });
 
   try {

--- a/scripts/deploy-starknet-account.ts
+++ b/scripts/deploy-starknet-account.ts
@@ -1,0 +1,116 @@
+/**
+ * Starknet Account Deployment Script
+ *
+ * Deploys an OpenZeppelin Account Contract on Starknet.
+ * Every Starknet account is a smart contract (native account abstraction).
+ *
+ * Usage:
+ *   npx ts-node scripts/deploy-starknet-account.ts [--generate | --deploy]
+ *
+ * Modes:
+ *   --generate   Generate a new key pair and compute the account address
+ *   --deploy     Deploy the account contract (requires funded address)
+ *
+ * Environment variables (for --deploy):
+ *   STARKNET_GATEWAY_URL        RPC endpoint (e.g. Alchemy, Infura)
+ *   STARKNET_WALLET_PRIVATE_KEY Private key (hex, from --generate step)
+ */
+
+import { Account, RpcProvider, CallData, ec, hash } from 'starknet';
+
+// OpenZeppelin Account v0.8.1 class hash on Starknet mainnet
+// Widely used, declared on mainnet, verified via starknet.js docs
+// https://starknetjs.com/docs/6.24.1/guides/create_account
+const OZ_ACCOUNT_CLASS_HASH = '0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f';
+
+async function generateKeys() {
+  // Generate random private key
+  const privateKey = '0x' + Buffer.from(ec.starkCurve.utils.randomPrivateKey()).toString('hex');
+  const publicKey = ec.starkCurve.getStarkKey(privateKey);
+
+  // Compute counterfactual address
+  const constructorCalldata = CallData.compile({ publicKey });
+  const address = hash.calculateContractAddressFromHash(publicKey, OZ_ACCOUNT_CLASS_HASH, constructorCalldata, 0);
+
+  console.log('=== Starknet Account Generated ===\n');
+  console.log('Private Key:', privateKey);
+  console.log('Public Key: ', publicKey);
+  console.log('Address:    ', address);
+  console.log('\n=== Next Steps ===\n');
+  console.log('1. Add to .env:');
+  console.log(`   STARKNET_WALLET_PRIVATE_KEY=${privateKey}`);
+  console.log(`   STARKNET_WALLET_ADDRESS=${address}`);
+  console.log('\n2. Send STRK to the address above (for gas fees, ~0.001 STRK)');
+  console.log('\n3. Run: npx ts-node scripts/deploy-starknet-account.ts --deploy');
+}
+
+async function deployAccount() {
+  const gatewayUrl = process.env.STARKNET_GATEWAY_URL;
+  const privateKey = process.env.STARKNET_WALLET_PRIVATE_KEY;
+
+  if (!gatewayUrl || !privateKey) {
+    console.error('Missing environment variables: STARKNET_GATEWAY_URL, STARKNET_WALLET_PRIVATE_KEY');
+    process.exit(1);
+  }
+
+  const provider = new RpcProvider({ nodeUrl: gatewayUrl });
+  const publicKey = ec.starkCurve.getStarkKey(privateKey);
+  const constructorCalldata = CallData.compile({ publicKey });
+
+  const address = hash.calculateContractAddressFromHash(publicKey, OZ_ACCOUNT_CLASS_HASH, constructorCalldata, 0);
+
+  console.log('Deploying account at:', address);
+
+  // Check balance before deployment
+  const account = new Account({ provider, address, signer: privateKey });
+
+  try {
+    const nonce = await account.getNonce();
+    if (BigInt(nonce) > 0n) {
+      console.log('Account already deployed (nonce > 0). Nothing to do.');
+      return;
+    }
+  } catch {
+    // getNonce fails if account not deployed yet — expected
+  }
+
+  console.log('Sending DEPLOY_ACCOUNT transaction...');
+
+  const deployResponse = await account.deployAccount({
+    classHash: OZ_ACCOUNT_CLASS_HASH,
+    constructorCalldata,
+    addressSalt: publicKey,
+  });
+
+  console.log('Transaction hash:', deployResponse.transaction_hash);
+  console.log('Waiting for confirmation...');
+
+  await provider.waitForTransaction(deployResponse.transaction_hash);
+
+  console.log('\n=== Account Deployed Successfully ===');
+  console.log('Address:', deployResponse.contract_address?.[0] ?? address);
+}
+
+async function main() {
+  const mode = process.argv[2];
+
+  switch (mode) {
+    case '--generate':
+      await generateKeys();
+      break;
+    case '--deploy':
+      await deployAccount();
+      break;
+    default:
+      console.log('Usage: npx ts-node scripts/deploy-starknet-account.ts [--generate | --deploy]');
+      console.log('');
+      console.log('  --generate   Generate key pair and compute account address');
+      console.log('  --deploy     Deploy account contract (requires funded address)');
+      process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error('Error:', e.message);
+  process.exit(1);
+});

--- a/scripts/test-starknet-integration.ts
+++ b/scripts/test-starknet-integration.ts
@@ -1,0 +1,218 @@
+/**
+ * Starknet Integration Test Script
+ *
+ * Tests all read operations against Starknet mainnet using a public RPC node.
+ * Does NOT require env vars or wallet configuration.
+ *
+ * Usage: npx ts-node scripts/test-starknet-integration.ts
+ */
+
+import { RpcProvider, Contract, hash, type Abi } from 'starknet';
+import BigNumber from 'bignumber.js';
+
+// --- CONFIG --- //
+
+// Public Starknet mainnet RPC (no API key needed)
+const PROVIDER = new RpcProvider({});
+
+// Well-known mainnet addresses
+const ETH_TOKEN = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7';
+const STRK_TOKEN = '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
+
+// Known account with activity (Starknet Foundation)
+const TEST_ADDRESS = '0x0518a38a5345118e4e41050fa96b68b56f81e1572a27bae7fceb062fa4206aab';
+
+// Will be set dynamically from a recent block
+let TEST_TX_HASH: string;
+
+const ERC20_ABI: Abi = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    inputs: [{ name: 'account', type: 'felt' }],
+    outputs: [{ name: 'balance', type: 'Uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'decimals',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: 'decimals', type: 'felt' }],
+    stateMutability: 'view',
+  },
+];
+
+// --- HELPERS --- //
+
+function fromWei(amount: string | bigint, decimals = 18): number {
+  return new BigNumber(amount.toString()).div(new BigNumber(10).pow(decimals)).toNumber();
+}
+
+let passed = 0;
+let failed = 0;
+
+async function test(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${e.message}`);
+  }
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+// --- TESTS --- //
+
+async function main() {
+  console.log('=== Starknet Integration Tests (Mainnet) ===\n');
+
+  // 0. Find a real transaction hash from a recent block
+  const recentBlock = await PROVIDER.getBlockWithTxHashes('latest');
+  TEST_TX_HASH = recentBlock.transactions[0];
+  console.log(`Using tx ${TEST_TX_HASH.slice(0, 18)}... from block ${recentBlock.block_number}\n`);
+
+  // 1. Block Height
+  console.log('Block Height:');
+  await test('getBlockLatestAccepted returns valid block number', async () => {
+    const block = await PROVIDER.getBlockLatestAccepted();
+    assert(typeof block.block_number === 'number', `expected number, got ${typeof block.block_number}`);
+    assert(block.block_number > 500000, `block number ${block.block_number} seems too low`);
+    console.log(`    block_number: ${block.block_number}`);
+  });
+
+  // 2. ERC20 Balance — STRK
+  console.log('\nSTRK Balance:');
+  await test('balanceOf returns a valid number for STRK', async () => {
+    const contract = new Contract({ abi: ERC20_ABI, address: STRK_TOKEN, providerOrAccount: PROVIDER });
+    const { balance: rawBalance } = await (contract.call('balanceOf', [TEST_ADDRESS]) as any);
+    const balance = fromWei(rawBalance, 18);
+    assert(typeof balance === 'number', `expected number, got ${typeof balance}`);
+    assert(!isNaN(balance), 'balance is NaN');
+    console.log(`    STRK balance: ${balance}`);
+  });
+
+  // 3. ERC20 Balance — ETH
+  console.log('\nETH Balance:');
+  await test('balanceOf returns a valid number for ETH', async () => {
+    const contract = new Contract({ abi: ERC20_ABI, address: ETH_TOKEN, providerOrAccount: PROVIDER });
+    const { balance: rawBalance } = await (contract.call('balanceOf', [TEST_ADDRESS]) as any);
+    const balance = fromWei(rawBalance, 18);
+    assert(typeof balance === 'number', `expected number, got ${typeof balance}`);
+    assert(!isNaN(balance), 'balance is NaN');
+    console.log(`    ETH balance: ${balance}`);
+  });
+
+  // 4. ERC20 Decimals
+  console.log('\nToken Decimals:');
+  await test('STRK decimals returns 18', async () => {
+    const contract = new Contract({ abi: ERC20_ABI, address: STRK_TOKEN, providerOrAccount: PROVIDER });
+    const result = await contract.call('decimals') as any;
+    assert(Number(result.decimals) === 18, `expected 18, got ${Number(result.decimals)}`);
+  });
+
+  await test('ETH decimals returns 18', async () => {
+    const contract = new Contract({ abi: ERC20_ABI, address: ETH_TOKEN, providerOrAccount: PROVIDER });
+    const result = await contract.call('decimals') as any;
+    assert(Number(result.decimals) === 18, `expected 18, got ${Number(result.decimals)}`);
+  });
+
+  // 5. Transaction Receipt
+  console.log('\nTransaction Receipt:');
+  await test('getTransactionReceipt returns valid receipt', async () => {
+    const receipt = await PROVIDER.getTransactionReceipt(TEST_TX_HASH);
+    assert(receipt.statusReceipt === 'SUCCEEDED', `expected SUCCEEDED, got ${receipt.statusReceipt}`);
+    console.log(`    status: ${receipt.statusReceipt}`);
+  });
+
+  await test('receipt.isSuccess() returns true for confirmed tx', async () => {
+    const receipt = await PROVIDER.getTransactionReceipt(TEST_TX_HASH);
+    assert(receipt.isSuccess() === true, 'isSuccess() returned false');
+  });
+
+  await test('successful receipt has actual_fee and block_number', async () => {
+    const receipt = await PROVIDER.getTransactionReceipt(TEST_TX_HASH);
+    assert(receipt.isSuccess(), 'not successful');
+    const val = receipt.value as any;
+    assert(val.actual_fee !== undefined, 'missing actual_fee');
+    assert(val.block_number !== undefined, 'missing block_number');
+    assert(typeof val.block_number === 'number', `block_number type: ${typeof val.block_number}`);
+    const fee = fromWei(val.actual_fee.amount, 18);
+    console.log(`    fee: ${fee} ETH, block: ${val.block_number}`);
+  });
+
+  // 6. Transaction By Hash
+  console.log('\nTransaction By Hash:');
+  await test('getTransactionByHash returns tx with sender_address', async () => {
+    const tx = await PROVIDER.getTransactionByHash(TEST_TX_HASH);
+    assert('transaction_hash' in tx, 'missing transaction_hash');
+    assert('sender_address' in tx, 'missing sender_address');
+    console.log(`    sender: ${(tx as any).sender_address}`);
+  });
+
+  // 7. isTxComplete logic
+  console.log('\nisTxComplete Logic:');
+  await test('confirmed tx with 0 confirmations returns true', async () => {
+    const receipt = await PROVIDER.getTransactionReceipt(TEST_TX_HASH);
+    const isSuccess = receipt.isSuccess();
+    assert(isSuccess === true, 'tx not successful');
+    // With 0 confirmations, should return true immediately
+  });
+
+  await test('confirmed tx block_number is less than current block', async () => {
+    const receipt = await PROVIDER.getTransactionReceipt(TEST_TX_HASH);
+    assert(receipt.isSuccess(), 'not successful');
+    const txBlock = (receipt.value as any).block_number;
+    const currentBlock = (await PROVIDER.getBlockLatestAccepted()).block_number;
+    assert(currentBlock > txBlock, `current ${currentBlock} should be > tx ${txBlock}`);
+    console.log(`    tx block: ${txBlock}, current: ${currentBlock}, diff: ${currentBlock - txBlock}`);
+  });
+
+  // 8. starknetKeccak
+  console.log('\nSignature Hashing:');
+  await test('starknetKeccak returns a bigint for a string message', async () => {
+    const messageHash = hash.starknetKeccak('test message');
+    assert(typeof messageHash === 'bigint', `expected bigint, got ${typeof messageHash}`);
+    assert(messageHash > 0n, 'hash should be positive');
+    console.log(`    hash("test message"): 0x${messageHash.toString(16).slice(0, 16)}...`);
+  });
+
+  await test('starknetKeccak is deterministic', async () => {
+    const hash1 = hash.starknetKeccak('DFX Swiss');
+    const hash2 = hash.starknetKeccak('DFX Swiss');
+    assert(hash1 === hash2, 'same input should produce same hash');
+  });
+
+  // 9. Contract instantiation
+  console.log('\nContract Instantiation:');
+  await test('Contract with ERC20 ABI can call balanceOf and returns named field', async () => {
+    const contract = new Contract({ abi: ERC20_ABI, address: STRK_TOKEN, providerOrAccount: PROVIDER });
+    const result = await (contract.call('balanceOf', [TEST_ADDRESS]) as any);
+    assert('balance' in result, 'result should have balance field');
+    assert(typeof result.balance === 'bigint', `balance should be bigint, got ${typeof result.balance}`);
+  });
+
+  // 10. Address format validation
+  console.log('\nAddress Format:');
+  await test('starknet address regex matches valid addresses', async () => {
+    const regex = /^0x[0-9a-fA-F]{50,64}$/;
+    assert(regex.test(TEST_ADDRESS), `TEST_ADDRESS should match: ${TEST_ADDRESS}`);
+    assert(regex.test(STRK_TOKEN), `STRK_TOKEN should match: ${STRK_TOKEN}`);
+    assert(regex.test(ETH_TOKEN), `ETH_TOKEN should match: ${ETH_TOKEN}`);
+    assert(!regex.test('0x1234567890abcdef1234567890abcdef12345678'), 'ETH address should NOT match');
+  });
+
+  // --- SUMMARY --- //
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error('Fatal error:', e.message);
+  process.exit(1);
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -166,8 +166,9 @@ export class Configuration {
   tronAddressFormat = 'T[1-9A-HJ-NP-Za-km-z]{32,34}';
   zanoAddressFormat = 'Z[a-zA-Z0-9]{96}|iZ[a-zA-Z0-9]{106}';
   internetComputerPrincipalFormat = '[a-z0-9]{5}(-[a-z0-9]{5})*(-[a-z0-9]{1,5})?';
+  starknetAddressFormat = '0x[0-9a-fA-F]{50,64}';
 
-  allAddressFormat = `${this.bitcoinAddressFormat}|${this.lightningAddressFormat}|${this.sparkAddressFormat}|${this.arkadeAddressFormat}|${this.firoSparkAddressFormat}|${this.firoAddressFormat}|${this.moneroAddressFormat}|${this.ethereumAddressFormat}|${this.liquidAddressFormat}|${this.arweaveAddressFormat}|${this.cardanoAddressFormat}|${this.defichainAddressFormat}|${this.railgunAddressFormat}|${this.solanaAddressFormat}|${this.tronAddressFormat}|${this.zanoAddressFormat}|${this.internetComputerPrincipalFormat}`;
+  allAddressFormat = `${this.bitcoinAddressFormat}|${this.lightningAddressFormat}|${this.sparkAddressFormat}|${this.arkadeAddressFormat}|${this.firoSparkAddressFormat}|${this.firoAddressFormat}|${this.moneroAddressFormat}|${this.ethereumAddressFormat}|${this.liquidAddressFormat}|${this.arweaveAddressFormat}|${this.cardanoAddressFormat}|${this.defichainAddressFormat}|${this.railgunAddressFormat}|${this.solanaAddressFormat}|${this.tronAddressFormat}|${this.zanoAddressFormat}|${this.internetComputerPrincipalFormat}|${this.starknetAddressFormat}`;
 
   masterKeySignatureFormat = '[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}';
   hashSignatureFormat = '[A-Fa-f0-9]{64}';
@@ -185,8 +186,9 @@ export class Configuration {
   tronSignatureFormat = '(0x)?[a-f0-9]{130}';
   zanoSignatureFormat = '[a-f0-9]{128}';
   internetComputerSignatureFormat = '[a-f0-9]{128,144}';
+  starknetSignatureFormat = '0x[0-9a-fA-F]{1,64},0x[0-9a-fA-F]{1,64}';
 
-  allSignatureFormat = `${this.masterKeySignatureFormat}|${this.hashSignatureFormat}|${this.bitcoinSignatureFormat}|${this.lightningSignatureFormat}|${this.lightningCustodialSignatureFormat}|${this.firoSignatureFormat}|${this.firoSparkSignatureFormat}|${this.moneroSignatureFormat}|${this.ethereumSignatureFormat}|${this.arweaveSignatureFormat}|${this.cardanoSignatureFormat}|${this.railgunSignatureFormat}|${this.solanaSignatureFormat}|${this.tronSignatureFormat}|${this.zanoSignatureFormat}|${this.internetComputerSignatureFormat}`;
+  allSignatureFormat = `${this.masterKeySignatureFormat}|${this.hashSignatureFormat}|${this.bitcoinSignatureFormat}|${this.lightningSignatureFormat}|${this.lightningCustodialSignatureFormat}|${this.firoSignatureFormat}|${this.firoSparkSignatureFormat}|${this.moneroSignatureFormat}|${this.ethereumSignatureFormat}|${this.arweaveSignatureFormat}|${this.cardanoSignatureFormat}|${this.railgunSignatureFormat}|${this.solanaSignatureFormat}|${this.tronSignatureFormat}|${this.zanoSignatureFormat}|${this.internetComputerSignatureFormat}|${this.starknetSignatureFormat}`;
 
   arweaveKeyFormat = '[\\w\\-]{683}';
   cardanoKeyFormat = '.*';
@@ -964,6 +966,11 @@ export class Configuration {
       },
       coinId: 'd6329b5b1f7c0805b5c345f4957554002a2f557845f64d7645dae0e051a6498a',
       fee: 0.01,
+    },
+    starknet: {
+      gatewayUrl: process.env.STARKNET_GATEWAY_URL,
+      walletAddress: process.env.STARKNET_WALLET_ADDRESS,
+      walletPrivateKey: process.env.STARKNET_WALLET_PRIVATE_KEY,
     },
     solana: {
       solanaWalletSeed: process.env.SOLANA_WALLET_SEED,

--- a/src/integration/blockchain/blockchain.module.ts
+++ b/src/integration/blockchain/blockchain.module.ts
@@ -37,6 +37,7 @@ import { ArkadeModule } from './arkade/arkade.module';
 import { SparkModule } from './spark/spark.module';
 import { TronModule } from './tron/tron.module';
 import { InternetComputerModule } from './icp/icp.module';
+import { StarknetModule } from './starknet/starknet.module';
 import { ZanoModule } from './zano/zano.module';
 
 @Module({
@@ -66,6 +67,7 @@ import { ZanoModule } from './zano/zano.module';
     ArweaveModule,
     RailgunModule,
     SolanaModule,
+    StarknetModule,
     TronModule,
     CardanoModule,
     InternetComputerModule,
@@ -101,6 +103,7 @@ import { ZanoModule } from './zano/zano.module';
     Ebel2xModule,
     RailgunModule,
     SolanaModule,
+    StarknetModule,
     TronModule,
     CardanoModule,
     InternetComputerModule,

--- a/src/integration/blockchain/shared/enums/blockchain.enum.ts
+++ b/src/integration/blockchain/shared/enums/blockchain.enum.ts
@@ -26,6 +26,7 @@ export enum Blockchain {
   CITREA = 'Citrea',
   CITREA_TESTNET = 'CitreaTestnet',
   BITCOIN_TESTNET4 = 'BitcoinTestnet4',
+  STARKNET = 'Starknet',
 
   // Payment Provider
   BINANCE_PAY = 'BinancePay',

--- a/src/integration/blockchain/shared/services/blockchain-registry.service.ts
+++ b/src/integration/blockchain/shared/services/blockchain-registry.service.ts
@@ -24,6 +24,8 @@ import { PolygonService } from '../../polygon/polygon.service';
 import { SepoliaService } from '../../sepolia/sepolia.service';
 import { SolanaService } from '../../solana/services/solana.service';
 import { SolanaClient } from '../../solana/solana-client';
+import { StarknetService } from '../../starknet/services/starknet.service';
+import { StarknetClient } from '../../starknet/starknet-client';
 import { ArkadeClient } from '../../arkade/arkade-client';
 import { ArkadeService } from '../../arkade/arkade.service';
 import { SparkClient } from '../../spark/spark-client';
@@ -50,7 +52,8 @@ type BlockchainClientType =
   | SolanaClient
   | TronClient
   | CardanoClient
-  | InternetComputerClient;
+  | InternetComputerClient
+  | StarknetClient;
 
 type BlockchainServiceType =
   | EvmService
@@ -64,7 +67,8 @@ type BlockchainServiceType =
   | SolanaService
   | TronService
   | CardanoService
-  | InternetComputerService;
+  | InternetComputerService
+  | StarknetService;
 
 type CoinOnlyServiceType = BlockchainServiceType | LightningService;
 
@@ -103,6 +107,7 @@ export class BlockchainRegistryService {
     private readonly citreaService: CitreaService,
     private readonly citreaTestnetService: CitreaTestnetService,
     private readonly bitcoinTestnet4Service: BitcoinTestnet4Service,
+    private readonly starknetService: StarknetService,
   ) {}
 
   getClient(blockchain: Blockchain): BlockchainClientType {
@@ -181,6 +186,8 @@ export class BlockchainRegistryService {
         return this.citreaService;
       case Blockchain.CITREA_TESTNET:
         return this.citreaTestnetService;
+      case Blockchain.STARKNET:
+        return this.starknetService;
 
       default:
         throw new Error(`No service found for blockchain ${blockchain}`);

--- a/src/integration/blockchain/shared/services/crypto.service.ts
+++ b/src/integration/blockchain/shared/services/crypto.service.ts
@@ -20,6 +20,7 @@ import { MoneroService } from '../../monero/services/monero.service';
 import { SolanaService } from '../../solana/services/solana.service';
 import { SparkService } from '../../spark/spark.service';
 import { TronService } from '../../tron/services/tron.service';
+import { StarknetService } from '../../starknet/services/starknet.service';
 import { ZanoService } from '../../zano/services/zano.service';
 import { Blockchain } from '../enums/blockchain.enum';
 import { EvmUtil } from '../evm/evm.util';
@@ -47,6 +48,7 @@ export class CryptoService {
     private readonly internetComputerService: InternetComputerService,
     private readonly arweaveService: ArweaveService,
     private readonly railgunService: RailgunService,
+    private readonly starknetService: StarknetService,
     private readonly blockchainRegistry: BlockchainRegistryService,
   ) {}
 
@@ -106,6 +108,9 @@ export class CryptoService {
 
       case Blockchain.INTERNET_COMPUTER:
         return this.internetComputerService.getPaymentRequest(address, amount, asset);
+
+      case Blockchain.STARKNET:
+        return this.starknetService.getPaymentRequest(address, amount);
 
       default:
         return undefined;
@@ -176,6 +181,9 @@ export class CryptoService {
       case Blockchain.RAILGUN:
         return UserAddressType.RAILGUN;
 
+      case Blockchain.STARKNET:
+        return UserAddressType.STARKNET;
+
       default:
         return UserAddressType.OTHER;
     }
@@ -202,6 +210,7 @@ export class CryptoService {
     if (CryptoService.isCardanoAddress(address)) return [Blockchain.CARDANO];
     if (CryptoService.isInternetComputerAddress(address)) return [Blockchain.INTERNET_COMPUTER];
     if (CryptoService.isRailgunAddress(address)) return [Blockchain.RAILGUN];
+    if (CryptoService.isStarknetAddress(address)) return [Blockchain.STARKNET];
     if (CryptoService.isDefichainAddress(address)) return [Blockchain.DEFICHAIN];
     return [];
   }
@@ -279,6 +288,10 @@ export class CryptoService {
     return new RegExp(`^(${Config.tronAddressFormat})$`).test(address);
   }
 
+  public static isStarknetAddress(address: string): boolean {
+    return new RegExp(`^(${Config.starknetAddressFormat})$`).test(address);
+  }
+
   private static isDefichainAddress(address: string): boolean {
     return new RegExp(`^(${Config.defichainAddressFormat})$`).test(address);
   }
@@ -315,6 +328,7 @@ export class CryptoService {
       if (detectedBlockchain === Blockchain.INTERNET_COMPUTER)
         return await this.verifyInternetComputer(message, address, signature, key);
       if (detectedBlockchain === Blockchain.RAILGUN) return await this.verifyRailgun(message, address, signature);
+      if (detectedBlockchain === Blockchain.STARKNET) return await this.verifyStarknet(message, address, signature);
     } catch (e) {
       if (e instanceof SignatureException) throw new BadRequestException(e.message);
     }
@@ -444,5 +458,9 @@ export class CryptoService {
 
   private async verifyRailgun(message: string, address: string, signature: string): Promise<boolean> {
     return this.railgunService.verifySignature(message, address, signature);
+  }
+
+  private async verifyStarknet(message: string, address: string, signature: string): Promise<boolean> {
+    return this.starknetService.verifySignature(message, address, signature);
   }
 }

--- a/src/integration/blockchain/shared/util/blockchain.util.ts
+++ b/src/integration/blockchain/shared/util/blockchain.util.ts
@@ -114,7 +114,7 @@ const BlockchainExplorerUrls: { [b in Blockchain]: string } = {
   [Blockchain.CARDANO]: 'https://cardanoscan.io',
   [Blockchain.INTERNET_COMPUTER]: 'https://dashboard.internetcomputer.org',
   [Blockchain.RAILGUN]: 'https://railgun-explorer.com',
-  [Blockchain.STARKNET]: 'https://starkscan.co',
+  [Blockchain.STARKNET]: 'https://voyager.online',
   [Blockchain.BINANCE_PAY]: undefined,
   [Blockchain.KUCOIN_PAY]: undefined,
   [Blockchain.KRAKEN]: undefined,

--- a/src/integration/blockchain/shared/util/blockchain.util.ts
+++ b/src/integration/blockchain/shared/util/blockchain.util.ts
@@ -114,6 +114,7 @@ const BlockchainExplorerUrls: { [b in Blockchain]: string } = {
   [Blockchain.CARDANO]: 'https://cardanoscan.io',
   [Blockchain.INTERNET_COMPUTER]: 'https://dashboard.internetcomputer.org',
   [Blockchain.RAILGUN]: 'https://railgun-explorer.com',
+  [Blockchain.STARKNET]: 'https://starkscan.co',
   [Blockchain.BINANCE_PAY]: undefined,
   [Blockchain.KUCOIN_PAY]: undefined,
   [Blockchain.KRAKEN]: undefined,
@@ -155,6 +156,7 @@ const TxPaths: { [b in Blockchain]: string } = {
   [Blockchain.CARDANO]: 'transaction',
   [Blockchain.INTERNET_COMPUTER]: 'transaction',
   [Blockchain.RAILGUN]: 'transaction',
+  [Blockchain.STARKNET]: 'tx',
   [Blockchain.BINANCE_PAY]: undefined,
   [Blockchain.KUCOIN_PAY]: undefined,
   [Blockchain.KRAKEN]: undefined,
@@ -197,6 +199,7 @@ function assetPaths(asset: Asset): string | undefined {
     case Blockchain.SOLANA:
     case Blockchain.HAQQ:
     case Blockchain.CARDANO:
+    case Blockchain.STARKNET:
       return asset.chainId ? `token/${asset.chainId}` : undefined;
 
     case Blockchain.INTERNET_COMPUTER:
@@ -239,5 +242,8 @@ function addressPaths(blockchain: Blockchain): string | undefined {
     case Blockchain.INTERNET_COMPUTER:
     case Blockchain.SOLANA:
       return 'account';
+
+    case Blockchain.STARKNET:
+      return 'contract';
   }
 }

--- a/src/integration/blockchain/starknet/dto/starknet.dto.ts
+++ b/src/integration/blockchain/starknet/dto/starknet.dto.ts
@@ -1,0 +1,26 @@
+export interface StarknetTransactionDto {
+  blockNumber: number;
+  blockTimestamp: number;
+  txHash: string;
+  from: string;
+  fee: number;
+  destinations: StarknetTransactionDestinationDto[];
+  status: string;
+}
+
+export interface StarknetTransactionDestinationDto {
+  to: string;
+  amount: number;
+  tokenInfo?: {
+    address: string;
+    decimals: number;
+  };
+}
+
+export interface StarknetTokenDto {
+  address: string;
+  contractAddress: string;
+  owner: string;
+  amount: number;
+  decimals: number;
+}

--- a/src/integration/blockchain/starknet/dto/starknet.dto.ts
+++ b/src/integration/blockchain/starknet/dto/starknet.dto.ts
@@ -16,11 +16,3 @@ export interface StarknetTransactionDestinationDto {
     decimals: number;
   };
 }
-
-export interface StarknetTokenDto {
-  address: string;
-  contractAddress: string;
-  owner: string;
-  amount: number;
-  decimals: number;
-}

--- a/src/integration/blockchain/starknet/services/starknet.service.ts
+++ b/src/integration/blockchain/starknet/services/starknet.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { Asset } from 'src/shared/models/asset/asset.entity';
+import { HttpService } from 'src/shared/services/http.service';
+import { Util } from 'src/shared/utils/util';
+import { BlockchainService } from '../../shared/util/blockchain.service';
+import { StarknetTransactionDto } from '../dto/starknet.dto';
+import { StarknetClient } from '../starknet-client';
+
+@Injectable()
+export class StarknetService extends BlockchainService {
+  private readonly client: StarknetClient;
+
+  constructor(private readonly http: HttpService) {
+    super();
+
+    this.client = new StarknetClient(this.http);
+  }
+
+  getDefaultClient(): StarknetClient {
+    return this.client;
+  }
+
+  getWalletAddress(): string {
+    return this.client.walletAddress;
+  }
+
+  async getBlockHeight(): Promise<number> {
+    return this.client.getBlockHeight();
+  }
+
+  async getNativeCoinBalance(): Promise<number> {
+    return this.client.getNativeCoinBalance();
+  }
+
+  async getNativeCoinBalanceForAddress(address: string): Promise<number> {
+    return this.client.getNativeCoinBalanceForAddress(address);
+  }
+
+  async getEthBalance(address?: string): Promise<number> {
+    return this.client.getEthBalance(address);
+  }
+
+  async getTokenBalance(asset: Asset, address?: string): Promise<number> {
+    return this.client.getTokenBalance(asset, address ?? this.client.walletAddress);
+  }
+
+  async sendNativeCoin(toAddress: string, amount: number): Promise<string> {
+    return this.client.sendNativeCoin(toAddress, amount);
+  }
+
+  async sendEth(toAddress: string, amount: number): Promise<string> {
+    return this.client.sendEth(toAddress, amount);
+  }
+
+  async sendToken(toAddress: string, token: Asset, amount: number): Promise<string> {
+    return this.client.sendToken(toAddress, token, amount);
+  }
+
+  async isTxComplete(txHash: string, confirmations?: number): Promise<boolean> {
+    return this.client.isTxComplete(txHash, confirmations);
+  }
+
+  async getTransaction(txHash: string): Promise<StarknetTransactionDto> {
+    return this.client.getTransaction(txHash);
+  }
+
+  async getTxActualFee(txHash: string): Promise<number> {
+    return this.client.getTxActualFee(txHash);
+  }
+
+  async getCurrentGasCostForCoinTransaction(): Promise<number> {
+    return this.client.getCurrentGasCostForCoinTransaction();
+  }
+
+  getPaymentRequest(address: string, amount: number): string {
+    return `starknet:${address}?amount=${Util.numberToFixedString(amount)}`;
+  }
+}

--- a/src/integration/blockchain/starknet/services/starknet.service.ts
+++ b/src/integration/blockchain/starknet/services/starknet.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { Asset } from 'src/shared/models/asset/asset.entity';
-import { HttpService } from 'src/shared/services/http.service';
 import { Util } from 'src/shared/utils/util';
 import { BlockchainService } from '../../shared/util/blockchain.service';
 import { StarknetTransactionDto } from '../dto/starknet.dto';
@@ -10,10 +9,10 @@ import { StarknetClient } from '../starknet-client';
 export class StarknetService extends BlockchainService {
   private readonly client: StarknetClient;
 
-  constructor(private readonly http: HttpService) {
+  constructor() {
     super();
 
-    this.client = new StarknetClient(this.http);
+    this.client = new StarknetClient();
   }
 
   getDefaultClient(): StarknetClient {

--- a/src/integration/blockchain/starknet/services/starknet.service.ts
+++ b/src/integration/blockchain/starknet/services/starknet.service.ts
@@ -72,6 +72,10 @@ export class StarknetService extends BlockchainService {
     return this.client.getCurrentGasCostForCoinTransaction();
   }
 
+  async verifySignature(message: string, address: string, signature: string): Promise<boolean> {
+    return this.client.verifySignature(message, address, signature);
+  }
+
   getPaymentRequest(address: string, amount: number): string {
     return `starknet:${address}?amount=${Util.numberToFixedString(amount)}`;
   }

--- a/src/integration/blockchain/starknet/starknet-client.ts
+++ b/src/integration/blockchain/starknet/starknet-client.ts
@@ -110,16 +110,16 @@ export class StarknetClient extends BlockchainClient {
   async isTxComplete(txHash: string, confirmations = 0): Promise<boolean> {
     const receipt = await this.provider.getTransactionReceipt(txHash);
 
-    if (receipt.statusReceipt === 'REVERTED' || receipt.statusReceipt === 'ERROR') {
-      throw new Error(`Transaction ${txHash} has failed: ${receipt.statusReceipt}`);
+    if (!receipt.isSuccess()) {
+      if (receipt.statusReceipt === 'REVERTED' || receipt.statusReceipt === 'ERROR') {
+        throw new Error(`Transaction ${txHash} has failed: ${receipt.statusReceipt}`);
+      }
+      return false;
     }
-
-    if (receipt.statusReceipt !== 'SUCCEEDED') return false;
 
     if (confirmations === 0) return true;
 
-    const successReceipt = receipt as any;
-    const txBlock = successReceipt.block_number;
+    const txBlock = receipt.value.block_number;
     if (!txBlock) return false;
 
     const currentBlock = await this.getBlockHeight();
@@ -179,16 +179,19 @@ export class StarknetClient extends BlockchainClient {
     const tx = await this.provider.getTransactionByHash(txHash);
     const receipt = await this.provider.getTransactionReceipt(txHash);
 
-    const successReceipt = receipt as any;
-    const fee = successReceipt.actual_fee
-      ? StarknetUtil.fromWeiAmount(successReceipt.actual_fee.amount, StarknetUtil.ethDecimals)
-      : 0;
+    let fee = 0;
+    let blockNumber = 0;
+
+    if (receipt.isSuccess()) {
+      fee = StarknetUtil.fromWeiAmount(receipt.value.actual_fee.amount, StarknetUtil.ethDecimals);
+      blockNumber = receipt.value.block_number;
+    }
 
     return {
-      blockNumber: successReceipt.block_number ?? 0,
+      blockNumber,
       blockTimestamp: 0,
       txHash: tx.transaction_hash,
-      from: (tx as any).sender_address ?? '',
+      from: 'sender_address' in tx ? (tx.sender_address as string) : '',
       fee,
       destinations: [],
       status: receipt.statusReceipt,
@@ -197,10 +200,10 @@ export class StarknetClient extends BlockchainClient {
 
   async getTxActualFee(txHash: string): Promise<number> {
     const receipt = await this.provider.getTransactionReceipt(txHash);
-    const successReceipt = receipt as any;
-    return successReceipt.actual_fee
-      ? StarknetUtil.fromWeiAmount(successReceipt.actual_fee.amount, StarknetUtil.ethDecimals)
-      : 0;
+
+    if (!receipt.isSuccess()) return 0;
+
+    return StarknetUtil.fromWeiAmount(receipt.value.actual_fee.amount, StarknetUtil.ethDecimals);
   }
 
   async getCurrentGasCostForCoinTransaction(): Promise<number> {

--- a/src/integration/blockchain/starknet/starknet-client.ts
+++ b/src/integration/blockchain/starknet/starknet-client.ts
@@ -1,0 +1,216 @@
+import { Account, Contract, RpcProvider, CallData, type Abi } from 'starknet';
+import { GetConfig } from 'src/config/config';
+import { Asset } from 'src/shared/models/asset/asset.entity';
+import { HttpService } from 'src/shared/services/http.service';
+import { BlockchainTokenBalance } from '../shared/dto/blockchain-token-balance.dto';
+import { BlockchainSignedTransactionResponse } from '../shared/dto/signed-transaction-reponse.dto';
+import { BlockchainClient } from '../shared/util/blockchain-client';
+import { StarknetTransactionDto } from './dto/starknet.dto';
+import { StarknetUtil } from './starknet.util';
+
+const ERC20_ABI: Abi = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    inputs: [{ name: 'account', type: 'felt' }],
+    outputs: [{ name: 'balance', type: 'Uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'transfer',
+    type: 'function',
+    inputs: [
+      { name: 'recipient', type: 'felt' },
+      { name: 'amount', type: 'Uint256' },
+    ],
+    outputs: [{ name: 'success', type: 'felt' }],
+  },
+  {
+    name: 'decimals',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: 'decimals', type: 'felt' }],
+    stateMutability: 'view',
+  },
+];
+
+// Well-known contract addresses on Starknet mainnet
+const ETH_TOKEN_ADDRESS = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7';
+const STRK_TOKEN_ADDRESS = '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
+
+export class StarknetClient extends BlockchainClient {
+  private readonly provider: RpcProvider;
+  private readonly account: Account;
+  private readonly address: string;
+
+  constructor(private readonly http: HttpService) {
+    super();
+
+    const { gatewayUrl, walletAddress, walletPrivateKey } = GetConfig().blockchain.starknet;
+
+    this.provider = new RpcProvider({ nodeUrl: gatewayUrl });
+    this.address = walletAddress;
+    this.account = new Account({ provider: this.provider, address: walletAddress, signer: walletPrivateKey });
+  }
+
+  get walletAddress(): string {
+    return this.address;
+  }
+
+  async getBlockHeight(): Promise<number> {
+    const block = await this.provider.getBlockLatestAccepted();
+    return block.block_number;
+  }
+
+  // --- Balance Methods --- //
+
+  async getNativeCoinBalance(): Promise<number> {
+    return this.getNativeCoinBalanceForAddress(this.walletAddress);
+  }
+
+  async getNativeCoinBalanceForAddress(address: string): Promise<number> {
+    return this.getErc20Balance(STRK_TOKEN_ADDRESS, address, StarknetUtil.strkDecimals);
+  }
+
+  async getEthBalance(address?: string): Promise<number> {
+    return this.getErc20Balance(ETH_TOKEN_ADDRESS, address ?? this.walletAddress, StarknetUtil.ethDecimals);
+  }
+
+  async getTokenBalance(asset: Asset, address?: string): Promise<number> {
+    const owner = address ?? this.walletAddress;
+    const contractAddress = asset.chainId;
+    if (!contractAddress) return 0;
+
+    return this.getErc20Balance(contractAddress, owner, asset.decimals);
+  }
+
+  async getTokenBalances(assets: Asset[], address?: string): Promise<BlockchainTokenBalance[]> {
+    const owner = address ?? this.walletAddress;
+    const balances: BlockchainTokenBalance[] = [];
+
+    for (const asset of assets) {
+      const contractAddress = asset.chainId;
+      if (!contractAddress) continue;
+
+      const balance = await this.getErc20Balance(contractAddress, owner, asset.decimals);
+      balances.push({ owner, contractAddress, balance });
+    }
+
+    return balances;
+  }
+
+  private async getErc20Balance(contractAddress: string, owner: string, decimals: number): Promise<number> {
+    const contract = new Contract({ abi: ERC20_ABI, address: contractAddress, providerOrAccount: this.provider });
+    const result = await contract.call('balanceOf', [owner]);
+    return StarknetUtil.fromWeiAmount(result.toString(), decimals);
+  }
+
+  // --- Transaction Methods --- //
+
+  async isTxComplete(txHash: string, confirmations = 0): Promise<boolean> {
+    const receipt = await this.provider.getTransactionReceipt(txHash);
+
+    if (receipt.statusReceipt === 'REVERTED' || receipt.statusReceipt === 'ERROR') {
+      throw new Error(`Transaction ${txHash} has failed: ${receipt.statusReceipt}`);
+    }
+
+    if (receipt.statusReceipt !== 'SUCCEEDED') return false;
+
+    if (confirmations === 0) return true;
+
+    const successReceipt = receipt as any;
+    const txBlock = successReceipt.block_number;
+    if (!txBlock) return false;
+
+    const currentBlock = await this.getBlockHeight();
+    return currentBlock - txBlock >= confirmations;
+  }
+
+  async sendSignedTransaction(tx: string): Promise<BlockchainSignedTransactionResponse> {
+    try {
+      const parsedTx = JSON.parse(tx);
+      const result = await this.provider.invokeFunction(parsedTx, parsedTx.details);
+      return { hash: result.transaction_hash };
+    } catch (e) {
+      return { error: { message: e.message } };
+    }
+  }
+
+  // --- Send Methods --- //
+
+  async sendNativeCoin(toAddress: string, amount: number): Promise<string> {
+    return this.sendErc20(STRK_TOKEN_ADDRESS, toAddress, amount, StarknetUtil.strkDecimals);
+  }
+
+  async sendEth(toAddress: string, amount: number): Promise<string> {
+    return this.sendErc20(ETH_TOKEN_ADDRESS, toAddress, amount, StarknetUtil.ethDecimals);
+  }
+
+  async sendToken(toAddress: string, asset: Asset, amount: number): Promise<string> {
+    const contractAddress = asset.chainId;
+    if (!contractAddress) throw new Error(`No contract address for token ${asset.uniqueName}`);
+
+    const decimals = asset.decimals;
+    if (!decimals) throw new Error(`No decimals for token ${asset.uniqueName}`);
+
+    return this.sendErc20(contractAddress, toAddress, amount, decimals);
+  }
+
+  private async sendErc20(
+    contractAddress: string,
+    toAddress: string,
+    amount: number,
+    decimals: number,
+  ): Promise<string> {
+    const weiAmount = StarknetUtil.toWeiAmount(amount, decimals);
+
+    const result = await this.account.execute({
+      contractAddress,
+      entrypoint: 'transfer',
+      calldata: CallData.compile({ recipient: toAddress, amount: { low: weiAmount, high: 0n } }),
+    });
+
+    return result.transaction_hash;
+  }
+
+  // --- Query Methods --- //
+
+  async getTransaction(txHash: string): Promise<StarknetTransactionDto> {
+    const tx = await this.provider.getTransactionByHash(txHash);
+    const receipt = await this.provider.getTransactionReceipt(txHash);
+
+    const successReceipt = receipt as any;
+    const fee = successReceipt.actual_fee
+      ? StarknetUtil.fromWeiAmount(successReceipt.actual_fee.amount, StarknetUtil.ethDecimals)
+      : 0;
+
+    return {
+      blockNumber: successReceipt.block_number ?? 0,
+      blockTimestamp: 0,
+      txHash: tx.transaction_hash,
+      from: (tx as any).sender_address ?? '',
+      fee,
+      destinations: [],
+      status: receipt.statusReceipt,
+    };
+  }
+
+  async getTxActualFee(txHash: string): Promise<number> {
+    const receipt = await this.provider.getTransactionReceipt(txHash);
+    const successReceipt = receipt as any;
+    return successReceipt.actual_fee
+      ? StarknetUtil.fromWeiAmount(successReceipt.actual_fee.amount, StarknetUtil.ethDecimals)
+      : 0;
+  }
+
+  async getCurrentGasCostForCoinTransaction(): Promise<number> {
+    const estimateFee = await this.account.estimateInvokeFee({
+      contractAddress: STRK_TOKEN_ADDRESS,
+      entrypoint: 'transfer',
+      calldata: CallData.compile({ recipient: this.walletAddress, amount: { low: 1n, high: 0n } }),
+    });
+
+    const fee = StarknetUtil.fromWeiAmount(estimateFee.overall_fee.toString(), StarknetUtil.ethDecimals);
+    return fee * 1.2;
+  }
+}

--- a/src/integration/blockchain/starknet/starknet-client.ts
+++ b/src/integration/blockchain/starknet/starknet-client.ts
@@ -1,7 +1,6 @@
-import { Account, Contract, RpcProvider, CallData, type Abi } from 'starknet';
+import { Account, Contract, RpcProvider, CallData, hash, type Abi } from 'starknet';
 import { GetConfig } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
-import { HttpService } from 'src/shared/services/http.service';
 import { BlockchainTokenBalance } from '../shared/dto/blockchain-token-balance.dto';
 import { BlockchainSignedTransactionResponse } from '../shared/dto/signed-transaction-reponse.dto';
 import { BlockchainClient } from '../shared/util/blockchain-client';
@@ -43,7 +42,7 @@ export class StarknetClient extends BlockchainClient {
   private readonly account: Account;
   private readonly address: string;
 
-  constructor(private readonly http: HttpService) {
+  constructor() {
     super();
 
     const { gatewayUrl, walletAddress, walletPrivateKey } = GetConfig().blockchain.starknet;
@@ -62,7 +61,7 @@ export class StarknetClient extends BlockchainClient {
     return block.block_number;
   }
 
-  // --- Balance Methods --- //
+  // --- BALANCES --- //
 
   async getNativeCoinBalance(): Promise<number> {
     return this.getNativeCoinBalanceForAddress(this.walletAddress);
@@ -78,10 +77,9 @@ export class StarknetClient extends BlockchainClient {
 
   async getTokenBalance(asset: Asset, address?: string): Promise<number> {
     const owner = address ?? this.walletAddress;
-    const contractAddress = asset.chainId;
-    if (!contractAddress) return 0;
+    if (!asset.chainId) return 0;
 
-    return this.getErc20Balance(contractAddress, owner, asset.decimals);
+    return this.getErc20Balance(asset.chainId, owner, asset.decimals);
   }
 
   async getTokenBalances(assets: Asset[], address?: string): Promise<BlockchainTokenBalance[]> {
@@ -89,11 +87,10 @@ export class StarknetClient extends BlockchainClient {
     const balances: BlockchainTokenBalance[] = [];
 
     for (const asset of assets) {
-      const contractAddress = asset.chainId;
-      if (!contractAddress) continue;
+      if (!asset.chainId) continue;
 
-      const balance = await this.getErc20Balance(contractAddress, owner, asset.decimals);
-      balances.push({ owner, contractAddress, balance });
+      const balance = await this.getErc20Balance(asset.chainId, owner, asset.decimals);
+      balances.push({ owner, contractAddress: asset.chainId, balance });
     }
 
     return balances;
@@ -105,7 +102,7 @@ export class StarknetClient extends BlockchainClient {
     return StarknetUtil.fromWeiAmount(result.toString(), decimals);
   }
 
-  // --- Transaction Methods --- //
+  // --- TRANSACTIONS --- //
 
   async isTxComplete(txHash: string, confirmations = 0): Promise<boolean> {
     const receipt = await this.provider.getTransactionReceipt(txHash);
@@ -135,45 +132,6 @@ export class StarknetClient extends BlockchainClient {
       return { error: { message: e.message } };
     }
   }
-
-  // --- Send Methods --- //
-
-  async sendNativeCoin(toAddress: string, amount: number): Promise<string> {
-    return this.sendErc20(STRK_TOKEN_ADDRESS, toAddress, amount, StarknetUtil.strkDecimals);
-  }
-
-  async sendEth(toAddress: string, amount: number): Promise<string> {
-    return this.sendErc20(ETH_TOKEN_ADDRESS, toAddress, amount, StarknetUtil.ethDecimals);
-  }
-
-  async sendToken(toAddress: string, asset: Asset, amount: number): Promise<string> {
-    const contractAddress = asset.chainId;
-    if (!contractAddress) throw new Error(`No contract address for token ${asset.uniqueName}`);
-
-    const decimals = asset.decimals;
-    if (!decimals) throw new Error(`No decimals for token ${asset.uniqueName}`);
-
-    return this.sendErc20(contractAddress, toAddress, amount, decimals);
-  }
-
-  private async sendErc20(
-    contractAddress: string,
-    toAddress: string,
-    amount: number,
-    decimals: number,
-  ): Promise<string> {
-    const weiAmount = StarknetUtil.toWeiAmount(amount, decimals);
-
-    const result = await this.account.execute({
-      contractAddress,
-      entrypoint: 'transfer',
-      calldata: CallData.compile({ recipient: toAddress, amount: { low: weiAmount, high: 0n } }),
-    });
-
-    return result.transaction_hash;
-  }
-
-  // --- Query Methods --- //
 
   async getTransaction(txHash: string): Promise<StarknetTransactionDto> {
     const tx = await this.provider.getTransactionByHash(txHash);
@@ -206,12 +164,51 @@ export class StarknetClient extends BlockchainClient {
     return StarknetUtil.fromWeiAmount(receipt.value.actual_fee.amount, StarknetUtil.ethDecimals);
   }
 
+  // --- SEND --- //
+
+  async sendNativeCoin(toAddress: string, amount: number): Promise<string> {
+    return this.sendErc20(STRK_TOKEN_ADDRESS, toAddress, amount, StarknetUtil.strkDecimals);
+  }
+
+  async sendEth(toAddress: string, amount: number): Promise<string> {
+    return this.sendErc20(ETH_TOKEN_ADDRESS, toAddress, amount, StarknetUtil.ethDecimals);
+  }
+
+  async sendToken(toAddress: string, asset: Asset, amount: number): Promise<string> {
+    if (!asset.chainId) throw new Error(`No contract address for token ${asset.uniqueName}`);
+    if (!asset.decimals) throw new Error(`No decimals for token ${asset.uniqueName}`);
+
+    return this.sendErc20(asset.chainId, toAddress, amount, asset.decimals);
+  }
+
+  private async sendErc20(
+    contractAddress: string,
+    toAddress: string,
+    amount: number,
+    decimals: number,
+  ): Promise<string> {
+    const weiAmount = StarknetUtil.toWeiAmount(amount, decimals);
+
+    const result = await this.account.execute({
+      contractAddress,
+      entrypoint: 'transfer',
+      calldata: CallData.compile({ recipient: toAddress, amount: { low: weiAmount, high: 0n } }),
+    });
+
+    return result.transaction_hash;
+  }
+
+  // --- SIGNATURE VERIFICATION --- //
+
   async verifySignature(message: string, address: string, signature: string): Promise<boolean> {
     const signatureParts = signature.split(',');
     if (signatureParts.length !== 2) return false;
 
-    return this.provider.verifyMessageInStarknet(BigInt(message), signatureParts, address);
+    const messageHash = hash.starknetKeccak(message);
+    return this.provider.verifyMessageInStarknet(messageHash, signatureParts, address);
   }
+
+  // --- FEES --- //
 
   async getCurrentGasCostForCoinTransaction(): Promise<number> {
     const estimateFee = await this.account.estimateInvokeFee({

--- a/src/integration/blockchain/starknet/starknet-client.ts
+++ b/src/integration/blockchain/starknet/starknet-client.ts
@@ -106,8 +106,8 @@ export class StarknetClient extends BlockchainClient {
 
   private async getErc20Balance(contractAddress: string, owner: string, decimals: number): Promise<number> {
     const contract = new Contract({ abi: ERC20_ABI, address: contractAddress, providerOrAccount: this.provider });
-    const result = await contract.call('balanceOf', [owner]);
-    return StarknetUtil.fromWeiAmount(result.toString(), decimals);
+    const result = (await contract.call('balanceOf', [owner])) as Record<string, bigint>;
+    return StarknetUtil.fromWeiAmount(result.balance, decimals);
   }
 
   // --- TRANSACTIONS --- //

--- a/src/integration/blockchain/starknet/starknet-client.ts
+++ b/src/integration/blockchain/starknet/starknet-client.ts
@@ -39,7 +39,7 @@ const STRK_TOKEN_ADDRESS = '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab0720
 
 export class StarknetClient extends BlockchainClient {
   private readonly provider: RpcProvider;
-  private readonly account: Account;
+  private readonly account: Account | undefined;
   private readonly address: string;
 
   constructor() {
@@ -48,8 +48,16 @@ export class StarknetClient extends BlockchainClient {
     const { gatewayUrl, walletAddress, walletPrivateKey } = GetConfig().blockchain.starknet;
 
     this.provider = new RpcProvider({ nodeUrl: gatewayUrl });
-    this.address = walletAddress;
-    this.account = new Account({ provider: this.provider, address: walletAddress, signer: walletPrivateKey });
+    this.address = walletAddress ?? '';
+    this.account =
+      walletAddress && walletPrivateKey
+        ? new Account({ provider: this.provider, address: walletAddress, signer: walletPrivateKey })
+        : undefined;
+  }
+
+  private getAccount(): Account {
+    if (!this.account) throw new Error('Starknet wallet not configured');
+    return this.account;
   }
 
   get walletAddress(): string {
@@ -189,7 +197,7 @@ export class StarknetClient extends BlockchainClient {
   ): Promise<string> {
     const weiAmount = StarknetUtil.toWeiAmount(amount, decimals);
 
-    const result = await this.account.execute({
+    const result = await this.getAccount().execute({
       contractAddress,
       entrypoint: 'transfer',
       calldata: CallData.compile({ recipient: toAddress, amount: { low: weiAmount, high: 0n } }),
@@ -211,7 +219,7 @@ export class StarknetClient extends BlockchainClient {
   // --- FEES --- //
 
   async getCurrentGasCostForCoinTransaction(): Promise<number> {
-    const estimateFee = await this.account.estimateInvokeFee({
+    const estimateFee = await this.getAccount().estimateInvokeFee({
       contractAddress: STRK_TOKEN_ADDRESS,
       entrypoint: 'transfer',
       calldata: CallData.compile({ recipient: this.walletAddress, amount: { low: 1n, high: 0n } }),

--- a/src/integration/blockchain/starknet/starknet-client.ts
+++ b/src/integration/blockchain/starknet/starknet-client.ts
@@ -206,6 +206,13 @@ export class StarknetClient extends BlockchainClient {
     return StarknetUtil.fromWeiAmount(receipt.value.actual_fee.amount, StarknetUtil.ethDecimals);
   }
 
+  async verifySignature(message: string, address: string, signature: string): Promise<boolean> {
+    const signatureParts = signature.split(',');
+    if (signatureParts.length !== 2) return false;
+
+    return this.provider.verifyMessageInStarknet(BigInt(message), signatureParts, address);
+  }
+
   async getCurrentGasCostForCoinTransaction(): Promise<number> {
     const estimateFee = await this.account.estimateInvokeFee({
       contractAddress: STRK_TOKEN_ADDRESS,

--- a/src/integration/blockchain/starknet/starknet.module.ts
+++ b/src/integration/blockchain/starknet/starknet.module.ts
@@ -1,9 +1,7 @@
 import { Module } from '@nestjs/common';
-import { SharedModule } from 'src/shared/shared.module';
 import { StarknetService } from './services/starknet.service';
 
 @Module({
-  imports: [SharedModule],
   controllers: [],
   providers: [StarknetService],
   exports: [StarknetService],

--- a/src/integration/blockchain/starknet/starknet.module.ts
+++ b/src/integration/blockchain/starknet/starknet.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SharedModule } from 'src/shared/shared.module';
+import { StarknetService } from './services/starknet.service';
+
+@Module({
+  imports: [SharedModule],
+  controllers: [],
+  providers: [StarknetService],
+  exports: [StarknetService],
+})
+export class StarknetModule {}

--- a/src/integration/blockchain/starknet/starknet.util.ts
+++ b/src/integration/blockchain/starknet/starknet.util.ts
@@ -1,0 +1,22 @@
+import BigNumber from 'bignumber.js';
+
+const STRK_DECIMALS = 18;
+const ETH_DECIMALS = 18;
+
+export class StarknetUtil {
+  static fromWeiAmount(amount: string | bigint, decimals: number = STRK_DECIMALS): number {
+    return new BigNumber(amount.toString()).div(new BigNumber(10).pow(decimals)).toNumber();
+  }
+
+  static toWeiAmount(amount: number, decimals: number = STRK_DECIMALS): bigint {
+    return BigInt(new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toFixed(0));
+  }
+
+  static get strkDecimals(): number {
+    return STRK_DECIMALS;
+  }
+
+  static get ethDecimals(): number {
+    return ETH_DECIMALS;
+  }
+}

--- a/src/integration/exchange/services/__tests__/exchange.test.ts
+++ b/src/integration/exchange/services/__tests__/exchange.test.ts
@@ -42,6 +42,7 @@ export class TestExchangeService extends ExchangeService {
     Citrea: undefined,
     CitreaTestnet: undefined,
     BitcoinTestnet4: undefined,
+    Starknet: undefined,
     Kraken: undefined,
     Binance: undefined,
     XT: undefined,

--- a/src/integration/exchange/services/binance.service.ts
+++ b/src/integration/exchange/services/binance.service.ts
@@ -34,6 +34,7 @@ export class BinanceService extends ExchangeService {
     BinancePay: undefined,
     KucoinPay: undefined,
     Solana: 'SOL',
+    Starknet: undefined,
     Tron: 'TRX',
     InternetComputer: 'ICP',
     Citrea: undefined,

--- a/src/integration/exchange/services/bitstamp.service.ts
+++ b/src/integration/exchange/services/bitstamp.service.ts
@@ -34,6 +34,7 @@ export class BitstampService extends ExchangeService {
     BinancePay: undefined,
     KucoinPay: undefined,
     Solana: undefined,
+    Starknet: undefined,
     Tron: undefined,
     InternetComputer: undefined,
     Citrea: undefined,

--- a/src/integration/exchange/services/kraken.service.ts
+++ b/src/integration/exchange/services/kraken.service.ts
@@ -41,6 +41,7 @@ export class KrakenService extends ExchangeService {
     BinancePay: undefined,
     KucoinPay: undefined,
     Solana: false,
+    Starknet: undefined,
     Tron: undefined,
     InternetComputer: undefined,
     Citrea: undefined,

--- a/src/integration/exchange/services/kucoin.service.ts
+++ b/src/integration/exchange/services/kucoin.service.ts
@@ -34,6 +34,7 @@ export class KucoinService extends ExchangeService {
     BinancePay: undefined,
     KucoinPay: undefined,
     Solana: undefined,
+    Starknet: undefined,
     Tron: undefined,
     InternetComputer: undefined,
     Citrea: undefined,

--- a/src/integration/exchange/services/mexc.service.ts
+++ b/src/integration/exchange/services/mexc.service.ts
@@ -50,6 +50,7 @@ export class MexcService extends ExchangeService {
     BinancePay: undefined,
     KucoinPay: undefined,
     Solana: 'SOL',
+    Starknet: undefined,
     Tron: 'TRX',
     InternetComputer: 'ICP',
     Citrea: undefined,

--- a/src/integration/exchange/services/p2b.service.ts
+++ b/src/integration/exchange/services/p2b.service.ts
@@ -24,6 +24,7 @@
 //     Haqq: undefined,
 //     Liquid: undefined,
 //     Arweave: undefined,
+//     Starknet: undefined,
 //   };
 
 //   constructor() {

--- a/src/integration/exchange/services/xt.service.ts
+++ b/src/integration/exchange/services/xt.service.ts
@@ -34,6 +34,7 @@ export class XtService extends ExchangeService {
     BinancePay: undefined,
     KucoinPay: undefined,
     Solana: undefined,
+    Starknet: undefined,
     Tron: undefined,
     InternetComputer: undefined,
     Citrea: undefined,

--- a/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
@@ -105,6 +105,7 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
 
         case Blockchain.ZANO:
         case Blockchain.SOLANA:
+        case Blockchain.STARKNET:
         case Blockchain.TRON:
         case Blockchain.CARDANO:
         case Blockchain.INTERNET_COMPUTER:

--- a/src/subdomains/core/payment-link/dto/payment-request.mapper.ts
+++ b/src/subdomains/core/payment-link/dto/payment-request.mapper.ts
@@ -27,6 +27,7 @@ export class PaymentRequestMapper {
       case Blockchain.TRON:
       case Blockchain.CARDANO:
       case Blockchain.INTERNET_COMPUTER:
+      case Blockchain.STARKNET:
         return this.toPaymentLinkPayment(paymentActivation.method, paymentActivation);
 
       case Blockchain.KUCOIN_PAY:

--- a/src/subdomains/core/payment-link/services/payment-balance.service.ts
+++ b/src/subdomains/core/payment-link/services/payment-balance.service.ts
@@ -31,6 +31,7 @@ export class PaymentBalanceService implements OnModuleInit {
     Blockchain.MONERO,
     Blockchain.ZANO,
     Blockchain.CARDANO,
+    Blockchain.STARKNET,
     Blockchain.BINANCE_PAY,
     Blockchain.KUCOIN_PAY,
   ];

--- a/src/subdomains/core/payment-link/services/payment-link-fee.service.ts
+++ b/src/subdomains/core/payment-link/services/payment-link-fee.service.ts
@@ -63,6 +63,7 @@ export class PaymentLinkFeeService implements OnModuleInit {
       case Blockchain.MONERO:
       case Blockchain.ZANO:
       case Blockchain.SOLANA:
+      case Blockchain.STARKNET:
       case Blockchain.TRON:
       case Blockchain.CARDANO:
       case Blockchain.INTERNET_COMPUTER:

--- a/src/subdomains/core/referral/reward/services/ref-reward.service.ts
+++ b/src/subdomains/core/referral/reward/services/ref-reward.service.ts
@@ -39,6 +39,7 @@ const PayoutLimits: { [k in Blockchain]: number } = {
   [Blockchain.POLYGON]: undefined,
   [Blockchain.BASE]: undefined,
   [Blockchain.SOLANA]: undefined,
+  [Blockchain.STARKNET]: undefined,
   [Blockchain.HAQQ]: undefined,
   [Blockchain.LIQUID]: undefined,
   [Blockchain.ARWEAVE]: undefined,

--- a/src/subdomains/generic/user/models/user/user.enum.ts
+++ b/src/subdomains/generic/user/models/user/user.enum.ts
@@ -27,6 +27,7 @@ export enum UserAddressType {
   TRON = 'Tron',
   INTERNET_COMPUTER = 'InternetComputer',
   ZANO = 'Zano',
+  STARKNET = 'Starknet',
   OTHER = 'Other',
 }
 


### PR DESCRIPTION
## Summary
Add Starknet (L2 ZK-STARK rollup on Ethereum) as new non-EVM blockchain with native account abstraction. This PR covers the infrastructure layer — blockchain client, service, address detection, signature verification, explorer URLs, and all enum/registry mappings.

Starknet is NOT EVM-compatible. It uses its own Cairo VM, stark-curve ECDSA signatures, felt-based addresses (32 bytes), and native account abstraction (every account is a smart contract). The integration follows the same pattern as Solana/Monero (custom `BlockchainClient` implementation).

## New files
- `src/integration/blockchain/starknet/starknet-client.ts` — RPC client (balance, send, tx queries, signature verification)
- `src/integration/blockchain/starknet/services/starknet.service.ts` — NestJS service wrapper
- `src/integration/blockchain/starknet/starknet.module.ts` — NestJS module
- `src/integration/blockchain/starknet/starknet.util.ts` — Wei/amount conversions (18 decimals for STRK and ETH)
- `src/integration/blockchain/starknet/dto/starknet.dto.ts` — Transaction/token DTOs
- `scripts/deploy-starknet-account.ts` — Key generation + OZ account contract deployment

## Modified files (infrastructure)
- `blockchain.enum.ts` — `STARKNET = 'Starknet'`
- `blockchain.module.ts` — import/export `StarknetModule`
- `blockchain-registry.service.ts` — register `StarknetService`/`StarknetClient` in types and switch
- `blockchain.util.ts` — explorer URL (`voyager.online`), tx/address/token paths
- `config.ts` — address format (`0x[0-9a-fA-F]{50,64}`), signature format, env vars, blockchain config block
- `crypto.service.ts` — address detection, signature verification (on-chain via account contract), payment request, `UserAddressType.STARKNET`
- `user.enum.ts` — `STARKNET = 'Starknet'` in `UserAddressType`

## Modified files (enum mappings)
- 7 exchange services + `exchange.test.ts` — `Starknet: undefined`
- `ref-reward.service.ts` — `Starknet: undefined` in `PayoutLimits`

## Modified files (business layer)
- `blockchain.adapter.ts` — add `STARKNET` to token client balance update (prevents crash in liquidity management)
- `payment-link-fee.service.ts` — add `STARKNET` with fee 0
- `payment-balance.service.ts` — add `STARKNET` to `chainsWithoutPaymentBalance`
- `payment-request.mapper.ts` — add `STARKNET` to payment link payment case

## Environment variables
- `STARKNET_GATEWAY_URL` — RPC endpoint (Alchemy, Infura, etc.)
- `STARKNET_WALLET_ADDRESS` — deployed account contract address
- `STARKNET_WALLET_PRIVATE_KEY` — stark-curve private key

## Dependencies
- `starknet` ^9.4.2 (starknet.js SDK)

## Account deployment (before first use)
Starknet has native account abstraction — every account is a smart contract. Before the wallet can send transactions, the account contract must be deployed once:
```bash
# 1. Generate key pair
npx ts-node scripts/deploy-starknet-account.ts --generate
# 2. Set env vars from output
# 3. Fund the address with STRK (~0.001 STRK for gas)
# 4. Deploy
npx ts-node scripts/deploy-starknet-account.ts --deploy
```
Uses OpenZeppelin Account v0.8.1 class hash (verified against starknet.js docs).

## Open items (follow-up PRs)

### Payout/Payin/DEX strategies (not needed until assets are activated)
Strategy files are required per blockchain for payout, payin, and DEX operations. These are only triggered when Starknet assets exist in the database AND are enabled for buy/sell. Without DB assets, no code path reaches these strategies.

Needed files (follow same pattern as Solana strategies):
- `payout/strategies/payout/impl/starknet-coin.strategy.ts`
- `payout/strategies/payout/impl/starknet-token.strategy.ts`
- `payout/strategies/prepare/impl/starknet.strategy.ts`
- `payin/strategies/register/impl/starknet.strategy.ts`
- `payin/strategies/send/impl/starknet-coin.strategy.ts`
- `payin/strategies/send/impl/starknet-token.strategy.ts`
- `dex/strategies/check-liquidity/impl/starknet-coin.strategy.ts`
- `dex/strategies/check-liquidity/impl/starknet-token.strategy.ts`
- `dex/strategies/purchase-liquidity/impl/starknet-coin.strategy.ts`
- `dex/strategies/purchase-liquidity/impl/starknet-token.strategy.ts`
- `dex/strategies/sell-liquidity/impl/starknet-coin.strategy.ts`
- `dex/strategies/sell-liquidity/impl/starknet-token.strategy.ts`
- `dex/strategies/supplementary/impl/starknet.strategy.ts`

Plus corresponding strategy registry tests.

### Deposit address generation (Account Abstraction complexity)
`deposit.service.ts` needs a `createStarknetDeposits()` method. Unlike EVM/Solana where addresses are derived from a seed, Starknet requires deploying an account contract for each deposit address. This needs a custom implementation:
1. Derive key pair from seed + index
2. Compute counterfactual address
3. Fund and deploy account contract

This is architecturally different from all other blockchains and warrants its own PR.

### Balance/Transaction API endpoints
`blockchain-balance.service.ts` and `blockchain-transaction.service.ts` need Starknet cases for the external REST API. Currently returns `BadRequestException("Blockchain Starknet is not supported for balance queries")` — acceptable for initial rollout.

### Payment Link full support
Starknet is in `chainsWithoutPaymentBalance`, so payment links won't be generated. To enable:
1. Add `STARKNET` to `PaymentLinkBlockchains` array
2. Implement deposit address generation (see above)
3. Add `STARKNET` to `payment-activation.service.ts` switch
4. Add `STARKNET` to `VerifiedTxIdBlockchains` or `UnverifiedTxIdBlockchains` in payment-link enums
5. Remove from `chainsWithoutPaymentBalance`

### Exchange network mappings
All exchange services have `Starknet: undefined`. When exchanges add Starknet withdrawal support, update with the correct network name (e.g. `Starknet: 'STRK'` for Binance).

### Database
Create Starknet assets in the database:
- STRK coin (type: `Coin`, decimals: 18)
- ETH bridged token (type: `Token`, chainId: `0x049d...dc7`, decimals: 18)
- Optional: USDC, USDT, and other tokens

## Test plan
- [x] TypeScript compilation passes (0 errors)
- [x] Build succeeds (`npm run build`)
- [x] ESLint clean
- [x] Prettier clean
- [ ] Account deployment script tested on Sepolia testnet
- [ ] STRK/ETH balance queries verified against mainnet
- [ ] Token transfer flow tested end-to-end