### PR TITLE
feat: auto-derive recall user from bank tx

### DIFF
--- a/src/subdomains/supporting/recall/recall.service.ts
+++ b/src/subdomains/supporting/recall/recall.service.ts
@@ -25,8 +25,17 @@ export class RecallService {
     }
 
     if (dto.bankTxId) {
-      entity.bankTx = await this.bankTxService.getBankTxById(dto.bankTxId);
+      // Load the relations referenced by the BankTx.user getter so it resolves.
+      // Transaction.user, BuyCrypto.transaction and BuyFiat.transaction are eager,
+      // so the user chain cascades transitively from these top-level relations.
+      entity.bankTx = await this.bankTxService.getBankTxById(dto.bankTxId, {
+        transaction: true,
+        buyCrypto: true,
+        buyCryptoChargeback: true,
+        buyFiats: true,
+      });
       if (!entity.bankTx) throw new NotFoundException('BankTx not found');
+      if (!entity.user) entity.user = entity.bankTx.user;
     }
 
     if (dto.checkoutTxId) {


### PR DESCRIPTION
## Summary
- When POST /recall is called with `bankTxId` but no explicit `userId`, derive the user automatically from the bank-tx relation chain (transaction → buyCrypto → buyCryptoChargeback → buyFiats)
- Load the relations needed by `BankTx.user` getter so it actually resolves

## Why
Lets the services frontend create recalls from contexts (user-data transactions tab) where no userId is available on the client side — the bank tx already knows its owning user via the existing getter, so deriving it server-side keeps the frontend simple.

Backward compatible: existing callers that pass `userId` explicitly keep the same behavior.

## Test plan
- [ ] POST /recall with `{ bankTxId, sequence, reason, comment, fee }` (no userId) → recall created, `recall.user` matches the bankTx's owning user
- [ ] POST /recall with explicit `userId` → behaves as before
- [ ] POST /recall with `checkoutTxId` only → unchanged