### PR TITLE
feat: compliance improvements (limit request, stop transaction, chargeback)

### DIFF
--- a/src/subdomains/core/history/dto/transaction-refund.dto.ts
+++ b/src/subdomains/core/history/dto/transaction-refund.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Util } from 'src/shared/utils/util';
 
 export class CreditorDataDto {
@@ -48,6 +48,11 @@ export class TransactionRefundDto {
   @ValidateNested()
   @Type(() => CreditorDataDto)
   creditorData?: CreditorDataDto;
+
+  @ApiPropertyOptional({ description: 'Manual chargeback amount override' })
+  @IsOptional()
+  @IsNumber()
+  chargebackAmount?: number;
 }
 
 export class BankRefundDto extends TransactionRefundDto {

--- a/src/subdomains/core/history/dto/transaction-refund.dto.ts
+++ b/src/subdomains/core/history/dto/transaction-refund.dto.ts
@@ -48,7 +48,9 @@ export class TransactionRefundDto {
   @ValidateNested()
   @Type(() => CreditorDataDto)
   creditorData?: CreditorDataDto;
+}
 
+export class ChargebackRefundDto extends TransactionRefundDto {
   @ApiPropertyOptional({ description: 'Manual chargeback amount override' })
   @IsOptional()
   @IsNumber()

--- a/src/subdomains/core/history/mappers/transaction-dto.mapper.ts
+++ b/src/subdomains/core/history/mappers/transaction-dto.mapper.ts
@@ -346,6 +346,7 @@ export class TransactionDtoMapper {
       inputTxId: null,
       inputTxUrl: null,
       chargebackAmount: bankTxReturn?.chargebackAmount,
+      chargebackAsset: bankTxReturn?.chargebackAsset,
       chargebackTarget: bankTxReturn?.chargebackIban,
       chargebackTxId: bankTxReturn?.chargebackRemittanceInfo,
       chargebackTxUrl: undefined,

--- a/src/subdomains/core/history/mappers/transaction-dto.mapper.ts
+++ b/src/subdomains/core/history/mappers/transaction-dto.mapper.ts
@@ -448,6 +448,8 @@ function getTransactionStateDetails(entity: BuyFiat | BuyCrypto | RefReward | Tr
         : null;
 
   if (entity instanceof BuyCrypto) {
+    if (entity.status === BuyCryptoStatus.STOPPED) return { state: TransactionState.STOPPED, reason };
+
     switch (entity.amlCheck) {
       case null:
         if (entity.comment != null) return { state: TransactionState.PROCESSING, reason };

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -12,11 +12,13 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth, ApiExcludeEndpoint, ApiOkResponse } from '@nestjs/swagger';
+import { GetJwt } from 'src/shared/auth/get-jwt.decorator';
+import { JwtPayload } from 'src/shared/auth/jwt-payload.interface';
 import { RoleGuard } from 'src/shared/auth/role.guard';
 import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
 import { UserRole } from 'src/shared/auth/user-role.enum';
 import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
-import { BankRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
+import { BankRefundDto, TransactionRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
 import { GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
 import {
@@ -41,6 +43,14 @@ export class SupportController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.SUPPORT), UserActiveGuard())
   async searchUserByKey(@Query() query: UserDataSupportQuery): Promise<UserDataSupportInfoResult> {
     return this.supportService.searchUserDataByKey(query);
+  }
+
+  @Get('me')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getSupportUserInfo(@GetJwt() jwt: JwtPayload): Promise<{ id: number; firstname: string; surname: string }> {
+    return this.supportService.getSupportUserInfo(jwt.account);
   }
 
   @Get('kycFileList')
@@ -138,5 +148,17 @@ export class SupportController {
   async setTransactionRefund(@Param('id') id: string, @Body() dto: BankRefundDto): Promise<void> {
     const success = await this.supportService.processTransactionRefund(+id, dto);
     if (!success) throw new BadRequestException('Refund failed');
+  }
+
+  @Put('transaction/:id/chargeback')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async chargebackTransaction(
+    @Param('id') id: string,
+    @Body() dto: TransactionRefundDto,
+    @GetJwt() jwt: JwtPayload,
+  ): Promise<void> {
+    await this.supportService.processChargebackRefund(+id, dto, jwt.account);
   }
 }

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -1,15 +1,4 @@
-import {
-  BadRequestException,
-  Body,
-  Controller,
-  Get,
-  NotFoundException,
-  Param,
-  Post,
-  Put,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth, ApiExcludeEndpoint, ApiOkResponse } from '@nestjs/swagger';
 import { GetJwt } from 'src/shared/auth/get-jwt.decorator';
@@ -18,7 +7,7 @@ import { RoleGuard } from 'src/shared/auth/role.guard';
 import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
 import { UserRole } from 'src/shared/auth/user-role.enum';
 import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
-import { BankRefundDto, TransactionRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
+import { ChargebackRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
 import { GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
 import {
@@ -43,14 +32,6 @@ export class SupportController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.SUPPORT), UserActiveGuard())
   async searchUserByKey(@Query() query: UserDataSupportQuery): Promise<UserDataSupportInfoResult> {
     return this.supportService.searchUserDataByKey(query);
-  }
-
-  @Get('me')
-  @ApiBearerAuth()
-  @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
-  async getSupportUserInfo(@GetJwt() jwt: JwtPayload): Promise<{ id: number; firstname: string; surname: string }> {
-    return this.supportService.getSupportUserInfo(jwt.account);
   }
 
   @Get('kycFileList')
@@ -145,20 +126,11 @@ export class SupportController {
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
   @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
-  async setTransactionRefund(@Param('id') id: string, @Body() dto: BankRefundDto): Promise<void> {
-    const success = await this.supportService.processTransactionRefund(+id, dto);
-    if (!success) throw new BadRequestException('Refund failed');
-  }
-
-  @Put('transaction/:id/chargeback')
-  @ApiBearerAuth()
-  @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
-  async chargebackTransaction(
+  async setTransactionRefund(
     @Param('id') id: string,
-    @Body() dto: TransactionRefundDto,
+    @Body() dto: ChargebackRefundDto,
     @GetJwt() jwt: JwtPayload,
   ): Promise<void> {
-    await this.supportService.processChargebackRefund(+id, dto, jwt.account);
+    await this.supportService.processTransactionRefund(+id, dto, jwt.account);
   }
 }

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -11,7 +11,7 @@ import { Buy } from 'src/subdomains/core/buy-crypto/routes/buy/buy.entity';
 import { BuyService } from 'src/subdomains/core/buy-crypto/routes/buy/buy.service';
 import { SwapService } from 'src/subdomains/core/buy-crypto/routes/swap/swap.service';
 import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
-import { BankRefundDto, TransactionRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
+import { ChargebackRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
 import { CardBankName } from 'src/subdomains/supporting/bank/bank/dto/bank.dto';
 import { BuyFiatService } from 'src/subdomains/core/sell-crypto/process/services/buy-fiat.service';
 import { Sell } from 'src/subdomains/core/sell-crypto/route/sell.entity';
@@ -783,12 +783,6 @@ export class SupportService {
     };
   }
 
-  async getSupportUserInfo(userDataId: number): Promise<{ id: number; firstname: string; surname: string }> {
-    const userData = await this.userDataService.getUserData(userDataId);
-    if (!userData) throw new NotFoundException('User not found');
-    return { id: userData.id, firstname: userData.firstname, surname: userData.surname };
-  }
-
   // --- REFUND METHODS --- //
 
   async getTransactionRefundData(transactionId: number): Promise<RefundDataDto | undefined> {
@@ -873,55 +867,9 @@ export class SupportService {
     return refundData;
   }
 
-  async processTransactionRefund(transactionId: number, dto: BankRefundDto): Promise<boolean> {
-    const transaction = await this.transactionService.getTransactionById(transactionId, {
-      bankTx: { bankTxReturn: true },
-      bankTxReturn: { bankTx: true, chargebackOutput: true },
-      userData: true,
-    });
-
-    if (!transaction?.bankTx) throw new NotFoundException('Transaction not found');
-    if (!BankTxTypeUnassigned(transaction.bankTx.type)) throw new BadRequestException('Transaction already assigned');
-
-    const refundData = this.refundList.get(transactionId);
-    if (!refundData) throw new BadRequestException('Request refund data first');
-    if (!this.isRefundDataValid(refundData)) throw new BadRequestException('Refund data expired');
-    this.refundList.delete(transactionId);
-
-    // Create BankTxReturn if not exists
-    if (!transaction.bankTxReturn) {
-      // Load bankTx with transaction relation for the create method
-      const bankTxWithRelations = await this.bankTxService.getBankTxById(transaction.bankTx.id, {
-        transaction: { userData: true },
-      });
-
-      transaction.bankTxReturn = await this.bankTxService
-        .updateInternal(bankTxWithRelations, { type: BankTxType.BANK_TX_RETURN })
-        .then((b) => b.bankTxReturn);
-    }
-
-    // Process refund
-    await this.bankTxReturnService.refundBankTx(transaction.bankTxReturn, {
-      refundIban: dto.refundTarget,
-      chargebackAmount: refundData.refundAmount,
-      chargebackAllowedDate: new Date(),
-      chargebackAllowedBy: 'Compliance',
-      creditorData: {
-        name: dto.name,
-        address: dto.address,
-        houseNumber: dto.houseNumber,
-        zip: dto.zip,
-        city: dto.city,
-        country: dto.country,
-      },
-    });
-
-    return true;
-  }
-
-  async processChargebackRefund(
+  async processTransactionRefund(
     transactionId: number,
-    dto: TransactionRefundDto,
+    dto: ChargebackRefundDto,
     agentUserDataId: number,
   ): Promise<void> {
     const transaction = await this.transactionService.getTransactionById(transactionId, {

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -3,13 +3,16 @@ import { isIP } from 'class-validator';
 import * as IbanTools from 'ibantools';
 import { Config } from 'src/config/config';
 import { SettingService } from 'src/shared/models/setting/setting.service';
-import { Util } from 'src/shared/utils/util';
+import { AmountType, Util } from 'src/shared/utils/util';
+import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
+import { NotRefundableAmlReasons } from 'src/subdomains/core/aml/enums/aml-reason.enum';
 import { BuyCryptoService } from 'src/subdomains/core/buy-crypto/process/services/buy-crypto.service';
 import { Buy } from 'src/subdomains/core/buy-crypto/routes/buy/buy.entity';
 import { BuyService } from 'src/subdomains/core/buy-crypto/routes/buy/buy.service';
 import { SwapService } from 'src/subdomains/core/buy-crypto/routes/swap/swap.service';
 import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
-import { BankRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
+import { BankRefundDto, TransactionRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
+import { CardBankName } from 'src/subdomains/supporting/bank/bank/dto/bank.dto';
 import { BuyFiatService } from 'src/subdomains/core/sell-crypto/process/services/buy-fiat.service';
 import { Sell } from 'src/subdomains/core/sell-crypto/route/sell.entity';
 import { SellService } from 'src/subdomains/core/sell-crypto/route/sell.service';
@@ -780,15 +783,77 @@ export class SupportService {
     };
   }
 
+  async getSupportUserInfo(userDataId: number): Promise<{ id: number; firstname: string; surname: string }> {
+    const userData = await this.userDataService.getUserData(userDataId);
+    if (!userData) throw new NotFoundException('User not found');
+    return { id: userData.id, firstname: userData.firstname, surname: userData.surname };
+  }
+
   // --- REFUND METHODS --- //
 
   async getTransactionRefundData(transactionId: number): Promise<RefundDataDto | undefined> {
     const transaction = await this.transactionService.getTransactionById(transactionId, {
       bankTx: { bankTxReturn: true },
+      buyCrypto: { cryptoInput: true, bankTx: true, checkoutTx: true },
+      buyFiat: { cryptoInput: true },
       userData: true,
     });
 
-    if (!transaction?.bankTx) return undefined;
+    if (!transaction) return undefined;
+
+    // BuyCrypto chargeback
+    if (transaction.buyCrypto) {
+      if (transaction.buyCrypto.amlCheck === CheckStatus.PASS) return undefined;
+      if (transaction.buyCrypto.chargebackAmount || transaction.buyCrypto.chargebackDate)
+        throw new BadRequestException('Transaction already charged back');
+      if (NotRefundableAmlReasons.includes(transaction.buyCrypto.amlReason))
+        throw new BadRequestException('Cannot refund with this AML reason');
+
+      const bankIn = transaction.buyCrypto.bankTx
+        ? await this.bankService.getBankByIban(transaction.buyCrypto.bankTx.accountIban).then((b) => b?.name)
+        : transaction.buyCrypto.checkoutTx
+          ? CardBankName.CHECKOUT
+          : undefined;
+
+      const refundTarget = await this.getChargebackRefundTarget(transaction);
+      const isFiat = !!transaction.buyCrypto.bankTx || !!transaction.buyCrypto.checkoutTx;
+
+      const refundData = await this.transactionHelper.getRefundData(
+        transaction.buyCrypto,
+        transaction.userData,
+        bankIn,
+        refundTarget,
+        isFiat,
+      );
+
+      this.refundList.set(transactionId, refundData);
+      return refundData;
+    }
+
+    // BuyFiat chargeback
+    if (transaction.buyFiat) {
+      if (transaction.buyFiat.amlCheck === CheckStatus.PASS) return undefined;
+      if (transaction.buyFiat.chargebackAmount || transaction.buyFiat.chargebackDate)
+        throw new BadRequestException('Transaction already charged back');
+      if (NotRefundableAmlReasons.includes(transaction.buyFiat.amlReason))
+        throw new BadRequestException('Cannot refund with this AML reason');
+
+      const refundTarget = transaction.buyFiat.chargebackAddress;
+
+      const refundData = await this.transactionHelper.getRefundData(
+        transaction.buyFiat,
+        transaction.userData,
+        undefined,
+        refundTarget,
+        false,
+      );
+
+      this.refundList.set(transactionId, refundData);
+      return refundData;
+    }
+
+    // Unassigned BankTx return
+    if (!transaction.bankTx) return undefined;
     if (!BankTxTypeUnassigned(transaction.bankTx.type)) return undefined;
     if (transaction.bankTx.bankTxReturn) throw new BadRequestException('Transaction already has a return');
 
@@ -852,6 +917,119 @@ export class SupportService {
     });
 
     return true;
+  }
+
+  async processChargebackRefund(
+    transactionId: number,
+    dto: TransactionRefundDto,
+    agentUserDataId: number,
+  ): Promise<void> {
+    const transaction = await this.transactionService.getTransactionById(transactionId, {
+      buyCrypto: { cryptoInput: true, bankTx: true, checkoutTx: true },
+      buyFiat: { cryptoInput: true },
+      bankTx: { bankTxReturn: true },
+      bankTxReturn: { bankTx: true, chargebackOutput: true },
+      userData: true,
+    });
+
+    if (!transaction?.buyCrypto && !transaction?.buyFiat && !transaction?.bankTx)
+      throw new NotFoundException('Transaction not found');
+
+    const refundData = this.refundList.get(transactionId);
+    if (!refundData) throw new BadRequestException('Request refund data first');
+    if (!this.isRefundDataValid(refundData)) throw new BadRequestException('Refund data expired');
+    this.refundList.delete(transactionId);
+
+    if (dto.chargebackAmount != null && (dto.chargebackAmount <= 0 || dto.chargebackAmount > refundData.inputAmount))
+      throw new BadRequestException('Chargeback amount must be greater than 0 and not exceed the transaction amount');
+
+    const agent = await this.userDataService.getUserData(agentUserDataId);
+    const chargebackAllowedBy = agent ? `Compliance/${agent.firstname}.${agent.surname}` : 'Compliance';
+
+    const chargebackAmount = dto.chargebackAmount ?? refundData.refundAmount;
+    const baseRefund = {
+      chargebackAmount,
+      chargebackCurrency: refundData.refundAsset.name,
+      chargebackAllowedDate: new Date(),
+      chargebackAllowedBy,
+    };
+
+    // BuyFiat refund (crypto back to sender)
+    if (transaction.buyFiat) {
+      return this.buyFiatService.refundBuyFiatInternal(transaction.buyFiat, {
+        refundUserAddress: dto.refundTarget,
+        ...baseRefund,
+      });
+    }
+
+    // Unassigned BankTx return
+    if (transaction.bankTx && BankTxTypeUnassigned(transaction.bankTx.type) && !transaction.buyCrypto) {
+      if (!dto.creditorData) throw new BadRequestException('Creditor data is required for bank refunds');
+
+      if (!transaction.bankTxReturn) {
+        const bankTxWithRelations = await this.bankTxService.getBankTxById(transaction.bankTx.id, {
+          transaction: { userData: true },
+        });
+
+        transaction.bankTxReturn = await this.bankTxService
+          .updateInternal(bankTxWithRelations, { type: BankTxType.BANK_TX_RETURN })
+          .then((b) => b.bankTxReturn);
+      }
+
+      return this.bankTxReturnService.refundBankTx(transaction.bankTxReturn, {
+        refundIban: dto.refundTarget ?? refundData.refundTarget,
+        creditorData: dto.creditorData,
+        ...baseRefund,
+      });
+    }
+
+    // BuyCrypto refunds
+    const buyCrypto = transaction.buyCrypto;
+
+    if (buyCrypto.checkoutTx) {
+      return this.buyCryptoService.refundCheckoutTx(buyCrypto, baseRefund);
+    }
+
+    if (buyCrypto.cryptoInput) {
+      return this.buyCryptoService.refundCryptoInput(buyCrypto, {
+        refundUserAddress: dto.refundTarget,
+        ...baseRefund,
+      });
+    }
+
+    // Bank refund
+    if (!dto.creditorData) throw new BadRequestException('Creditor data is required for bank refunds');
+
+    return this.buyCryptoService.refundBankTx(buyCrypto, {
+      refundIban: dto.refundTarget ?? refundData.refundTarget,
+      creditorData: dto.creditorData,
+      chargebackReferenceAmount: Util.roundReadable(
+        refundData.refundPrice.invert().convert(chargebackAmount),
+        AmountType.FIAT,
+      ),
+      ...baseRefund,
+    });
+  }
+
+  private async getChargebackRefundTarget(transaction: Transaction): Promise<string | undefined> {
+    const buyCrypto = transaction.buyCrypto;
+    if (!buyCrypto) return undefined;
+
+    if (buyCrypto.bankTx) {
+      try {
+        const iban = buyCrypto.bankTx.iban;
+        if (iban && IbanTools.validateIBAN(iban).valid) return iban;
+      } catch (_) {
+        // fall through
+      }
+      return buyCrypto.chargebackIban;
+    }
+
+    if (buyCrypto.checkoutTx) {
+      return `${buyCrypto.checkoutTx.cardBin}****${buyCrypto.checkoutTx.cardLast4}`;
+    }
+
+    return buyCrypto.chargebackIban;
   }
 
   private isRefundDataValid(refundData: RefundDataDto): boolean {

--- a/src/subdomains/supporting/payment/controllers/transaction-admin.controller.ts
+++ b/src/subdomains/supporting/payment/controllers/transaction-admin.controller.ts
@@ -28,6 +28,14 @@ export class TransactionAdminController {
     return this.transactionService.update(+id, dto);
   }
 
+  @Post(':id/stop')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  @ApiExcludeEndpoint()
+  async stopTransaction(@Param('id') id: string): Promise<void> {
+    return this.transactionService.stop(+id);
+  }
+
   @Post(':txId/riskAssessment')
   @ApiBearerAuth()
   @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())

--- a/src/subdomains/supporting/payment/dto/transaction.dto.ts
+++ b/src/subdomains/supporting/payment/dto/transaction.dto.ts
@@ -29,6 +29,7 @@ export enum TransactionState {
   RETURNED = 'Returned',
   UNASSIGNED = 'Unassigned',
   WAITING_FOR_PAYMENT = 'WaitingForPayment',
+  STOPPED = 'Stopped',
 }
 
 export enum TransactionReason {

--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -1,6 +1,8 @@
-import { Inject, Injectable, NotFoundException, forwardRef } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, NotFoundException, forwardRef } from '@nestjs/common';
 import { Config } from 'src/config/config';
 import { Util } from 'src/shared/utils/util';
+import { BuyCryptoStatus } from 'src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity';
+import { BuyCryptoRepository } from 'src/subdomains/core/buy-crypto/process/repositories/buy-crypto.repository';
 import { BankDataType } from 'src/subdomains/generic/user/models/bank-data/bank-data.entity';
 import { BankDataService } from 'src/subdomains/generic/user/models/bank-data/bank-data.service';
 import { UserDataService } from 'src/subdomains/generic/user/models/user-data/user-data.service';
@@ -22,6 +24,8 @@ export class TransactionService {
     @Inject(forwardRef(() => BankDataService))
     private readonly bankDataService: BankDataService,
     private readonly specialExternalAccountService: SpecialExternalAccountService,
+    @Inject(forwardRef(() => BuyCryptoRepository))
+    private readonly buyCryptoRepo: BuyCryptoRepository,
   ) {}
 
   async create(dto: CreateTransactionDto): Promise<Transaction | undefined> {
@@ -82,6 +86,18 @@ export class TransactionService {
     }
 
     return this.repo.save(entity);
+  }
+
+  async stop(id: number): Promise<void> {
+    const entity = await this.getTransactionById(id, { buyCrypto: true });
+    if (!entity) throw new NotFoundException('Transaction not found');
+    if (entity.completionDate) throw new BadRequestException('Transaction is already completed');
+    if (!entity.buyCrypto) throw new BadRequestException('Only BuyCrypto transactions can be stopped');
+    if (entity.buyCrypto.status === BuyCryptoStatus.STOPPED)
+      throw new BadRequestException('Transaction is already stopped');
+
+    entity.buyCrypto.status = BuyCryptoStatus.STOPPED;
+    await this.buyCryptoRepo.save(entity.buyCrypto);
   }
 
   async getTransactionById(id: number, relations: FindOptionsRelations<Transaction> = {}): Promise<Transaction> {

--- a/src/subdomains/supporting/payment/transaction.module.ts
+++ b/src/subdomains/supporting/payment/transaction.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SharedModule } from 'src/shared/shared.module';
+import { BuyCryptoModule } from 'src/subdomains/core/buy-crypto/buy-crypto.module';
 import { UserModule } from 'src/subdomains/generic/user/user.module';
 import { BankTxModule } from '../bank-tx/bank-tx.module';
 import { BankModule } from '../bank/bank.module';
@@ -22,6 +23,7 @@ import { TransactionService } from './services/transaction.service';
     forwardRef(() => UserModule),
     forwardRef(() => BankTxModule),
     forwardRef(() => BankModule),
+    forwardRef(() => BuyCryptoModule),
     SharedModule,
     TypeOrmModule.forFeature([Transaction, TransactionRiskAssessment]),
   ],

--- a/src/subdomains/supporting/support-issue/dto/create-support-issue.dto.ts
+++ b/src/subdomains/supporting/support-issue/dto/create-support-issue.dto.ts
@@ -80,4 +80,11 @@ export class CreateSupportIssueDto extends CreateSupportIssueBaseDto {
   limitRequest?: LimitRequestDto;
 }
 
-export class CreateSupportIssueSupportDto extends CreateSupportIssueBaseDto {}
+export class CreateSupportIssueSupportDto extends CreateSupportIssueBaseDto {
+  @ApiPropertyOptional()
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => LimitRequestDto)
+  @ValidateIf((dto: CreateSupportIssueSupportDto) => dto.type === SupportIssueType.LIMIT_REQUEST)
+  limitRequest?: LimitRequestDto;
+}

--- a/src/subdomains/supporting/support-issue/support-issue.controller.ts
+++ b/src/subdomains/supporting/support-issue/support-issue.controller.ts
@@ -56,13 +56,11 @@ export class SupportIssueController {
   async createIssueBySupport(
     @Query('userDataId') userDataId: string,
     @Body() dto: CreateSupportIssueSupportDto,
+    @GetJwt() jwt: JwtPayload,
   ): Promise<SupportIssueDto> {
     const input: CreateSupportIssueSupportDto = {
       ...dto,
-      department:
-        dto.type === SupportIssueType.VERIFICATION_CALL || dto.limitRequest
-          ? Department.COMPLIANCE
-          : Department.SUPPORT,
+      department: jwt.role === UserRole.COMPLIANCE ? Department.COMPLIANCE : Department.SUPPORT,
     };
     return this.supportIssueService.createIssue(+userDataId, input);
   }

--- a/src/subdomains/supporting/support-issue/support-issue.controller.ts
+++ b/src/subdomains/supporting/support-issue/support-issue.controller.ts
@@ -57,7 +57,14 @@ export class SupportIssueController {
     @Query('userDataId') userDataId: string,
     @Body() dto: CreateSupportIssueSupportDto,
   ): Promise<SupportIssueDto> {
-    return this.supportIssueService.createIssue(+userDataId, dto);
+    const input: CreateSupportIssueSupportDto = {
+      ...dto,
+      department:
+        dto.type === SupportIssueType.VERIFICATION_CALL || dto.limitRequest
+          ? Department.COMPLIANCE
+          : Department.SUPPORT,
+    };
+    return this.supportIssueService.createIssue(+userDataId, input);
   }
 
   @Get()


### PR DESCRIPTION
## Summary
- **Limit Request via support endpoint** (`bf5f6956a` → `ddfe3f858`): extend `CreateSupportIssueSupportDto` with optional `limitRequest` and route to COMPLIANCE department, mirroring the public createIssue endpoint.
- **Stop transaction endpoint** (`6da95caa2` → `723ee4c7a`): new `POST /transaction/admin/:id/stop` for COMPLIANCE users to halt a BuyCrypto transaction (sets `BuyCryptoStatus.STOPPED`). Mapper exposes the new `STOPPED` transaction state.
- **Chargeback endpoint** (`a0da59e98`): new `PUT /support/transaction/:id/chargeback` to release a refund for BuyCrypto / BuyFiat / unassigned BankTx, recording the agent identity (`Compliance/<Vorname>.<Nachname>`). Adds `GET /support/me`, exposes `chargebackAsset` on the transaction DTO and adds an optional `chargebackAmount` override on `TransactionRefundDto`.

## Companion PRs
- packages: DFXswiss/packages#145 (adds `TransactionState.STOPPED`)
- services: linked separately

## Test plan
- [ ] `npm run format:check` ✅
- [ ] `npm run lint` ✅
- [ ] `npm test` ✅ (66 suites, 927 tests passing)
- [ ] Manual: COMPLIANCE user can call `POST /transaction/admin/{id}/stop` and the transaction state becomes `Stopped`.
- [ ] Manual: COMPLIANCE user can call `GET /support/transaction/{id}/refund` followed by `PUT /support/transaction/{id}/chargeback` for BuyCrypto, BuyFiat and unassigned BankTx; `chargebackAllowedBy` records the agent.
- [ ] Manual: `GET /support/me` returns `{ id, firstname, surname }` of the calling COMPLIANCE user.
- [ ] Manual: COMPLIANCE user can submit a Limit Request via `POST /support/issue/...` with `limitRequest` payload; department resolves to COMPLIANCE.