### PR TITLE
feat: support dashboard counts endpoint, configurable clerks, message stats single query

### DIFF
--- a/src/shared/models/setting/setting-schema.registry.ts
+++ b/src/shared/models/setting/setting-schema.registry.ts
@@ -29,6 +29,9 @@ export const SettingSchemaRegistry: Record<string, SettingSchema> = {
   // Custom Balance Settings
   customBalanceAddresses: 'string[]',
   customBalanceAssets: 'string[]', // asset unique name
+
+  // Support
+  supportClerks: 'string[]',
 };
 
 export function isArraySchema(schema: SettingSchema): schema is ArraySchema {

--- a/src/shared/utils/dto-transforms.ts
+++ b/src/shared/utils/dto-transforms.ts
@@ -1,0 +1,11 @@
+import { Transform } from 'class-transformer';
+
+export const StringToArray = (): PropertyDecorator =>
+  Transform(({ value }) =>
+    typeof value === 'string'
+      ? value
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : value,
+  );

--- a/src/subdomains/supporting/support-issue/dto/get-support-issue.dto.ts
+++ b/src/subdomains/supporting/support-issue/dto/get-support-issue.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { StringToArray } from 'src/shared/utils/dto-transforms';
 import { Department } from '../enums/department.enum';
 import { SupportIssueInternalState, SupportIssueType } from '../enums/support-issue.enum';
 
@@ -18,10 +19,15 @@ export class GetSupportIssueListFilter {
   @IsEnum(Department)
   department?: Department;
 
-  @ApiPropertyOptional({ enum: SupportIssueInternalState })
+  @ApiPropertyOptional({
+    enum: SupportIssueInternalState,
+    isArray: true,
+    description: 'Comma-separated list of states',
+  })
   @IsOptional()
-  @IsEnum(SupportIssueInternalState)
-  state?: SupportIssueInternalState;
+  @StringToArray()
+  @IsEnum(SupportIssueInternalState, { each: true })
+  states?: SupportIssueInternalState[];
 
   @ApiPropertyOptional({ enum: SupportIssueType })
   @IsOptional()

--- a/src/subdomains/supporting/support-issue/dto/support-issue-dto.mapper.ts
+++ b/src/subdomains/supporting/support-issue/dto/support-issue-dto.mapper.ts
@@ -57,10 +57,10 @@ export class SupportIssueDtoMapper {
     return Object.assign(new SupportIssueInternalDataDto(), dto);
   }
 
-  static mapSupportIssueListItem(issue: SupportIssue): SupportIssueListDto {
-    const messages = issue.messages ?? [];
-    const lastMessage = messages.length > 0 ? messages.reduce((a, b) => (a.id > b.id ? a : b)) : undefined;
-
+  static mapSupportIssueListItem(
+    issue: SupportIssue,
+    stats?: { count: number; lastDate?: Date; lastAuthor?: string },
+  ): SupportIssueListDto {
     return {
       id: issue.id,
       uid: issue.uid,
@@ -71,9 +71,9 @@ export class SupportIssueDtoMapper {
       clerk: issue.clerk,
       department: issue.department,
       created: issue.created,
-      messageCount: messages.length,
-      lastMessageDate: lastMessage?.created,
-      lastMessageAuthor: lastMessage?.author,
+      messageCount: stats?.count ?? 0,
+      lastMessageDate: stats?.lastDate,
+      lastMessageAuthor: stats?.lastAuthor,
     };
   }
 

--- a/src/subdomains/supporting/support-issue/enums/department.enum.ts
+++ b/src/subdomains/supporting/support-issue/enums/department.enum.ts
@@ -1,6 +1,13 @@
+import { UserRole } from 'src/shared/auth/user-role.enum';
+
 export enum Department {
   SUPPORT = 'Support',
   COMPLIANCE = 'Compliance',
   MARKETING = 'Marketing',
   COOPERATION = 'Cooperation',
 }
+
+export const RoleDepartmentMap: Partial<Record<UserRole, Department>> = {
+  [UserRole.SUPPORT]: Department.SUPPORT,
+  [UserRole.COMPLIANCE]: Department.COMPLIANCE,
+};

--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -33,7 +33,7 @@ import {
 import { UpdateSupportIssueDto } from '../dto/update-support-issue.dto';
 import { SupportIssue } from '../entities/support-issue.entity';
 import { AutoResponder, CustomerAuthor, SupportMessage } from '../entities/support-message.entity';
-import { Department } from '../enums/department.enum';
+import { RoleDepartmentMap } from '../enums/department.enum';
 import { SupportIssueInternalState, SupportIssueReason, SupportIssueType } from '../enums/support-issue.enum';
 import { SupportLogType } from '../enums/support-log.enum';
 import { SupportIssueRepository } from '../repositories/support-issue.repository';
@@ -71,12 +71,7 @@ export class SupportIssueService {
       .addSelect('COUNT(*)', 'count')
       .groupBy('issue.state');
 
-    const roleDepartmentMap: Partial<Record<UserRole, Department>> = {
-      [UserRole.SUPPORT]: Department.SUPPORT,
-      [UserRole.COMPLIANCE]: Department.COMPLIANCE,
-    };
-
-    const departmentByRole = roleDepartmentMap[role];
+    const departmentByRole = RoleDepartmentMap[role];
     if (departmentByRole) qb.andWhere('issue.department = :department', { department: departmentByRole });
 
     const raw: { state: SupportIssueInternalState; count: string }[] = await qb.getRawMany();
@@ -91,11 +86,7 @@ export class SupportIssueService {
   }
 
   async getSupportIssueActivity(since: Date | undefined, role: UserRole): Promise<{ count: number; latestAt?: Date }> {
-    const roleDepartmentMap: Partial<Record<UserRole, Department>> = {
-      [UserRole.SUPPORT]: Department.SUPPORT,
-      [UserRole.COMPLIANCE]: Department.COMPLIANCE,
-    };
-    const departmentByRole = roleDepartmentMap[role];
+    const departmentByRole = RoleDepartmentMap[role];
 
     const qb = this.messageRepo
       .createQueryBuilder('m')
@@ -276,12 +267,7 @@ export class SupportIssueService {
     const where: FindOptionsWhere<SupportIssue> = {};
 
     // department filtering based on role
-    const roleDepartmentMap: Partial<Record<UserRole, Department>> = {
-      [UserRole.SUPPORT]: Department.SUPPORT,
-      [UserRole.COMPLIANCE]: Department.COMPLIANCE,
-    };
-
-    const departmentByRole = roleDepartmentMap[role];
+    const departmentByRole = RoleDepartmentMap[role];
     if (departmentByRole) {
       where.department = departmentByRole;
     } else if (filter.department) {
@@ -341,11 +327,23 @@ export class SupportIssueService {
         .select('m.issueId', 'issueId')
         .addSelect('COUNT(*)', 'count')
         .addSelect(
-          `(SELECT TOP 1 m2.created FROM support_message m2 WHERE m2.issueId = m.issueId ORDER BY m2.id DESC)`,
+          (sub) =>
+            sub
+              .select('m2.created')
+              .from(SupportMessage, 'm2')
+              .where('m2.issueId = m.issueId')
+              .orderBy('m2.id', 'DESC')
+              .limit(1),
           'lastDate',
         )
         .addSelect(
-          `(SELECT TOP 1 m2.author FROM support_message m2 WHERE m2.issueId = m.issueId ORDER BY m2.id DESC)`,
+          (sub) =>
+            sub
+              .select('m2.author')
+              .from(SupportMessage, 'm2')
+              .where('m2.issueId = m.issueId')
+              .orderBy('m2.id', 'DESC')
+              .limit(1),
           'lastAuthor',
         )
         .where('m.issueId IN (:...ids)', { ids: issueIds })

--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -90,6 +90,25 @@ export class SupportIssueService {
     return counts;
   }
 
+  async getSupportIssueActivity(since: Date | undefined, role: UserRole): Promise<{ count: number; latestAt?: Date }> {
+    const roleDepartmentMap: Partial<Record<UserRole, Department>> = {
+      [UserRole.SUPPORT]: Department.SUPPORT,
+      [UserRole.COMPLIANCE]: Department.COMPLIANCE,
+    };
+    const departmentByRole = roleDepartmentMap[role];
+
+    const qb = this.messageRepo
+      .createQueryBuilder('m')
+      .innerJoin('m.issue', 'i')
+      .select('COUNT(*)', 'count')
+      .addSelect('MAX(m.created)', 'latestAt');
+    if (since) qb.andWhere('m.created > :since', { since: since.toISOString() });
+    if (departmentByRole) qb.andWhere('i.department = :department', { department: departmentByRole });
+
+    const raw = await qb.getRawOne<{ count: string | number; latestAt: Date | null }>();
+    return { count: +(raw?.count ?? 0), latestAt: raw?.latestAt ?? undefined };
+  }
+
   async createTransactionRequestIssue(dto: CreateSupportIssueBaseDto): Promise<SupportIssueDto> {
     if (!dto?.transaction?.orderUid) throw new BadRequestException('JWT Token or quoteUid missing');
     const transactionRequest = await this.transactionRequestService.getTransactionRequestByUid(

--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -8,6 +8,7 @@ import {
 import { Config } from 'src/config/config';
 import { BlobContent } from 'src/integration/infrastructure/azure-storage.service';
 import { UserRole } from 'src/shared/auth/user-role.enum';
+import { SettingService } from 'src/shared/models/setting/setting.service';
 import { Util } from 'src/shared/utils/util';
 import { ContentType } from 'src/subdomains/generic/kyc/enums/content-type.enum';
 import { BankDataService } from 'src/subdomains/generic/user/models/bank-data/bank-data.service';
@@ -55,7 +56,39 @@ export class SupportIssueService {
     private readonly transactionRequestService: TransactionRequestService,
     private readonly supportLogService: SupportLogService,
     private readonly bankDataService: BankDataService,
+    private readonly settingService: SettingService,
   ) {}
+
+  async getSupportIssueClerks(): Promise<string[]> {
+    const clerks = await this.settingService.getObj<string[]>('supportClerks', []);
+    return clerks.length > 0 ? clerks : ['Support'];
+  }
+
+  async getSupportIssueCounts(role: UserRole): Promise<Record<SupportIssueInternalState, number>> {
+    const qb = this.supportIssueRepo
+      .createQueryBuilder('issue')
+      .select('issue.state', 'state')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('issue.state');
+
+    const roleDepartmentMap: Partial<Record<UserRole, Department>> = {
+      [UserRole.SUPPORT]: Department.SUPPORT,
+      [UserRole.COMPLIANCE]: Department.COMPLIANCE,
+    };
+
+    const departmentByRole = roleDepartmentMap[role];
+    if (departmentByRole) qb.andWhere('issue.department = :department', { department: departmentByRole });
+
+    const raw: { state: SupportIssueInternalState; count: string }[] = await qb.getRawMany();
+
+    const counts = Object.values(SupportIssueInternalState).reduce(
+      (acc, state) => ({ ...acc, [state]: 0 }),
+      {} as Record<SupportIssueInternalState, number>,
+    );
+    for (const row of raw) counts[row.state] = +row.count;
+
+    return counts;
+  }
 
   async createTransactionRequestIssue(dto: CreateSupportIssueBaseDto): Promise<SupportIssueDto> {
     if (!dto?.transaction?.orderUid) throw new BadRequestException('JWT Token or quoteUid missing');
@@ -236,7 +269,6 @@ export class SupportIssueService {
       where.department = filter.department;
     }
 
-    if (filter.state) where.state = filter.state;
     if (filter.type) where.type = filter.type;
 
     // server-side search: split query into terms, each term must match at least one field (AND between terms, OR between fields)
@@ -246,13 +278,11 @@ export class SupportIssueService {
       .filter((t) => t.length > 0)
       .slice(0, 10);
 
-    const qb = this.supportIssueRepo
-      .createQueryBuilder('issue')
-      .leftJoinAndSelect('issue.messages', 'messages')
-      .leftJoinAndSelect('issue.userData', 'userData');
+    const qb = this.supportIssueRepo.createQueryBuilder('issue');
+    if (terms.length > 0) qb.leftJoin('issue.userData', 'userData');
 
     if (where.department) qb.andWhere('issue.department = :department', { department: where.department });
-    if (where.state) qb.andWhere('issue.state = :state', { state: where.state });
+    if (filter.states?.length) qb.andWhere('issue.state IN (:...states)', { states: filter.states });
     if (where.type) qb.andWhere('issue.type = :type', { type: where.type });
 
     const termCount = Math.min(terms.length, 10);
@@ -273,7 +303,42 @@ export class SupportIssueService {
 
     const [issues, total] = await qb.getManyAndCount();
 
-    return { data: issues.map(SupportIssueDtoMapper.mapSupportIssueListItem), total };
+    const stats = await this.getMessageStats(issues.map((i) => i.id));
+
+    return {
+      data: issues.map((i) => SupportIssueDtoMapper.mapSupportIssueListItem(i, stats.get(i.id))),
+      total,
+    };
+  }
+
+  private async getMessageStats(
+    issueIds: number[],
+  ): Promise<Map<number, { count: number; lastDate?: Date; lastAuthor?: string }>> {
+    if (issueIds.length === 0) return new Map();
+
+    const rows: { issueId: string; count: string; lastDate: Date | null; lastAuthor: string | null }[] =
+      await this.messageRepo
+        .createQueryBuilder('m')
+        .select('m.issueId', 'issueId')
+        .addSelect('COUNT(*)', 'count')
+        .addSelect(
+          `(SELECT TOP 1 m2.created FROM support_message m2 WHERE m2.issueId = m.issueId ORDER BY m2.id DESC)`,
+          'lastDate',
+        )
+        .addSelect(
+          `(SELECT TOP 1 m2.author FROM support_message m2 WHERE m2.issueId = m.issueId ORDER BY m2.id DESC)`,
+          'lastAuthor',
+        )
+        .where('m.issueId IN (:...ids)', { ids: issueIds })
+        .groupBy('m.issueId')
+        .getRawMany();
+
+    return new Map(
+      rows.map((r) => [
+        +r.issueId,
+        { count: +r.count, lastDate: r.lastDate ?? undefined, lastAuthor: r.lastAuthor ?? undefined },
+      ]),
+    );
   }
 
   async getIssueEntities(userDataId: number): Promise<SupportIssue[]> {

--- a/src/subdomains/supporting/support-issue/support-issue.controller.ts
+++ b/src/subdomains/supporting/support-issue/support-issue.controller.ts
@@ -91,6 +91,17 @@ export class SupportIssueController {
     return this.supportIssueService.getSupportIssueCounts(jwt.role);
   }
 
+  @Get('activity')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.SUPPORT), UserActiveGuard())
+  async getSupportIssueActivity(
+    @GetJwt() jwt: JwtPayload,
+    @Query('since') since?: string,
+  ): Promise<{ count: number; latestAt?: Date }> {
+    return this.supportIssueService.getSupportIssueActivity(since ? new Date(since) : undefined, jwt.role);
+  }
+
   @Get('clerks')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()

--- a/src/subdomains/supporting/support-issue/support-issue.controller.ts
+++ b/src/subdomains/supporting/support-issue/support-issue.controller.ts
@@ -21,7 +21,7 @@ import { UpdateSupportIssueDto } from './dto/update-support-issue.dto';
 import { SupportIssue } from './entities/support-issue.entity';
 import { CustomerAuthor } from './entities/support-message.entity';
 import { Department } from './enums/department.enum';
-import { SupportIssueType } from './enums/support-issue.enum';
+import { SupportIssueInternalState, SupportIssueType } from './enums/support-issue.enum';
 import { SupportIssueService } from './services/support-issue.service';
 
 @ApiTags('Support')
@@ -81,6 +81,22 @@ export class SupportIssueController {
     @Query() filter: GetSupportIssueListFilter,
   ): Promise<{ data: SupportIssueListDto[]; total: number }> {
     return this.supportIssueService.getSupportIssueList(filter, jwt.role);
+  }
+
+  @Get('counts')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.SUPPORT), UserActiveGuard())
+  async getSupportIssueCounts(@GetJwt() jwt: JwtPayload): Promise<Record<SupportIssueInternalState, number>> {
+    return this.supportIssueService.getSupportIssueCounts(jwt.role);
+  }
+
+  @Get('clerks')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.SUPPORT), UserActiveGuard())
+  async getSupportIssueClerks(): Promise<string[]> {
+    return this.supportIssueService.getSupportIssueClerks();
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- **New endpoints**: `GET /support/issue/counts` (single `GROUP BY` query replaces 3 list calls) and `GET /support/issue/clerks` (reads from `supportClerks` setting, falls back to `['Support']`).
- **Setting**: registered `supportClerks` (`string[]`) in the schema registry so clerk names are configurable instead of hardcoded in the frontend.
- **Performance**: `getMessageStats` now uses a single correlated-subquery query instead of two round-trips.
- **DTO cleanup**: dropped single `state` filter in favor of `states` (comma-separated), added reusable `@StringToArray()` transform decorator, Swagger now advertises the enum with `isArray`.
- **Bug fix**: restored last-writer-wins clerk assignment on message creation (previous change left `AutoResponder` stuck as clerk).

## Test plan
- [ ] `GET /support/issue/counts` returns `{ Created, Pending, OnHold, Completed, Canceled }` counts honoring role-based department filter
- [ ] `GET /support/issue/clerks` returns configured list; `['Support']` when setting is missing or empty
- [ ] `GET /support/issue/list?states=OnHold,Canceled` filters correctly
- [ ] Sending a support reply updates `issue.clerk` to the message author
- [ ] Full test suite passes (`npm test`)