### PR TITLE
ci: skip pull_request workflows for bot-authored release PRs

### DIFF
--- a/.github/workflows/api-pr.yaml
+++ b/.github/workflows/api-pr.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Build and test
-    if: github.head_ref != 'develop'
+    if: github.head_ref != 'develop' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: github.event_name != 'pull_request' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   review:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Release-PRs `develop → main` werden vom `github-actions[bot]` automatisch erstellt
- GitHub blockt standardmäßig alle `pull_request`-Workflows, die vom Bot getriggert werden → UI zeigt "3 workflows awaiting approval"
- Dieselben Checks laufen bereits beim Push auf `develop`, die PR-Runs sind also redundant
- Mit `if: github.actor != 'github-actions[bot]'` auf Job-Level werden die Workflows bei Bot-PRs übersprungen; für echte Entwickler-PRs ändert sich nichts

## Changes
- `api-pr.yaml` — Actor-Filter zusätzlich zum bestehenden `head_ref != 'develop'`
- `codeql.yml` — Filter nur für `pull_request`-Event (push-Runs bleiben unangetastet)
- `pr-review-bot.yml` — Filter auf einzigen Job

## Test plan
- [ ] Nach Merge in develop: nächster Auto-Release-PR erstellt keine "awaiting approval"-Workflows mehr
- [ ] Nächster normaler Feature-PR triggert weiterhin alle 3 Workflows