### PR TITLE
feat: include recall info in bank tx support responses

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty } from 'class-validator';
 import { BankTxType } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
+import { RecallReason } from 'src/subdomains/supporting/recall/recall-reason.enum';
 import { KycFile } from '../../kyc/entities/kyc-file.entity';
 import { AccountType } from '../../user/models/user-data/account-type.enum';
 import { UserData } from '../../user/models/user-data/user-data.entity';
@@ -43,6 +44,16 @@ export class BankTxSupportInfo {
   name?: string;
   iban?: string;
   remittanceInfo?: string;
+  recall?: RecallSupportInfo;
+}
+
+export class RecallSupportInfo {
+  id: number;
+  created: Date;
+  sequence: number;
+  reason?: RecallReason;
+  comment: string;
+  fee: number;
 }
 
 export class UserSupportInfo {

--- a/src/subdomains/generic/support/support.module.ts
+++ b/src/subdomains/generic/support/support.module.ts
@@ -7,6 +7,7 @@ import { BankTxModule } from 'src/subdomains/supporting/bank-tx/bank-tx.module';
 import { PayInModule } from 'src/subdomains/supporting/payin/payin.module';
 import { PaymentModule } from 'src/subdomains/supporting/payment/payment.module';
 import { TransactionModule } from 'src/subdomains/supporting/payment/transaction.module';
+import { RecallModule } from 'src/subdomains/supporting/recall/recall.module';
 import { SupportIssueModule } from 'src/subdomains/supporting/support-issue/support-issue.module';
 import { KycModule } from '../kyc/kyc.module';
 import { UserModule } from '../user/user.module';
@@ -26,6 +27,7 @@ import { SupportService } from './support.service';
     KycModule,
     TransactionModule,
     SupportIssueModule,
+    RecallModule,
     forwardRef(() => PaymentModule),
   ],
   controllers: [SupportController],

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -17,6 +17,8 @@ import { BuyFiatService } from 'src/subdomains/core/sell-crypto/process/services
 import { Sell } from 'src/subdomains/core/sell-crypto/route/sell.entity';
 import { SellService } from 'src/subdomains/core/sell-crypto/route/sell.service';
 import { BankTxReturnService } from 'src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service';
+import { Recall } from 'src/subdomains/supporting/recall/recall.entity';
+import { RecallService } from 'src/subdomains/supporting/recall/recall.service';
 import {
   BankTx,
   BankTxComplianceSearchableTypes,
@@ -70,6 +72,7 @@ import {
   KycFileYearlyStats,
   KycLogSupportInfo,
   KycStepSupportInfo,
+  RecallSupportInfo,
   RecommendationEntry,
   RecommendationGraph,
   RecommendationGraphEdge,
@@ -122,6 +125,7 @@ export class SupportService {
     private readonly supportIssueService: SupportIssueService,
     private readonly kycDocumentService: KycDocumentService,
     private readonly supportPdfService: SupportPdfService,
+    private readonly recallService: RecallService,
   ) {}
 
   async generateIpLogPdf(userDataId: number): Promise<string> {
@@ -211,6 +215,7 @@ export class SupportService {
         return bankTx;
       });
     const bankTxs = [...incomingBankTxs, ...outgoingBankTxs];
+    const recallByBankTxId = await this.buildRecallByBankTxIdMap(bankTxs.map((b) => b.id));
 
     // Load recommendation data for Recommendation steps
     const recommendationStepIds = kycSteps.filter((s) => s.name === KycStepName.RECOMMENDATION).map((s) => s.id);
@@ -242,7 +247,7 @@ export class SupportService {
       ),
       kycLogs: kycLogs.map((l) => this.toKycLogSupportInfo(l)),
       transactions: transactions.map((t) => this.toTransactionSupportInfo(t)),
-      bankTxs: bankTxs.map((b) => this.toBankTxDto(b)),
+      bankTxs: bankTxs.map((b) => this.toBankTxDto(b, recallByBankTxId.get(b.id))),
       cryptoInputs: cryptoInputs.map((c) => this.toCryptoInputSupportInfo(c)),
       ipLogs: ipLogs.map((l) => this.toIpLogSupportInfo(l)),
       supportIssues: supportIssues.map((s) => this.toSupportIssueSupportInfo(s)),
@@ -550,11 +555,12 @@ export class SupportService {
 
     const orgUserIds = uniqueUserDatas.filter((u) => u.accountType === AccountType.ORGANIZATION).map((u) => u.id);
     const onboardingStatuses = await this.getDfxApprovalStatuses(orgUserIds);
+    const recallByBankTxId = await this.buildRecallByBankTxIdMap(bankTx.map((b) => b.id));
 
     return {
       type: searchResult.type,
       userDatas: uniqueUserDatas.map((u) => this.toUserDataDto(u, onboardingStatuses)),
-      bankTx: bankTx.sort((a, b) => a.id - b.id).map((b) => this.toBankTxDto(b)),
+      bankTx: bankTx.sort((a, b) => a.id - b.id).map((b) => this.toBankTxDto(b, recallByBankTxId.get(b.id))),
     };
   }
 
@@ -718,7 +724,7 @@ export class SupportService {
     };
   }
 
-  private toBankTxDto(bankTx: BankTx): BankTxSupportInfo {
+  private toBankTxDto(bankTx: BankTx, recall?: Recall): BankTxSupportInfo {
     return {
       id: bankTx.id,
       transactionId: bankTx.transaction?.id,
@@ -729,7 +735,24 @@ export class SupportService {
       name: bankTx.completeName(),
       iban: bankTx.iban,
       remittanceInfo: bankTx.remittanceInfo,
+      recall: recall ? this.toRecallSupportInfo(recall) : undefined,
     };
+  }
+
+  private toRecallSupportInfo(recall: Recall): RecallSupportInfo {
+    return {
+      id: recall.id,
+      created: recall.created,
+      sequence: recall.sequence,
+      reason: recall.reason,
+      comment: recall.comment,
+      fee: recall.fee,
+    };
+  }
+
+  private async buildRecallByBankTxIdMap(bankTxIds: number[]): Promise<Map<number, Recall>> {
+    const recalls = await this.recallService.findByBankTxIds(bankTxIds);
+    return new Map(recalls.map((r) => [r.bankTx.id, r]));
   }
 
   private toCryptoInputSupportInfo(ci: CryptoInput): CryptoInputSupportInfo {

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -751,7 +751,7 @@ export class SupportService {
   }
 
   private async buildRecallByBankTxIdMap(bankTxIds: number[]): Promise<Map<number, Recall>> {
-    const recalls = await this.recallService.findByBankTxIds(bankTxIds);
+    const recalls = await this.recallService.getByBankTxIds(bankTxIds);
     return new Map(recalls.map((r) => [r.bankTx.id, r]));
   }
 

--- a/src/subdomains/supporting/recall/recall.module.ts
+++ b/src/subdomains/supporting/recall/recall.module.ts
@@ -13,6 +13,6 @@ import { RecallService } from './recall.service';
   imports: [TypeOrmModule.forFeature([Recall]), SharedModule, UserModule, BankTxModule, FiatPayInModule],
   controllers: [RecallController],
   providers: [RecallRepository, RecallService],
-  exports: [],
+  exports: [RecallService],
 })
 export class RecallModule {}

--- a/src/subdomains/supporting/recall/recall.service.ts
+++ b/src/subdomains/supporting/recall/recall.service.ts
@@ -63,7 +63,7 @@ export class RecallService {
     return this.repo.find({ relations: { bankTx: true, checkoutTx: true, user: true } });
   }
 
-  async findByBankTxIds(bankTxIds: number[]): Promise<Recall[]> {
+  async getByBankTxIds(bankTxIds: number[]): Promise<Recall[]> {
     if (!bankTxIds.length) return [];
     return this.repo.find({
       where: { bankTx: { id: In(bankTxIds) } },

--- a/src/subdomains/supporting/recall/recall.service.ts
+++ b/src/subdomains/supporting/recall/recall.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { UserService } from 'src/subdomains/generic/user/models/user/user.service';
+import { In } from 'typeorm';
 import { BankTxService } from '../bank-tx/bank-tx/services/bank-tx.service';
 import { CheckoutTxService } from '../fiat-payin/services/checkout-tx.service';
 import { CreateRecallDto } from './dto/create-recall.dto';
@@ -60,6 +61,14 @@ export class RecallService {
 
   async getAll(): Promise<Recall[]> {
     return this.repo.find({ relations: { bankTx: true, checkoutTx: true, user: true } });
+  }
+
+  async findByBankTxIds(bankTxIds: number[]): Promise<Recall[]> {
+    if (!bankTxIds.length) return [];
+    return this.repo.find({
+      where: { bankTx: { id: In(bankTxIds) } },
+      relations: { bankTx: true },
+    });
   }
 
   async getById(id: number): Promise<Recall> {


### PR DESCRIPTION
## Summary
- Adds `recall?: RecallSupportInfo` to `BankTxSupportInfo`, so both the compliance search result and the user-data detail endpoint carry the recall (if any) directly on the bank tx
- Lets the frontend render "Recall exists" state without an extra roundtrip
- `RecallService.findByBankTxIds` batches the lookup for a whole response; `SupportService` builds a bankTxId → Recall map and hands it to `toBankTxDto`

## Notes
- `RecallSupportInfo` exposes `id`, `created`, `sequence`, `reason`, `comment`, `fee` — same fields as `RecallListEntry` minus the bankTx/checkoutTx/user refs (implicit from context)
- No backend change to the recall creation flow
- Requires the services PR (to be opened) to render the new field

## Test plan
- [ ] GET /support/userData/:id → `bankTxs[i].recall` present when a recall exists for that bank tx, absent otherwise
- [ ] POST /support/userDataByKey (compliance search) → `bankTx[i].recall` present / absent accordingly