### PR TITLE
fix: support endpoint performance and null outputAsset crash

### DIFF
--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -139,16 +139,13 @@ export class TransactionService {
   }
 
   async getTransactionsByUserDataId(userDataId: number): Promise<Transaction[]> {
-    return this.repo
-      .createQueryBuilder('transaction')
-      .leftJoinAndSelect('transaction.buyCrypto', 'buyCrypto')
-      .leftJoinAndSelect('transaction.buyFiat', 'buyFiat')
-      .leftJoinAndSelect('transaction.bankTxReturn', 'bankTxReturn')
-      .leftJoinAndSelect('transaction.bankTxRepeat', 'bankTxRepeat')
-      .where('transaction.userDataId = :userDataId', { userDataId })
-      .orderBy('transaction.created', 'DESC')
-      .take(100)
-      .getMany();
+    return this.repo.find({
+      where: { userData: { id: userDataId } },
+      relations: { buyCrypto: true, buyFiat: true, bankTxReturn: true, bankTxRepeat: true },
+      loadEagerRelations: false,
+      order: { created: 'DESC' },
+      take: 100,
+    });
   }
 
   async getTransactionList(dateFrom?: Date, dateTo?: Date, outputFrom?: Date, outputTo?: Date): Promise<Transaction[]> {

--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -139,12 +139,16 @@ export class TransactionService {
   }
 
   async getTransactionsByUserDataId(userDataId: number): Promise<Transaction[]> {
-    return this.repo.find({
-      where: { userData: { id: userDataId } },
-      relations: { buyCrypto: true, buyFiat: true, bankTxReturn: true, bankTxRepeat: true },
-      order: { created: 'DESC' },
-      take: 100,
-    });
+    return this.repo
+      .createQueryBuilder('transaction')
+      .leftJoinAndSelect('transaction.buyCrypto', 'buyCrypto')
+      .leftJoinAndSelect('transaction.buyFiat', 'buyFiat')
+      .leftJoinAndSelect('transaction.bankTxReturn', 'bankTxReturn')
+      .leftJoinAndSelect('transaction.bankTxRepeat', 'bankTxRepeat')
+      .where('transaction.userDataId = :userDataId', { userDataId })
+      .orderBy('transaction.created', 'DESC')
+      .take(100)
+      .getMany();
   }
 
   async getTransactionList(dateFrom?: Date, dateTo?: Date, outputFrom?: Date, outputTo?: Date): Promise<Transaction[]> {

--- a/src/subdomains/supporting/support-issue/dto/support-issue-dto.mapper.ts
+++ b/src/subdomains/supporting/support-issue/dto/support-issue-dto.mapper.ts
@@ -133,8 +133,8 @@ export class SupportIssueDtoMapper {
       inputAsset: targetEntity?.inputAsset,
       inputBlockchain: targetEntity?.cryptoInput?.asset?.blockchain,
       outputAmount: targetEntity?.outputAmount,
-      outputAsset: targetEntity?.outputAsset.name,
-      outputBlockchain: transaction?.buyCrypto?.outputAsset.blockchain,
+      outputAsset: targetEntity?.outputAsset?.name,
+      outputBlockchain: transaction?.buyCrypto?.outputAsset?.blockchain,
       wallet: transaction.user?.wallet
         ? {
             name: transaction.user.wallet.displayName ?? transaction.user.wallet.name,

--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -276,14 +276,12 @@ export class SupportIssueService {
   }
 
   async getIssueEntities(userDataId: number): Promise<SupportIssue[]> {
-    return this.supportIssueRepo
-      .createQueryBuilder('supportIssue')
-      .leftJoinAndSelect('supportIssue.transaction', 'transaction')
-      .leftJoinAndSelect('supportIssue.limitRequest', 'limitRequest')
-      .leftJoinAndSelect('supportIssue.messages', 'messages')
-      .where('supportIssue.userDataId = :userDataId', { userDataId })
-      .orderBy('supportIssue.created', 'DESC')
-      .getMany();
+    return this.supportIssueRepo.find({
+      where: { userData: { id: userDataId } },
+      relations: { transaction: true, limitRequest: true, messages: true },
+      loadEagerRelations: false,
+      order: { created: 'DESC' },
+    });
   }
 
   async getIssues(userDataId: number): Promise<SupportIssueDto[]> {
@@ -311,24 +309,19 @@ export class SupportIssueService {
   }
 
   async getIssueData(id: number, role: UserRole): Promise<SupportIssueInternalDataDto> {
-    const issue = await this.supportIssueRepo
-      .createQueryBuilder('supportIssue')
-      .leftJoinAndSelect('supportIssue.userData', 'userData')
-      .leftJoinAndSelect('userData.country', 'userDataCountry')
-      .leftJoinAndSelect('supportIssue.transaction', 'transaction')
-      .leftJoinAndSelect('transaction.user', 'user')
-      .leftJoinAndSelect('user.wallet', 'wallet')
-      .leftJoinAndSelect('transaction.buyCrypto', 'buyCrypto')
-      .leftJoinAndSelect('buyCrypto.outputAsset', 'buyCryptoOutputAsset')
-      .leftJoinAndSelect('buyCrypto.cryptoInput', 'buyCryptoInput')
-      .leftJoinAndSelect('buyCryptoInput.asset', 'buyCryptoInputAsset')
-      .leftJoinAndSelect('transaction.buyFiat', 'buyFiat')
-      .leftJoinAndSelect('buyFiat.outputAsset', 'buyFiatOutputAsset')
-      .leftJoinAndSelect('buyFiat.cryptoInput', 'buyFiatInput')
-      .leftJoinAndSelect('buyFiatInput.asset', 'buyFiatInputAsset')
-      .leftJoinAndSelect('supportIssue.limitRequest', 'limitRequest')
-      .where('supportIssue.id = :id', { id })
-      .getOne();
+    const issue = await this.supportIssueRepo.findOne({
+      where: { id },
+      relations: {
+        userData: { country: true },
+        transaction: {
+          user: { wallet: true },
+          buyCrypto: { outputAsset: true, cryptoInput: { asset: true } },
+          buyFiat: { outputAsset: true, cryptoInput: { asset: true } },
+        },
+        limitRequest: true,
+      },
+      loadEagerRelations: false,
+    });
     if (!issue) throw new NotFoundException('Support issue not found');
 
     return SupportIssueDtoMapper.mapSupportIssueData(issue, role);

--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -29,10 +29,10 @@ import {
   SupportIssueListDto,
   SupportMessageDto,
 } from '../dto/support-issue.dto';
-import { Department } from '../enums/department.enum';
 import { UpdateSupportIssueDto } from '../dto/update-support-issue.dto';
 import { SupportIssue } from '../entities/support-issue.entity';
 import { AutoResponder, CustomerAuthor, SupportMessage } from '../entities/support-message.entity';
+import { Department } from '../enums/department.enum';
 import { SupportIssueInternalState, SupportIssueReason, SupportIssueType } from '../enums/support-issue.enum';
 import { SupportLogType } from '../enums/support-log.enum';
 import { SupportIssueRepository } from '../repositories/support-issue.repository';
@@ -276,11 +276,14 @@ export class SupportIssueService {
   }
 
   async getIssueEntities(userDataId: number): Promise<SupportIssue[]> {
-    return this.supportIssueRepo.find({
-      where: { userData: { id: userDataId } },
-      relations: { transaction: true, limitRequest: true, messages: true },
-      order: { created: 'DESC' },
-    });
+    return this.supportIssueRepo
+      .createQueryBuilder('supportIssue')
+      .leftJoinAndSelect('supportIssue.transaction', 'transaction')
+      .leftJoinAndSelect('supportIssue.limitRequest', 'limitRequest')
+      .leftJoinAndSelect('supportIssue.messages', 'messages')
+      .where('supportIssue.userDataId = :userDataId', { userDataId })
+      .orderBy('supportIssue.created', 'DESC')
+      .getMany();
   }
 
   async getIssues(userDataId: number): Promise<SupportIssueDto[]> {
@@ -308,17 +311,24 @@ export class SupportIssueService {
   }
 
   async getIssueData(id: number, role: UserRole): Promise<SupportIssueInternalDataDto> {
-    const issue = await this.supportIssueRepo.findOne({
-      where: { id },
-      relations: {
-        transaction: {
-          user: { wallet: true },
-          buyCrypto: { transaction: true, cryptoInput: true },
-          buyFiat: { transaction: true, cryptoInput: true },
-        },
-        limitRequest: true,
-      },
-    });
+    const issue = await this.supportIssueRepo
+      .createQueryBuilder('supportIssue')
+      .leftJoinAndSelect('supportIssue.userData', 'userData')
+      .leftJoinAndSelect('userData.country', 'userDataCountry')
+      .leftJoinAndSelect('supportIssue.transaction', 'transaction')
+      .leftJoinAndSelect('transaction.user', 'user')
+      .leftJoinAndSelect('user.wallet', 'wallet')
+      .leftJoinAndSelect('transaction.buyCrypto', 'buyCrypto')
+      .leftJoinAndSelect('buyCrypto.outputAsset', 'buyCryptoOutputAsset')
+      .leftJoinAndSelect('buyCrypto.cryptoInput', 'buyCryptoInput')
+      .leftJoinAndSelect('buyCryptoInput.asset', 'buyCryptoInputAsset')
+      .leftJoinAndSelect('transaction.buyFiat', 'buyFiat')
+      .leftJoinAndSelect('buyFiat.outputAsset', 'buyFiatOutputAsset')
+      .leftJoinAndSelect('buyFiat.cryptoInput', 'buyFiatInput')
+      .leftJoinAndSelect('buyFiatInput.asset', 'buyFiatInputAsset')
+      .leftJoinAndSelect('supportIssue.limitRequest', 'limitRequest')
+      .where('supportIssue.id = :id', { id })
+      .getOne();
     if (!issue) throw new NotFoundException('Support issue not found');
 
     return SupportIssueDtoMapper.mapSupportIssueData(issue, role);


### PR DESCRIPTION
## Summary

- Rewrite three support-related repo queries (`getIssueData`, `getIssueEntities`, `getTransactionsByUserDataId`) from `findOne + relations` to explicit `createQueryBuilder` joins — avoids transitive eager-load fan-out through `BuyCrypto.transaction` / `BuyFiat.transaction` / `BankTxReturn.transaction` (all `eager: true`), which ballooned the query plan to 2–3s even when the target entity had zero related rows.
- Add optional chaining on `targetEntity?.outputAsset?.name` / `?.blockchain` in `SupportIssueDtoMapper.mapTransactionData` — fixes a 500 when a BuyCrypto has no outputAsset yet.

## Measured impact (DEV DB)

| Endpoint | Before | After | Factor |
|---|---|---|---|
| `GET /v1/support/issue/:id/data` (warm) | 2.3–4.0s | 66–90ms | 30–45× |
| `GET /v1/support/:id` (user w/ 75 txns, 19 issues) | ~900–2000ms | ~700ms | ~1.5–2.9× |
| `GET /v1/support/:id/transaction-pdf` | 655ms | 203ms | 3.2× |

## Data equivalence

Response payloads were diffed between DEV (old) and local (new) for:

- `GET /v1/support/:id` across 5 user profiles (empty, medium, heavy at 386KB / 75 txns / 19 issues / 338 kyc-logs / 512 ip-logs / 123 kyc-files) — **0 diff lines** after timezone normalization.
- `GET /v1/support/issue/:id/data` across 15 issues (empty, with transaction, with limitRequest, with messages) — **0 diff lines** on 14 of them; issue 64 shows the intentional mapper-fix difference (DEV 500 → 200).
- `GET /v1/support/:id/transaction-pdf` — decoded PDFs compared via `pdftotext -layout`; only diff is the generation-timestamp footer.

## Test plan

- [x] `npm run format` — unchanged
- [x] `npm run lint` — 0 warnings
- [x] `npm run type-check` — 0 errors
- [x] `npm test` — 927 passed, 0 failed
- [x] Local API against DEV DB — manual diff of all 3 affected endpoints
- [ ] DEV deploy + smoke test in compliance/support UI