### PR TITLE
feat: compliance pending reviews endpoint

### DIFF
--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -1893,13 +1893,11 @@ export class KycService {
   }
 
   async getPendingReviewSteps(name: KycStepName, status: ReviewStatus): Promise<KycStep[]> {
-    return this.kycStepRepo
-      .createQueryBuilder('step')
-      .innerJoinAndSelect('step.userData', 'userData')
-      .where('step.name = :name', { name })
-      .andWhere('step.status = :status', { status })
-      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
-      .orderBy('step.updated', 'ASC')
-      .getMany();
+    return this.kycStepRepo.find({
+      where: { name, status, userData: { status: Not(UserDataStatus.MERGED) } },
+      relations: { userData: true },
+      loadEagerRelations: false,
+      order: { updated: 'ASC' },
+    });
   }
 }

--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -1874,4 +1874,32 @@ export class KycService {
       relations: { userData: true },
     });
   }
+
+  // --- Pending Review Queries ---
+
+  async getPendingReviewSummary(): Promise<{ name: KycStepName; status: ReviewStatus; count: number }[]> {
+    return this.kycStepRepo
+      .createQueryBuilder('step')
+      .select('step.name', 'name')
+      .addSelect('step.status', 'status')
+      .addSelect('COUNT(step.id)', 'count')
+      .innerJoin('step.userData', 'userData')
+      .where('step.status IN (:...statuses)', { statuses: [ReviewStatus.MANUAL_REVIEW, ReviewStatus.INTERNAL_REVIEW] })
+      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
+      .groupBy('step.name')
+      .addGroupBy('step.status')
+      .getRawMany<{ name: KycStepName; status: ReviewStatus; count: string }>()
+      .then((rows) => rows.map((r) => ({ name: r.name, status: r.status, count: Number(r.count) })));
+  }
+
+  async getPendingReviewSteps(name: KycStepName, status: ReviewStatus): Promise<KycStep[]> {
+    return this.kycStepRepo
+      .createQueryBuilder('step')
+      .innerJoinAndSelect('step.userData', 'userData')
+      .where('step.name = :name', { name })
+      .andWhere('step.status = :status', { status })
+      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
+      .orderBy('step.updated', 'ASC')
+      .getMany();
+  }
 }

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -1,6 +1,7 @@
 import { IsNotEmpty } from 'class-validator';
 import { BankTxType } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
 import { KycFile } from '../../kyc/entities/kyc-file.entity';
+import { ReviewStatus } from '../../kyc/enums/review-status.enum';
 import { AccountType } from '../../user/models/user-data/account-type.enum';
 import { UserData } from '../../user/models/user-data/user-data.entity';
 import { KycStatus } from '../../user/models/user-data/user-data.enum';
@@ -30,6 +31,28 @@ export class PendingOnboardingInfo {
   id: number;
   name?: string;
   accountType?: string;
+  date: Date;
+}
+
+export enum PendingReviewType {
+  KYC_STEP = 'KycStep',
+  BANK_DATA = 'BankData',
+}
+
+export class PendingReviewSummaryEntry {
+  type: PendingReviewType;
+  name: string;
+  manualReview: number;
+  internalReview: number;
+}
+
+export class PendingReviewItem {
+  id: number;
+  userDataId: number;
+  userName?: string;
+  accountType?: AccountType;
+  kycLevel?: number;
+  status: ReviewStatus;
   date: Date;
 }
 

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -10,10 +10,14 @@ import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
 import { ChargebackRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
 import { GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
+import { ReviewStatus } from '../kyc/enums/review-status.enum';
 import {
   KycFileListEntry,
   KycFileYearlyStats,
   PendingOnboardingInfo,
+  PendingReviewItem,
+  PendingReviewSummaryEntry,
+  PendingReviewType,
   RecommendationGraph,
   TransactionListEntry,
   UserDataSupportInfoDetails,
@@ -72,6 +76,26 @@ export class SupportController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getPendingOnboardings(): Promise<PendingOnboardingInfo[]> {
     return this.supportService.getPendingOnboardings();
+  }
+
+  @Get('pending-reviews')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getPendingReviews(): Promise<PendingReviewSummaryEntry[]> {
+    return this.supportService.getPendingReviewsSummary();
+  }
+
+  @Get('pending-reviews/items')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getPendingReviewItems(
+    @Query('type') type: PendingReviewType,
+    @Query('status') status: ReviewStatus,
+    @Query('name') name?: string,
+  ): Promise<PendingReviewItem[]> {
+    return this.supportService.getPendingReviewsList(type, name, status);
   }
 
   @Get(':id/ip-log-pdf')

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -79,6 +79,9 @@ import {
   TransactionSupportInfo,
   OnboardingStatus,
   PendingOnboardingInfo,
+  PendingReviewItem,
+  PendingReviewSummaryEntry,
+  PendingReviewType,
   UserDataSupportInfo,
   UserDataSupportInfoDetails,
   UserDataSupportInfoResult,
@@ -565,11 +568,84 @@ export class SupportService {
       .filter((ud): ud is UserData => !!ud)
       .map((ud) => ({
         id: ud.id,
-        name:
-          ud.verifiedName ?? ([ud.firstname, ud.surname, ud.organization?.name].filter(Boolean).join(' ') || undefined),
+        name: this.formatUserName(ud),
         accountType: ud.accountType,
         date: dateMap.get(ud.id) ?? ud.created,
       }));
+  }
+
+  async getPendingReviewsSummary(): Promise<PendingReviewSummaryEntry[]> {
+    const [kycRows, bankRows] = await Promise.all([
+      this.kycService.getPendingReviewSummary(),
+      this.bankDataService.getPendingReviewSummary(),
+    ]);
+
+    const allRows: { type: PendingReviewType; name: string; status: ReviewStatus; count: number }[] = [
+      ...kycRows.map((r) => ({ type: PendingReviewType.KYC_STEP, name: r.name, status: r.status, count: r.count })),
+      ...bankRows.map((r) => ({ type: PendingReviewType.BANK_DATA, name: r.name, status: r.status, count: r.count })),
+    ];
+
+    const entries = new Map<string, PendingReviewSummaryEntry>();
+
+    for (const row of allRows) {
+      const key = `${row.type}:${row.name}`;
+      const entry = entries.get(key) ?? { type: row.type, name: row.name, manualReview: 0, internalReview: 0 };
+      if (row.status === ReviewStatus.MANUAL_REVIEW) entry.manualReview = row.count;
+      else if (row.status === ReviewStatus.INTERNAL_REVIEW) entry.internalReview = row.count;
+      entries.set(key, entry);
+    }
+
+    return Array.from(entries.values()).sort((a, b) => {
+      if (a.type !== b.type) return a.type.localeCompare(b.type);
+      return a.name.localeCompare(b.name);
+    });
+  }
+
+  async getPendingReviewsList(
+    type: PendingReviewType,
+    name: string | undefined,
+    status: ReviewStatus,
+  ): Promise<PendingReviewItem[]> {
+    if (![ReviewStatus.MANUAL_REVIEW, ReviewStatus.INTERNAL_REVIEW].includes(status)) {
+      throw new BadRequestException('Status must be ManualReview or InternalReview');
+    }
+
+    if (type === PendingReviewType.KYC_STEP) {
+      if (!name) throw new BadRequestException('Name is required for KycStep lookup');
+      if (!Object.values(KycStepName).includes(name as KycStepName)) {
+        throw new BadRequestException('Unknown KycStepName');
+      }
+      const steps = await this.kycService.getPendingReviewSteps(name as KycStepName, status);
+      return steps.map((step) => this.toPendingReviewItem(step, status));
+    }
+
+    if (type === PendingReviewType.BANK_DATA) {
+      const bankDatas = await this.bankDataService.getPendingReviewList(status);
+      return bankDatas.map((bd) => this.toPendingReviewItem(bd, status));
+    }
+
+    throw new BadRequestException('Unknown review type');
+  }
+
+  private toPendingReviewItem(
+    entity: { id: number; userData: UserData; updated: Date },
+    status: ReviewStatus,
+  ): PendingReviewItem {
+    return {
+      id: entity.id,
+      userDataId: entity.userData.id,
+      userName: this.formatUserName(entity.userData),
+      accountType: entity.userData.accountType,
+      kycLevel: entity.userData.kycLevel,
+      status,
+      date: entity.updated,
+    };
+  }
+
+  private formatUserName(ud: UserData): string | undefined {
+    return (
+      ud.verifiedName ?? ([ud.firstname, ud.surname, ud.organization?.name].filter(Boolean).join(' ') || undefined)
+    );
   }
 
   //*** HELPER METHODS ***//

--- a/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
+++ b/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
@@ -484,12 +484,11 @@ export class BankDataService {
   }
 
   async getPendingReviewList(status: ReviewStatus): Promise<BankData[]> {
-    return this.bankDataRepo
-      .createQueryBuilder('bankData')
-      .innerJoinAndSelect('bankData.userData', 'userData')
-      .where('bankData.status = :status', { status })
-      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
-      .orderBy('bankData.updated', 'ASC')
-      .getMany();
+    return this.bankDataRepo.find({
+      where: { status, userData: { status: Not(UserDataStatus.MERGED) } },
+      relations: { userData: true },
+      loadEagerRelations: false,
+      order: { updated: 'ASC' },
+    });
   }
 }

--- a/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
+++ b/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
@@ -465,4 +465,31 @@ export class BankDataService {
   get bankDataObservable(): Observable<BankData> {
     return this.newUserBankDataSubject.asObservable();
   }
+
+  // --- Pending Review Queries ---
+
+  async getPendingReviewSummary(): Promise<{ name: string; status: ReviewStatus; count: number }[]> {
+    return this.bankDataRepo
+      .createQueryBuilder('bankData')
+      .select('bankData.status', 'status')
+      .addSelect('COUNT(bankData.id)', 'count')
+      .innerJoin('bankData.userData', 'userData')
+      .where('bankData.status IN (:...statuses)', {
+        statuses: [ReviewStatus.MANUAL_REVIEW, ReviewStatus.INTERNAL_REVIEW],
+      })
+      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
+      .groupBy('bankData.status')
+      .getRawMany<{ status: ReviewStatus; count: string }>()
+      .then((rows) => rows.map((r) => ({ name: 'BankData', status: r.status, count: Number(r.count) })));
+  }
+
+  async getPendingReviewList(status: ReviewStatus): Promise<BankData[]> {
+    return this.bankDataRepo
+      .createQueryBuilder('bankData')
+      .innerJoinAndSelect('bankData.userData', 'userData')
+      .where('bankData.status = :status', { status })
+      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
+      .orderBy('bankData.updated', 'ASC')
+      .getMany();
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `GET /support/pending-reviews` returning a summary of all `kyc_step` and `bank_data` entries in `ManualReview` or `InternalReview`, grouped by type and name with per-status counts.
- Adds `GET /support/pending-reviews/items?type=&name=&status=` returning the affected users for a given review category.
- Both endpoints mirror the auth/role guards of the existing `pending-onboardings` endpoint (Compliance role required).
- Refactors the existing name-fallback logic in `getPendingOnboardings` into a reusable helper to avoid drift.

## Context
Today the compliance team relies on an external Google Sheet (`NutzerMonitoring`) to see pending manual checks. The new endpoints expose the same data from the internal database, enabling the services frontend to render a `Pending Reviews` section on the compliance landing page (see companion PR in the services repo).

The implementation covers a superset of the Google Sheet scope — in addition to all explicitly tracked step types, it includes `NameChange`, `AddressChange`, `PhoneChange`, and any other `KycStepName` that happens to be in `ManualReview`/`InternalReview`.

## Test plan
- [ ] `/support/pending-reviews` returns one entry per `(type, name)` with `manualReview` and `internalReview` counts matching the DB.
- [ ] `/support/pending-reviews/items?type=KycStep&name=Ident&status=ManualReview` returns the expected users.
- [ ] `/support/pending-reviews/items?type=BankData&status=ManualReview` returns the expected bank data entries.
- [ ] Unauthenticated requests return 401; non-compliance roles return 403.
- [ ] Merged users are excluded.
- [ ] Existing `/support/pending-onboardings` endpoint is unaffected.