### PR TITLE
ci: block modifications to existing migration files

### DIFF
--- a/.github/workflows/api-migration-check.yaml
+++ b/.github/workflows/api-migration-check.yaml
@@ -1,0 +1,37 @@
+name: API Migration Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'migration/**'
+
+permissions:
+  contents: read
+
+jobs:
+  immutability:
+    name: Migration immutability
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block changes to existing migrations
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=100
+          CHANGED=$(git diff --name-status origin/${{ github.base_ref }}...HEAD -- migration/ \
+                    | awk '$1 ~ /^[MDR]/ {print}')
+          if [ -n "$CHANGED" ]; then
+            echo "::error::Existing migrations must not be modified, renamed or deleted."
+            echo ""
+            echo "$CHANGED"
+            echo ""
+            echo "If a migration is wrong, add a follow-up migration instead of editing the old one."
+            exit 1
+          fi
+          echo "No existing migrations were modified."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/api-migration-check.yaml` with a lightweight PR check that fails when an existing migration file is modified, renamed or deleted.
- Forces corrections to come in as a follow-up migration instead of editing the original.

## Context
Motivated by #3613, where the MROS migration constraint names were fixed by renaming the migration file and rewriting its contents. That works on PRD (first run), but breaks any environment where the original migration has already run — the renamed file will try to re-create an existing table.

General rule: once a migration is on a long-lived branch, it is applied somewhere. Editing it creates silent drift.

## Scope
- DB-agnostic (pure git diff on `migration/`), so it survives the upcoming MSSQL → PostgreSQL migration unchanged.
- A future schema-drift check (entity ↔ migration consistency) is intentionally left out — that one is DB-specific and better set up on the new PG baseline.

## Escape hatch
If the PG migration wipes the `migration/` folder and starts from a fresh baseline, this check would block that PR. Either temporarily disable the workflow for that single PR or extend the job with a label-based skip. Can be added when needed.

## Test plan
- [ ] CI runs on this PR and passes (no existing migrations touched).
- [ ] Verify the `paths` filter only triggers the job when `migration/**` changes.
- [ ] After merge: open a throwaway PR that edits an old migration file and confirm the check fails.