### PR TITLE
feat: add MROS reporting module

### DIFF
--- a/migration/1776932301279-AddMros.js
+++ b/migration/1776932301279-AddMros.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddMros1776932301279 {
+    name = 'AddMros1776932301279'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`CREATE TABLE "mros" ("id" int NOT NULL IDENTITY(1,1), "updated" datetime2 NOT NULL CONSTRAINT "DF_mros_updated" DEFAULT getdate(), "created" datetime2 NOT NULL CONSTRAINT "DF_mros_created" DEFAULT getdate(), "status" nvarchar(256) NOT NULL, "submissionDate" datetime2, "authorityReference" nvarchar(256), "caseManager" nvarchar(256) NOT NULL, "userDataId" int NOT NULL, CONSTRAINT "PK_mros" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "mros" ADD CONSTRAINT "FK_mros_userData" FOREIGN KEY ("userDataId") REFERENCES "user_data"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "mros" DROP CONSTRAINT "FK_mros_userData"`);
+        await queryRunner.query(`DROP TABLE "mros"`);
+    }
+}

--- a/src/subdomains/supporting/mros/dto/create-mros.dto.ts
+++ b/src/subdomains/supporting/mros/dto/create-mros.dto.ts
@@ -1,0 +1,24 @@
+import { IsDateString, IsEnum, IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { MrosStatus } from '../mros-status.enum';
+
+export class CreateMrosDto {
+  @IsNotEmpty()
+  @IsInt()
+  userDataId: number;
+
+  @IsNotEmpty()
+  @IsEnum(MrosStatus)
+  status: MrosStatus;
+
+  @IsOptional()
+  @IsDateString()
+  submissionDate?: Date;
+
+  @IsOptional()
+  @IsString()
+  authorityReference?: string;
+
+  @IsNotEmpty()
+  @IsString()
+  caseManager: string;
+}

--- a/src/subdomains/supporting/mros/dto/update-mros.dto.ts
+++ b/src/subdomains/supporting/mros/dto/update-mros.dto.ts
@@ -1,0 +1,21 @@
+import { IsDateString, IsEnum, IsString } from 'class-validator';
+import { IsOptionalButNotNull } from 'src/shared/validators/is-not-null.validator';
+import { MrosStatus } from '../mros-status.enum';
+
+export class UpdateMrosDto {
+  @IsOptionalButNotNull()
+  @IsEnum(MrosStatus)
+  status?: MrosStatus;
+
+  @IsOptionalButNotNull()
+  @IsDateString()
+  submissionDate?: Date;
+
+  @IsOptionalButNotNull()
+  @IsString()
+  authorityReference?: string;
+
+  @IsOptionalButNotNull()
+  @IsString()
+  caseManager?: string;
+}

--- a/src/subdomains/supporting/mros/mros-status.enum.ts
+++ b/src/subdomains/supporting/mros/mros-status.enum.ts
@@ -1,0 +1,6 @@
+export enum MrosStatus {
+  DRAFT = 'Draft',
+  SUBMITTED = 'Submitted',
+  CONFIRMED = 'Confirmed',
+  CLOSED = 'Closed',
+}

--- a/src/subdomains/supporting/mros/mros.controller.ts
+++ b/src/subdomains/supporting/mros/mros.controller.ts
@@ -17,7 +17,7 @@ export class MrosController {
   @Post()
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async createMros(@Body() dto: CreateMrosDto): Promise<void> {
     await this.mrosService.create(dto);
   }
@@ -25,7 +25,7 @@ export class MrosController {
   @Put(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async updateMros(@Param('id') id: string, @Body() dto: UpdateMrosDto): Promise<void> {
     await this.mrosService.update(+id, dto);
   }
@@ -33,7 +33,7 @@ export class MrosController {
   @Get()
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getAll(): Promise<Mros[]> {
     return this.mrosService.getAll();
   }
@@ -41,7 +41,7 @@ export class MrosController {
   @Get(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getById(@Param('id') id: string): Promise<Mros> {
     return this.mrosService.getById(+id);
   }

--- a/src/subdomains/supporting/mros/mros.controller.ts
+++ b/src/subdomains/supporting/mros/mros.controller.ts
@@ -1,0 +1,48 @@
+import { Body, Controller, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
+import { RoleGuard } from 'src/shared/auth/role.guard';
+import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
+import { UserRole } from 'src/shared/auth/user-role.enum';
+import { CreateMrosDto } from './dto/create-mros.dto';
+import { UpdateMrosDto } from './dto/update-mros.dto';
+import { Mros } from './mros.entity';
+import { MrosService } from './mros.service';
+
+@ApiTags('Mros')
+@Controller('mros')
+export class MrosController {
+  constructor(private readonly mrosService: MrosService) {}
+
+  @Post()
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  async createMros(@Body() dto: CreateMrosDto): Promise<void> {
+    await this.mrosService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  async updateMros(@Param('id') id: string, @Body() dto: UpdateMrosDto): Promise<void> {
+    await this.mrosService.update(+id, dto);
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  async getAll(): Promise<Mros[]> {
+    return this.mrosService.getAll();
+  }
+
+  @Get(':id')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  async getById(@Param('id') id: string): Promise<Mros> {
+    return this.mrosService.getById(+id);
+  }
+}

--- a/src/subdomains/supporting/mros/mros.entity.ts
+++ b/src/subdomains/supporting/mros/mros.entity.ts
@@ -1,0 +1,22 @@
+import { IEntity } from 'src/shared/models/entity';
+import { UserData } from 'src/subdomains/generic/user/models/user-data/user-data.entity';
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { MrosStatus } from './mros-status.enum';
+
+@Entity()
+export class Mros extends IEntity {
+  @ManyToOne(() => UserData, { nullable: false })
+  userData: UserData;
+
+  @Column({ length: 256 })
+  status: MrosStatus;
+
+  @Column({ type: 'datetime2', nullable: true })
+  submissionDate?: Date;
+
+  @Column({ length: 256, nullable: true })
+  authorityReference?: string;
+
+  @Column({ length: 256 })
+  caseManager: string;
+}

--- a/src/subdomains/supporting/mros/mros.module.ts
+++ b/src/subdomains/supporting/mros/mros.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SharedModule } from 'src/shared/shared.module';
+import { UserModule } from 'src/subdomains/generic/user/user.module';
+import { MrosController } from './mros.controller';
+import { Mros } from './mros.entity';
+import { MrosRepository } from './mros.repository';
+import { MrosService } from './mros.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Mros]), SharedModule, UserModule],
+  controllers: [MrosController],
+  providers: [MrosRepository, MrosService],
+  exports: [],
+})
+export class MrosModule {}

--- a/src/subdomains/supporting/mros/mros.repository.ts
+++ b/src/subdomains/supporting/mros/mros.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { BaseRepository } from 'src/shared/repositories/base.repository';
+import { EntityManager } from 'typeorm';
+import { Mros } from './mros.entity';
+
+@Injectable()
+export class MrosRepository extends BaseRepository<Mros> {
+  constructor(manager: EntityManager) {
+    super(Mros, manager);
+  }
+}

--- a/src/subdomains/supporting/mros/mros.service.ts
+++ b/src/subdomains/supporting/mros/mros.service.ts
@@ -7,7 +7,10 @@ import { MrosRepository } from './mros.repository';
 
 @Injectable()
 export class MrosService {
-  constructor(private readonly repo: MrosRepository, private readonly userDataService: UserDataService) {}
+  constructor(
+    private readonly repo: MrosRepository,
+    private readonly userDataService: UserDataService,
+  ) {}
 
   async create(dto: CreateMrosDto): Promise<Mros> {
     const entity = this.repo.create(dto);

--- a/src/subdomains/supporting/mros/mros.service.ts
+++ b/src/subdomains/supporting/mros/mros.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UserDataService } from 'src/subdomains/generic/user/models/user-data/user-data.service';
+import { CreateMrosDto } from './dto/create-mros.dto';
+import { UpdateMrosDto } from './dto/update-mros.dto';
+import { Mros } from './mros.entity';
+import { MrosRepository } from './mros.repository';
+
+@Injectable()
+export class MrosService {
+  constructor(private readonly repo: MrosRepository, private readonly userDataService: UserDataService) {}
+
+  async create(dto: CreateMrosDto): Promise<Mros> {
+    const entity = this.repo.create(dto);
+
+    entity.userData = await this.userDataService.getUserData(dto.userDataId);
+    if (!entity.userData) throw new NotFoundException('UserData not found');
+
+    return this.repo.save(entity);
+  }
+
+  async update(id: number, dto: UpdateMrosDto): Promise<Mros> {
+    const entity = await this.repo.findOneBy({ id });
+    if (!entity) throw new NotFoundException('Mros not found');
+
+    return this.repo.save({ ...entity, ...dto });
+  }
+
+  async getAll(): Promise<Mros[]> {
+    return this.repo.find({ relations: { userData: true } });
+  }
+
+  async getById(id: number): Promise<Mros> {
+    const entity = await this.repo.findOne({ where: { id }, relations: { userData: true } });
+    if (!entity) throw new NotFoundException('Mros not found');
+
+    return entity;
+  }
+}

--- a/src/subdomains/supporting/supporting.module.ts
+++ b/src/subdomains/supporting/supporting.module.ts
@@ -8,6 +8,7 @@ import { DexModule } from './dex/dex.module';
 import { FiatOutputModule } from './fiat-output/fiat-output.module';
 import { FiatPayInModule } from './fiat-payin/fiat-payin.module';
 import { LogModule } from './log/log.module';
+import { MrosModule } from './mros/mros.module';
 import { NotificationModule } from './notification/notification.module';
 import { PayInModule } from './payin/payin.module';
 import { PayoutModule } from './payout/payout.module';
@@ -34,6 +35,7 @@ import { SupportIssueModule } from './support-issue/support-issue.module';
     FiatOutputModule,
     SupportIssueModule,
     RecallModule,
+    MrosModule,
   ],
   controllers: [],
   providers: [],


### PR DESCRIPTION
## Summary
- Adds `Mros` entity under `subdomains/supporting/mros/` for compliance dashboard
- Tracks SAR / Meldestelle für Geldwäscherei filings linked to `UserData`
- Fields: `status` (enum: Draft/Submitted/Confirmed/Closed), `submissionDate`, `authorityReference`, `caseManager` (free text)
- Admin-only REST: `POST /mros`, `PUT /mros/:id`, `GET /mros`, `GET /mros/:id`
- Migration creates `mros` table with FK on `user_data(id)`

## Notes
- Migration uses readable constraint names (`PK_mros`, `FK_mros_userData`, …) because it was hand-written. If preferred, regenerate via `npm run migration:generate` to get the hash-based names consistent with the auto-generated repo style.

## Test plan
- [ ] Run migration on DEV, verify `mros` table + FK created
- [ ] POST `/mros` with valid payload → 201, row persisted
- [ ] POST without required fields (userDataId/status/caseManager) → 400
- [ ] POST with invalid `status` value → 400
- [ ] PUT `/mros/:id` updating `status` → row updated
- [ ] GET `/mros` → returns list with `userData` relation
- [ ] GET `/mros/:id` → returns single entry, 404 if missing
- [ ] All endpoints reject non-ADMIN users