### PR TITLE
feat: extend trade history check to refUser

### DIFF
--- a/src/subdomains/core/aml/enums/aml-error.enum.ts
+++ b/src/subdomains/core/aml/enums/aml-error.enum.ts
@@ -70,7 +70,7 @@ export enum AmlError {
   BANK_TX_CUSTOMER_NAME_MISSING = 'BankTxCustomerNameMissing',
   FORCE_MANUAL_CHECK = 'ForceManualCheck',
   ASSET_INPUT_NOT_ALLOWED = 'AssetInputNotAllowed',
-  RECOMMENDER_NO_TRADE_HISTORY = 'RecommenderNoTradeHistory',
+  REFERRAL_NO_TRADE_HISTORY = 'ReferralNoTradeHistory',
 }
 
 export const DelayResultError = [
@@ -347,7 +347,7 @@ export const AmlErrorResult: {
     amlCheck: CheckStatus.FAIL,
     amlReason: AmlReason.ASSET_INPUT_NOT_ALLOWED,
   },
-  [AmlError.RECOMMENDER_NO_TRADE_HISTORY]: {
+  [AmlError.REFERRAL_NO_TRADE_HISTORY]: {
     type: AmlErrorType.CRUCIAL,
     amlCheck: CheckStatus.PENDING,
     amlReason: AmlReason.MANUAL_CHECK_PHONE,

--- a/src/subdomains/core/aml/services/aml-helper.service.ts
+++ b/src/subdomains/core/aml/services/aml-helper.service.ts
@@ -83,17 +83,16 @@ export class AmlHelperService {
     if (!entity.userData.isPaymentKycStatusEnabled) errors.push(AmlError.INVALID_KYC_STATUS);
     if (refUser && !refUser.userData.isPaymentKycStatusEnabled) errors.push(AmlError.INVALID_KYC_STATUS_REF_USER);
     if (
-      recommender &&
-      !recommender.hasTradeHistory &&
       !entity.userData.phoneCallCheckDate &&
-      !recommender.isTrustedReferrer
+      ((recommender && !recommender.hasTradeHistory && !recommender.isTrustedReferrer) ||
+        (refUser && !refUser.userData.hasTradeHistory && !refUser.userData.isTrustedReferrer))
     )
       errors.push(
         entity.userData.phoneCallStatus === PhoneCallStatus.FAILED
           ? AmlError.USER_DATA_FAILED_CALL
           : entity.userData.phoneCallStatus === PhoneCallStatus.USER_REJECTED && !entity.userData.phoneCallAccepted
             ? AmlError.USER_DATA_REJECTED_CALL
-            : AmlError.RECOMMENDER_NO_TRADE_HISTORY,
+            : AmlError.REFERRAL_NO_TRADE_HISTORY,
       );
     if (entity.userData.kycType !== KycType.DFX) errors.push(AmlError.INVALID_KYC_TYPE);
     if (!entity.userData.verifiedName) errors.push(AmlError.NO_VERIFIED_NAME);


### PR DESCRIPTION
## Summary
- Extends the phone verification gate to also check the refUser (referral code owner) for trade history
- Both referral paths (recommendation and ref code) now trigger the same AML check
- Renamed enum to `REFERRAL_NO_TRADE_HISTORY` to reflect both paths

## Context
Follow-up to #3585 — the same abuse vector exists via referral codes, not just recommendations.

## Test plan
- [ ] Verify transactions from users with a non-trading refUser are held in `PENDING`
- [ ] Verify transactions from users with a non-trading recommender are still held in `PENDING`
- [ ] Verify trusted referrers are not affected
- [ ] Verify users without refUser/recommender are not affected
- [ ] Verify `phoneCallCheckDate` clears the block