### PR TITLE
fix: override protobufjs to resolve critical vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4957,30 +4957,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@grpc/grpc-js/node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -23257,30 +23233,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/nice-grpc/node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/nice-grpc/node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -24682,9 +24634,9 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -24698,14 +24650,18 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "uuid": "^9.0.0",
     "semver": "^7.6.0",
     "fast-xml-parser": "$fast-xml-parser",
-    "axios": "$axios"
+    "axios": "$axios",
+    "protobufjs": ">=7.5.5"
   }
 }


### PR DESCRIPTION
## Summary

Override `protobufjs` to `>=7.5.5` to fix all 3 critical npm audit vulnerabilities reported in the release PR #3581.

## Problem

`npm audit` reports 3 critical vulnerabilities, all caused by the same root issue: **protobufjs < 7.5.5** is affected by [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) — an **arbitrary code execution** vulnerability where a crafted protobuf message can execute arbitrary JavaScript code during parsing.

The 3 critical findings are:
1. **protobufjs@6.11.4** — directly affected
2. **@grpc/proto-loader@0.6.13** — pulls in vulnerable protobufjs 6.x
3. **@firebase/firestore@3.13.0** — depends on both affected grpc packages

## Root Cause

The vulnerable `protobufjs` versions are deeply nested transitive dependencies that cannot be updated by bumping direct dependencies:

```
@dhedge/v2-sdk@1.11.1
  └── @lyrafinance/lyra-js@0.0.20
        └── firebase@9.23.0
              └── @firebase/firestore@3.13.0
                    ├── @grpc/proto-loader@0.6.13 → protobufjs@6.11.4  ❌ critical
                    └── @grpc/grpc-js@1.7.3
                          └── @grpc/proto-loader@0.7.15 → protobufjs@7.5.4  ❌ critical

@buildonspark/spark-sdk@0.6.7
  └── nice-grpc@2.1.14
        └── @grpc/grpc-js@1.14.3
              └── @grpc/proto-loader@0.8.0 → protobufjs@7.5.4  ❌ critical
```

- `@lyrafinance/lyra-js` is unmaintained and pins `firebase@^9.9.4`
- Even upgrading `@dhedge/v2-sdk` to v2.x doesn't help — it still depends on `@lyrafinance/lyra-js@^0.0.20`
- The intermediate packages don't offer versions that resolve the transitive vulnerability

## Fix

Add an npm override in `package.json`:

```json
"overrides": {
  "protobufjs": ">=7.5.5"
}
```

This forces all nested `protobufjs` instances (including the 6.x one) to resolve to a patched version. This is consistent with the existing override pattern already used in this project for `body-parser`, `qs`, `semver`, `multer`, and others.

## Verification

| Check | Result |
|-------|--------|
| `npm audit` critical | **0** (was 3) |
| ESLint | ✅ pass |
| Prettier | ✅ pass |
| Build | ✅ pass |
| Tests | ✅ 927 passed (66 suites) |