### PR TITLE
ci: use PAT to create release PRs

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Create Release PR
         if: steps.check-pr.outputs.pr_exists == 'false' && steps.check-diff.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           COMMIT_COUNT: ${{ steps.check-diff.outputs.commit_count }}
         run: |
           printf '%s\n' \


### PR DESCRIPTION
## Summary
- Release-PRs `develop → main` werden vom `auto-release-pr.yaml` Workflow erstellt
- Bisher nutzt der Workflow `secrets.GITHUB_TOKEN` → PR wird `github-actions[bot]` zugeschrieben → alle `pull_request`-Workflows werden mit `action_required` blockiert
- Fix: `gh pr create` verwendet neu `secrets.RELEASE_PR_TOKEN` (PAT eines echten Users) → PR triggert CI normal ohne Approval-Gate

## Required setup before merge
Vor dem Merge muss der Secret `RELEASE_PR_TOKEN` im Repo angelegt werden:

1. Fine-grained Personal Access Token erstellen unter https://github.com/settings/personal-access-tokens/new
   - **Resource owner:** DFXswiss
   - **Repository access:** Only select repositories → `DFXswiss/api`
   - **Repository permissions:**
     - `Contents`: Read-only
     - `Pull requests`: Read and write
   - Expiration: max. 1 Jahr (Reminder setzen)
2. Token kopieren
3. Unter https://github.com/DFXswiss/api/settings/secrets/actions als neuen Repo-Secret `RELEASE_PR_TOKEN` speichern

## Test plan
- [ ] Secret `RELEASE_PR_TOKEN` im Repo angelegt
- [ ] PR gemerged in develop
- [ ] Nach nächstem Push auf develop: neuer Release-PR wird als Autor des PAT-Owners erstellt
- [ ] Keine "awaiting approval"-Workflows mehr sichtbar am Release-PR
- [ ] API PR CI / CodeQL / PR Review Bot laufen automatisch durch