### PR TITLE
Fix CI security audit level

### DIFF
--- a/.github/workflows/api-pr.yaml
+++ b/.github/workflows/api-pr.yaml
@@ -49,5 +49,4 @@ jobs:
         run: npm run test
 
       - name: Security audit
-        run: npm audit --audit-level=high
-        continue-on-error: true
+        run: npm audit --audit-level=critical


### PR DESCRIPTION
## Summary

- Change `npm audit --audit-level=high` to `--audit-level=critical` in PR CI
- Remove `continue-on-error: true` so the step actually blocks on critical CVEs

The audit step has been permanently red on every PR due to 179 vulnerabilities (73 high, 0 critical) in transitive crypto dependencies (`@openzeppelin`, `@ethersproject`, `ws`, etc.). With `continue-on-error: true` it never blocked anything — just produced a misleading error annotation.

Now it only fails on critical CVEs (currently 0) and will actually block if one appears.

## Test plan

- [ ] CI passes without the misleading error annotation
- [ ] `npm audit --audit-level=critical` exits 0 (verified locally)