### PR TITLE
feat: include BankTxReturn and BankTxRepeat in compliance search (name + IBAN)

### DIFF
--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -19,6 +19,7 @@ import { SellService } from 'src/subdomains/core/sell-crypto/route/sell.service'
 import { BankTxReturnService } from 'src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service';
 import {
   BankTx,
+  BankTxComplianceSearchableTypes,
   BankTxType,
   BankTxTypeUnassigned,
 } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
@@ -526,7 +527,12 @@ export class SupportService {
   async searchUserDataByKey(query: UserDataSupportQuery): Promise<UserDataSupportInfoResult> {
     const searchResult = await this.getUserDatasByKey(query.key);
     const bankTx = [ComplianceSearchType.IBAN, ComplianceSearchType.VIRTUAL_IBAN].includes(searchResult.type)
-      ? await this.bankTxService.getUnassignedBankTx([query.key], [query.key])
+      ? await this.bankTxService.getUnassignedBankTx(
+          [query.key],
+          [query.key],
+          undefined,
+          BankTxComplianceSearchableTypes,
+        )
       : searchResult.type === ComplianceSearchType.NAME
         ? await this.bankTxService.getBankTxsByName(query.key)
         : [];

--- a/src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity.ts
@@ -427,3 +427,9 @@ export const BankTxUnassignedTypes = [BankTxType.GSHEET, BankTxType.UNKNOWN, Ban
 export function BankTxTypeUnassigned(bankTxType?: BankTxType): boolean {
   return BankTxUnassignedTypes.includes(bankTxType);
 }
+
+export const BankTxComplianceSearchableTypes = [
+  ...BankTxUnassignedTypes,
+  BankTxType.BANK_TX_RETURN,
+  BankTxType.BANK_TX_REPEAT,
+];

--- a/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
@@ -557,7 +557,7 @@ export class BankTxService implements OnModuleInit {
 
   async getBankTxsByName(name: string): Promise<BankTx[]> {
     const request: FindOptionsWhere<BankTx> = {
-      type: In(BankTxUnassignedTypes),
+      type: In([...BankTxUnassignedTypes, BankTxType.BANK_TX_RETURN]),
       creditDebitIndicator: BankTxIndicator.CREDIT,
     };
 

--- a/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
+++ b/src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service.ts
@@ -50,6 +50,7 @@ import { UpdateBankTxDto } from '../dto/update-bank-tx.dto';
 import { BankTxBatch } from '../entities/bank-tx-batch.entity';
 import {
   BankTx,
+  BankTxComplianceSearchableTypes,
   BankTxIndicator,
   BankTxType,
   BankTxTypeCompleted,
@@ -533,9 +534,10 @@ export class BankTxService implements OnModuleInit {
     accounts: string[],
     virtualIbans: string[],
     relations: FindOptionsRelations<BankTx> = { transaction: true },
+    types: BankTxType[] = BankTxUnassignedTypes,
   ): Promise<BankTx[]> {
     const request: FindOptionsWhere<BankTx> = {
-      type: In(BankTxUnassignedTypes),
+      type: In(types),
       creditDebitIndicator: BankTxIndicator.CREDIT,
     };
 
@@ -557,7 +559,7 @@ export class BankTxService implements OnModuleInit {
 
   async getBankTxsByName(name: string): Promise<BankTx[]> {
     const request: FindOptionsWhere<BankTx> = {
-      type: In([...BankTxUnassignedTypes, BankTxType.BANK_TX_RETURN]),
+      type: In(BankTxComplianceSearchableTypes),
       creditDebitIndicator: BankTxIndicator.CREDIT,
     };
 


### PR DESCRIPTION
## Summary
Compliance search (`GET /support?key=<...>`) now also surfaces **completed-but-still-name-bearing** bank_tx rows — both on **name** and **IBAN/virtualIBAN** lookups.

### Covered types (additional)
- `BankTxReturn` — original credit that was later returned to sender
- `BankTxRepeat` — original credit that was re-sent / duplicated

Exposed via new exported constant `BankTxComplianceSearchableTypes = [...BankTxUnassignedTypes, BANK_TX_RETURN, BANK_TX_REPEAT]`.

### Changes
- `bank-tx.entity.ts`: new exported `BankTxComplianceSearchableTypes`.
- `bank-tx.service.ts`:
  - `getBankTxsByName` → uses the new constant (was inline spread incl. only `BANK_TX_RETURN`).
  - `getUnassignedBankTx` → new optional `types` param (default = `BankTxUnassignedTypes`), so the user-facing `/transaction/unassigned` endpoint is unaffected.
- `support.service.ts`: IBAN/virtualIBAN branch passes `BankTxComplianceSearchableTypes` when calling `getUnassignedBankTx`.

### Motivation
Already-returned or repeated deposits were invisible in compliance search, even though the sender's name/IBAN is still on the record. Example: bank_tx 156149 (MEEKERS MARCEL JOHANNES, returned 01.07.2025) — not findable by name until now.

### Scope notes
- `BANK_TX_RETURN_CHARGEBACK` intentionally **not** included (scope decision).
- Kundenseitiger `/transaction/unassigned` bleibt unverändert (type default unchanged).

## Test plan
- [ ] Name search for `MEEKERS  MARCEL JOHANNES` → bank_tx 156149 (type=BankTxReturn) must appear in `bankTx` list.
- [ ] Name search that only matches a `BankTxRepeat` credit → must appear.
- [ ] Name search on a `Pending` tx → still found (regression check).
- [ ] IBAN search where the only matching tx is `BankTxReturn`/`BankTxRepeat` → must appear.
- [ ] `GET /transaction/unassigned` (customer view) → **still** only `GSheet/Unknown/Pending` (no regression, no returns shown to customers).