### PR TITLE
feat: add recall list endpoints for compliance dashboard

### DIFF
--- a/src/subdomains/supporting/recall/recall.controller.ts
+++ b/src/subdomains/supporting/recall/recall.controller.ts
@@ -17,7 +17,7 @@ export class RecallController {
   @Post()
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async createRecall(@Body() dto: CreateRecallDto): Promise<void> {
     await this.recallService.create(dto);
   }
@@ -25,7 +25,7 @@ export class RecallController {
   @Put(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async updateRecall(@Param('id') id: string, @Body() dto: UpdateRecallDto): Promise<void> {
     await this.recallService.update(+id, dto);
   }
@@ -33,7 +33,7 @@ export class RecallController {
   @Get()
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getAll(): Promise<Recall[]> {
     return this.recallService.getAll();
   }
@@ -41,7 +41,7 @@ export class RecallController {
   @Get(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getById(@Param('id') id: string): Promise<Recall> {
     return this.recallService.getById(+id);
   }

--- a/src/subdomains/supporting/recall/recall.controller.ts
+++ b/src/subdomains/supporting/recall/recall.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth, ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 import { RoleGuard } from 'src/shared/auth/role.guard';
@@ -6,6 +6,7 @@ import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
 import { UserRole } from 'src/shared/auth/user-role.enum';
 import { CreateRecallDto } from './dto/create-recall.dto';
 import { UpdateRecallDto } from './dto/update-recall.dto';
+import { Recall } from './recall.entity';
 import { RecallService } from './recall.service';
 
 @ApiTags('Recall')
@@ -27,5 +28,21 @@ export class RecallController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
   async updateRecall(@Param('id') id: string, @Body() dto: UpdateRecallDto): Promise<void> {
     await this.recallService.update(+id, dto);
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  async getAll(): Promise<Recall[]> {
+    return this.recallService.getAll();
+  }
+
+  @Get(':id')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  async getById(@Param('id') id: string): Promise<Recall> {
+    return this.recallService.getById(+id);
   }
 }

--- a/src/subdomains/supporting/recall/recall.service.ts
+++ b/src/subdomains/supporting/recall/recall.service.ts
@@ -48,4 +48,18 @@ export class RecallService {
 
     return this.repo.save({ ...entity, ...dto });
   }
+
+  async getAll(): Promise<Recall[]> {
+    return this.repo.find({ relations: { bankTx: true, checkoutTx: true, user: true } });
+  }
+
+  async getById(id: number): Promise<Recall> {
+    const entity = await this.repo.findOne({
+      where: { id },
+      relations: { bankTx: true, checkoutTx: true, user: true },
+    });
+    if (!entity) throw new NotFoundException('Recall not found');
+
+    return entity;
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `GET /recall` (list all) and `GET /recall/:id` (single) on `RecallController`
- Eager-loads `bankTx`, `checkoutTx` and `user` relations so the compliance dashboard receives full context without extra calls
- Admin-only guard stack matches existing POST/PUT routes

## Test plan
- [ ] GET `/recall` as ADMIN → 200, array with all recalls incl. relations
- [ ] GET `/recall/:id` valid id → 200, single recall with relations
- [ ] GET `/recall/:id` invalid id → 404
- [ ] GET endpoints reject non-ADMIN users