### PR TITLE
feat: add reason field to recall entity

### DIFF
--- a/migration/1776930994259-AddRecallReason.js
+++ b/migration/1776930994259-AddRecallReason.js
@@ -1,0 +1,19 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddRecallReason1776930994259 {
+    name = 'AddRecallReason1776930994259'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "recall" ADD "reason" nvarchar(256)`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "recall" DROP COLUMN "reason"`);
+    }
+}

--- a/migration/1776930994259-AddRecallReason.js
+++ b/migration/1776930994259-AddRecallReason.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
  */
 
 /**
@@ -9,10 +10,16 @@
 module.exports = class AddRecallReason1776930994259 {
     name = 'AddRecallReason1776930994259'
 
+    /**
+     * @param {QueryRunner} queryRunner
+     */
     async up(queryRunner) {
         await queryRunner.query(`ALTER TABLE "recall" ADD "reason" nvarchar(256)`);
     }
 
+    /**
+     * @param {QueryRunner} queryRunner
+     */
     async down(queryRunner) {
         await queryRunner.query(`ALTER TABLE "recall" DROP COLUMN "reason"`);
     }

--- a/src/subdomains/supporting/recall/dto/create-recall.dto.ts
+++ b/src/subdomains/supporting/recall/dto/create-recall.dto.ts
@@ -1,4 +1,5 @@
-import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateIf } from 'class-validator';
+import { IsEnum, IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateIf } from 'class-validator';
+import { RecallReason } from '../recall-reason.enum';
 
 export class CreateRecallDto {
   @IsNotEmpty()
@@ -26,4 +27,8 @@ export class CreateRecallDto {
   @IsNotEmpty()
   @IsNumber()
   fee: number;
+
+  @IsNotEmpty()
+  @IsEnum(RecallReason)
+  reason: RecallReason;
 }

--- a/src/subdomains/supporting/recall/dto/update-recall.dto.ts
+++ b/src/subdomains/supporting/recall/dto/update-recall.dto.ts
@@ -1,5 +1,6 @@
-import { IsInt, IsNumber, IsString } from 'class-validator';
+import { IsEnum, IsInt, IsNumber, IsString } from 'class-validator';
 import { IsOptionalButNotNull } from 'src/shared/validators/is-not-null.validator';
+import { RecallReason } from '../recall-reason.enum';
 
 export class UpdateRecallDto {
   @IsOptionalButNotNull()
@@ -17,4 +18,8 @@ export class UpdateRecallDto {
   @IsOptionalButNotNull()
   @IsNumber()
   fee?: number;
+
+  @IsOptionalButNotNull()
+  @IsEnum(RecallReason)
+  reason?: RecallReason;
 }

--- a/src/subdomains/supporting/recall/recall-reason.enum.ts
+++ b/src/subdomains/supporting/recall/recall-reason.enum.ts
@@ -1,0 +1,9 @@
+export enum RecallReason {
+  DUPL = 'DUPL',
+  TECH = 'TECH',
+  FRAD = 'FRAD',
+  CUST = 'CUST',
+  AM09 = 'AM09',
+  AC03 = 'AC03',
+  UNKNOWN = 'Unknown',
+}

--- a/src/subdomains/supporting/recall/recall.entity.ts
+++ b/src/subdomains/supporting/recall/recall.entity.ts
@@ -3,6 +3,7 @@ import { User } from 'src/subdomains/generic/user/models/user/user.entity';
 import { Column, Entity, Index, ManyToOne } from 'typeorm';
 import { BankTx } from '../bank-tx/bank-tx/entities/bank-tx.entity';
 import { CheckoutTx } from '../fiat-payin/entities/checkout-tx.entity';
+import { RecallReason } from './recall-reason.enum';
 
 @Entity()
 @Index((r: Recall) => [r.bankTx, r.checkoutTx, r.sequence], { unique: true })
@@ -24,4 +25,7 @@ export class Recall extends IEntity {
 
   @Column({ type: 'float' })
   fee: number;
+
+  @Column({ length: 256, nullable: true })
+  reason?: RecallReason;
 }


### PR DESCRIPTION
## Summary
- Adds mandatory `reason` field to newly created recalls using SEPA ISO 20022 reason codes
- Enum values: `DUPL`, `TECH`, `FRAD`, `CUST`, `AM09`, `AC03`, `Unknown` (fallback)
- DB column is nullable — existing recalls keep `NULL`, only new creates via `CreateRecallDto` are required to pass a reason
- `UpdateRecallDto` accepts `reason` as optional-but-not-null

## Test plan
- [ ] Run migration `1776930994259-AddRecallReason` on DEV, verify column exists as `nvarchar(256)` nullable
- [ ] POST `/recall` without `reason` → 400 validation error
- [ ] POST `/recall` with valid enum value → 201, row persisted with reason
- [ ] POST `/recall` with invalid enum value → 400 validation error
- [ ] PUT `/recall/:id` updating only `reason` → row updated, other fields untouched
- [ ] Verify existing recalls (reason = NULL) are still readable