### PR TITLE
fix: add concurrency group to DEV deploy workflow

### DIFF
--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
 env:
   AZURE_WEBAPP_NAME: app-dfx-api-dev
   AZURE_WEBAPP_PACKAGE_PATH: '.'


### PR DESCRIPTION
## Summary
- Adds `concurrency` group with `cancel-in-progress: true` to the DEV deploy workflow
- Fixes race condition where rapid successive pushes to develop trigger parallel Azure deploys, but only the first takes effect (Azure silently drops subsequent concurrent deploys)
- Root cause of [PR #3583](https://github.com/DFXswiss/api/pull/3583) CI failure: 3 commits in 3 minutes → 3 parallel deploys → DEV stuck on `b746ca6` while `d3ded0c` and `b2e4666` were lost

## Test plan
- [ ] Push two rapid commits to develop, verify only the latest deploy runs
- [ ] Confirm verify step passes for the surviving run