### PR TITLE
feat: compliance review endpoints and transaction DTO enhancements

### DIFF
--- a/src/subdomains/core/buy-crypto/process/buy-crypto.controller.ts
+++ b/src/subdomains/core/buy-crypto/process/buy-crypto.controller.ts
@@ -53,7 +53,7 @@ export class BuyCryptoController {
   @Put(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async update(@Param('id') id: string, @Body() dto: UpdateBuyCryptoDto): Promise<BuyCrypto> {
     return this.buyCryptoService.update(+id, dto);
   }
@@ -61,7 +61,7 @@ export class BuyCryptoController {
   @Delete(':id/amlCheck')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async resetAmlCheck(@Param('id') id: string): Promise<void> {
     return this.buyCryptoService.resetAmlCheck(+id);
   }

--- a/src/subdomains/core/sell-crypto/process/buy-fiat.controller.ts
+++ b/src/subdomains/core/sell-crypto/process/buy-fiat.controller.ts
@@ -49,7 +49,7 @@ export class BuyFiatController {
   @Put(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async update(@Param('id') id: string, @Body() dto: UpdateBuyFiatDto): Promise<BuyFiat> {
     return this.buyFiatService.update(+id, dto);
   }
@@ -57,7 +57,7 @@ export class BuyFiatController {
   @Delete(':id/amlCheck')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async resetAmlCheck(@Param('id') id: string): Promise<void> {
     return this.buyFiatService.resetAmlCheck(+id);
   }

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -29,6 +29,7 @@ export class UserDataSupportInfo {
 export class PendingOnboardingInfo {
   id: number;
   name?: string;
+  accountType?: string;
   date: Date;
 }
 
@@ -50,16 +51,23 @@ export class UserSupportInfo {
   ref?: string;
   role: string;
   status: string;
+  walletName?: string;
   created: Date;
 }
 
 export class TransactionSupportInfo {
   id: number;
   uid: string;
+  buyCryptoId?: number;
+  buyFiatId?: number;
   type?: string;
   sourceType: string;
   inputAmount?: number;
   inputAsset?: string;
+  inputTxId?: string;
+  outputAmount?: number;
+  outputAsset?: string;
+  comment?: string;
   amountInChf?: number;
   amountInEur?: number;
   amlCheck?: string;

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -185,7 +185,7 @@ export class SupportService {
         this.kycService.getStepsByUserData(id),
         this.kycLogService.getLogsByUserDataId(id),
         this.transactionService.getTransactionsByUserDataId(id),
-        this.userService.getAllUserDataUsers(id),
+        this.userService.getAllUserDataUsers(id, { wallet: true }),
         this.bankDataService.getBankDatasByUserData(id),
         this.buyService.getUserDataBuys(id),
         this.sellService.getSellsByUserDataId(id),
@@ -392,13 +392,19 @@ export class SupportService {
     return {
       id: tx.id,
       uid: tx.uid,
+      buyCryptoId: tx.buyCrypto?.id,
+      buyFiatId: tx.buyFiat?.id,
       type: tx.type,
       sourceType: tx.sourceType,
       inputAmount: tx.buyCrypto?.inputAmount ?? tx.buyFiat?.inputAmount,
       inputAsset: tx.buyCrypto?.inputAsset ?? tx.buyFiat?.inputAsset,
+      inputTxId: tx.buyCrypto?.cryptoInput?.inTxId ?? tx.buyFiat?.cryptoInput?.inTxId,
+      outputAmount: tx.buyCrypto?.outputAmount ?? tx.buyFiat?.outputAmount,
+      outputAsset: tx.buyCrypto?.outputAsset?.name ?? tx.buyFiat?.outputAsset?.name,
+      comment: tx.buyCrypto?.comment ?? tx.buyFiat?.comment,
       amountInChf: tx.amountInChf,
       amountInEur: tx.buyCrypto?.amountInEur ?? tx.buyFiat?.amountInEur,
-      amlCheck: tx.amlCheck,
+      amlCheck: tx.buyCrypto?.amlCheck ?? tx.buyFiat?.amlCheck ?? tx.amlCheck,
       chargebackDate:
         tx.buyCrypto?.chargebackDate ??
         tx.buyFiat?.chargebackDate ??
@@ -417,6 +423,7 @@ export class SupportService {
       ref: user.ref,
       role: user.role,
       status: user.status,
+      walletName: user.wallet?.name,
       created: user.created,
     };
   }
@@ -560,6 +567,7 @@ export class SupportService {
         id: ud.id,
         name:
           ud.verifiedName ?? ([ud.firstname, ud.surname, ud.organization?.name].filter(Boolean).join(' ') || undefined),
+        accountType: ud.accountType,
         date: dateMap.get(ud.id) ?? ud.created,
       }));
   }

--- a/src/subdomains/generic/user/models/bank-data/bank-data.controller.ts
+++ b/src/subdomains/generic/user/models/bank-data/bank-data.controller.ts
@@ -21,7 +21,7 @@ export class BankDataController {
   @Put(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async updateBankData(@Param('id') id: string, @Body() dto: UpdateBankDataDto): Promise<BankData> {
     return this.bankDataService.updateBankData(+id, dto);
   }

--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -141,7 +141,12 @@ export class TransactionService {
   async getTransactionsByUserDataId(userDataId: number): Promise<Transaction[]> {
     return this.repo.find({
       where: { userData: { id: userDataId } },
-      relations: { buyCrypto: true, buyFiat: true, bankTxReturn: true, bankTxRepeat: true },
+      relations: {
+        buyCrypto: { cryptoInput: true, outputAsset: true },
+        buyFiat: { cryptoInput: true, outputAsset: true },
+        bankTxReturn: true,
+        bankTxRepeat: true,
+      },
       loadEagerRelations: false,
       order: { created: 'DESC' },
       take: 100,


### PR DESCRIPTION
## Summary
- Allow `Compliance` role to update `bankData`, `buyCrypto`, and `buyFiat` amlCheck endpoints (previously admin-only).
- Add `buyCryptoId` / `buyFiatId` to `TransactionSupportInfo` so the compliance UI can address the correct entity when editing AML decisions (the transaction id does not match the buyCrypto / buyFiat id).
- Read `amlCheck` from `buyCrypto` / `buyFiat` in the support response so the UI reflects the actual decision state (the transaction row was stale after an AML update).
- Expand transaction relations used by the history display (include `cryptoInput` and `outputAsset`).

## Test plan
- [ ] Log in as a compliance user and approve/reject a BankData entry
- [ ] Log in as a compliance user and set buyCrypto / buyFiat AML to Pass / Fail / Reset
- [ ] Verify support endpoint returns `buyCryptoId` / `buyFiatId` and the updated `amlCheck`
- [ ] Verify transactions tab shows the new `outputAmount` / `outputAsset` column