### PR TITLE
feat: add personOverrides JSON column to Mros (PR 1.2)

### DIFF
--- a/migration/1777101337758-AddMrosPersonOverrides.js
+++ b/migration/1777101337758-AddMrosPersonOverrides.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddMrosPersonOverrides1777101337758 {
+    name = 'AddMrosPersonOverrides1777101337758'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "mros" ADD "personOverrides" nvarchar(MAX)`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "mros" DROP COLUMN "personOverrides"`);
+    }
+}

--- a/migration/1777101337758-AddMrosPersonOverrides.js
+++ b/migration/1777101337758-AddMrosPersonOverrides.js
@@ -14,7 +14,7 @@ module.exports = class AddMrosPersonOverrides1777101337758 {
      * @param {QueryRunner} queryRunner
      */
     async up(queryRunner) {
-        await queryRunner.query(`ALTER TABLE "mros" ADD "personOverrides" nvarchar(MAX)`);
+        await queryRunner.query(`ALTER TABLE "mros" ADD "personOverrides" ntext`);
     }
 
     /**

--- a/src/subdomains/supporting/mros/dto/create-mros.dto.ts
+++ b/src/subdomains/supporting/mros/dto/create-mros.dto.ts
@@ -1,5 +1,17 @@
-import { IsArray, IsDateString, IsEnum, IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { MrosStatus } from '../mros-status.enum';
+import { MrosPersonOverridesDto } from './mros-person-overrides.dto';
 
 export class CreateMrosDto {
   @IsNotEmpty()
@@ -38,4 +50,10 @@ export class CreateMrosDto {
   @IsArray()
   @IsString({ each: true })
   indicators?: string[];
+
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => MrosPersonOverridesDto)
+  personOverrides?: MrosPersonOverridesDto;
 }

--- a/src/subdomains/supporting/mros/dto/mros-person-overrides.dto.ts
+++ b/src/subdomains/supporting/mros/dto/mros-person-overrides.dto.ts
@@ -1,0 +1,39 @@
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+
+export class MrosPersonOverridesDto {
+  @IsOptional()
+  @IsString()
+  gender?: string;
+
+  @IsOptional()
+  @IsString()
+  middleName?: string;
+
+  @IsOptional()
+  @IsString()
+  birthPlace?: string;
+
+  @IsOptional()
+  @IsString()
+  profession?: string;
+
+  @IsOptional()
+  @IsString()
+  sourceOfWealth?: string;
+
+  @IsOptional()
+  @IsString()
+  canton?: string;
+
+  @IsOptional()
+  @IsDateString()
+  idDocIssueDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  idDocValidUntil?: string;
+
+  @IsOptional()
+  @IsString()
+  idDocIssuingCountryCode?: string;
+}

--- a/src/subdomains/supporting/mros/dto/update-mros.dto.ts
+++ b/src/subdomains/supporting/mros/dto/update-mros.dto.ts
@@ -1,6 +1,8 @@
-import { IsArray, IsDateString, IsEnum, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsArray, IsDateString, IsEnum, IsObject, IsString, ValidateNested } from 'class-validator';
 import { IsOptionalButNotNull } from 'src/shared/validators/is-not-null.validator';
 import { MrosStatus } from '../mros-status.enum';
+import { MrosPersonOverridesDto } from './mros-person-overrides.dto';
 
 export class UpdateMrosDto {
   @IsOptionalButNotNull()
@@ -35,4 +37,10 @@ export class UpdateMrosDto {
   @IsArray()
   @IsString({ each: true })
   indicators?: string[];
+
+  @IsOptionalButNotNull()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => MrosPersonOverridesDto)
+  personOverrides?: MrosPersonOverridesDto;
 }

--- a/src/subdomains/supporting/mros/mros.entity.ts
+++ b/src/subdomains/supporting/mros/mros.entity.ts
@@ -3,6 +3,18 @@ import { UserData } from 'src/subdomains/generic/user/models/user-data/user-data
 import { Column, Entity, ManyToOne } from 'typeorm';
 import { MrosStatus } from './mros-status.enum';
 
+export interface MrosPersonOverrides {
+  gender?: string;
+  middleName?: string;
+  birthPlace?: string;
+  profession?: string;
+  sourceOfWealth?: string;
+  canton?: string;
+  idDocIssueDate?: string;
+  idDocValidUntil?: string;
+  idDocIssuingCountryCode?: string;
+}
+
 @Entity()
 export class Mros extends IEntity {
   @ManyToOne(() => UserData, { nullable: false })
@@ -39,5 +51,19 @@ export class Mros extends IEntity {
 
   set indicatorCodes(codes: string[]) {
     this.indicators = JSON.stringify(codes);
+  }
+
+  // JSON-serialized MrosPersonOverrides — fields that override UserData
+  // when the compliance officer needs to supply goAML-required data that
+  // is not captured on UserData (e.g. gender, middle name, profession).
+  @Column({ length: 'MAX', nullable: true })
+  personOverrides?: string;
+
+  get personOverridesObject(): MrosPersonOverrides {
+    return this.personOverrides ? JSON.parse(this.personOverrides) : {};
+  }
+
+  set personOverridesObject(overrides: MrosPersonOverrides) {
+    this.personOverrides = JSON.stringify(overrides);
   }
 }

--- a/src/subdomains/supporting/mros/mros.entity.ts
+++ b/src/subdomains/supporting/mros/mros.entity.ts
@@ -53,17 +53,9 @@ export class Mros extends IEntity {
     this.indicators = JSON.stringify(codes);
   }
 
-  // JSON-serialized MrosPersonOverrides — fields that override UserData
-  // when the compliance officer needs to supply goAML-required data that
-  // is not captured on UserData (e.g. gender, middle name, profession).
-  @Column({ length: 'MAX', nullable: true })
-  personOverrides?: string;
-
-  get personOverridesObject(): MrosPersonOverrides {
-    return this.personOverrides ? JSON.parse(this.personOverrides) : {};
-  }
-
-  set personOverridesObject(overrides: MrosPersonOverrides) {
-    this.personOverrides = JSON.stringify(overrides);
-  }
+  // Fields that override UserData when the compliance officer needs to
+  // supply goAML-required data that is not captured on UserData (e.g.
+  // gender, middle name, profession).
+  @Column({ type: 'simple-json', nullable: true })
+  personOverrides?: MrosPersonOverrides;
 }

--- a/src/subdomains/supporting/mros/mros.service.ts
+++ b/src/subdomains/supporting/mros/mros.service.ts
@@ -13,14 +13,13 @@ export class MrosService {
   ) {}
 
   async create(dto: CreateMrosDto): Promise<Mros> {
-    const { userDataId, indicators, personOverrides, ...rest } = dto;
+    const { userDataId, indicators, ...rest } = dto;
     const entity = this.repo.create(rest);
 
     entity.userData = await this.userDataService.getUserData(userDataId);
     if (!entity.userData) throw new NotFoundException('UserData not found');
 
     if (indicators) entity.indicatorCodes = indicators;
-    if (personOverrides) entity.personOverridesObject = personOverrides;
 
     return this.repo.save(entity);
   }
@@ -29,10 +28,9 @@ export class MrosService {
     const entity = await this.repo.findOneBy({ id });
     if (!entity) throw new NotFoundException('Mros not found');
 
-    const { indicators, personOverrides, ...rest } = dto;
+    const { indicators, ...rest } = dto;
     Object.assign(entity, rest);
     if (indicators !== undefined) entity.indicatorCodes = indicators;
-    if (personOverrides !== undefined) entity.personOverridesObject = personOverrides;
 
     return this.repo.save(entity);
   }

--- a/src/subdomains/supporting/mros/mros.service.ts
+++ b/src/subdomains/supporting/mros/mros.service.ts
@@ -13,13 +13,14 @@ export class MrosService {
   ) {}
 
   async create(dto: CreateMrosDto): Promise<Mros> {
-    const { userDataId, indicators, ...rest } = dto;
+    const { userDataId, indicators, personOverrides, ...rest } = dto;
     const entity = this.repo.create(rest);
 
     entity.userData = await this.userDataService.getUserData(userDataId);
     if (!entity.userData) throw new NotFoundException('UserData not found');
 
     if (indicators) entity.indicatorCodes = indicators;
+    if (personOverrides) entity.personOverridesObject = personOverrides;
 
     return this.repo.save(entity);
   }
@@ -28,9 +29,10 @@ export class MrosService {
     const entity = await this.repo.findOneBy({ id });
     if (!entity) throw new NotFoundException('Mros not found');
 
-    const { indicators, ...rest } = dto;
+    const { indicators, personOverrides, ...rest } = dto;
     Object.assign(entity, rest);
     if (indicators !== undefined) entity.indicatorCodes = indicators;
+    if (personOverrides !== undefined) entity.personOverridesObject = personOverrides;
 
     return this.repo.save(entity);
   }


### PR DESCRIPTION
## Summary
Second of four small API PRs preparing Mros for goAML SAR export. Adds an optional `personOverrides` JSON column so compliance officers can supply goAML-required person data that's not available on `UserData`:

- `gender`
- `middleName`
- `birthPlace`
- `profession`
- `sourceOfWealth`
- `canton`
- `idDocIssueDate`
- `idDocValidUntil`
- `idDocIssuingCountryCode`

All fields are optional — an override is only stored when the officer actively enters it; otherwise the goAML XML falls back to UserData at export time (Phase 2).

## Pattern
Stored as a single `nvarchar(MAX)` JSON string with a typed getter/setter `personOverridesObject`, following the canonical `priceStepsObject` / `creditorData` patterns from `buy-crypto.entity.ts`.

## Migration
Per `CONTRIBUTING.md`, the schema migration must be generated locally:

\`\`\`bash
cd ~/Documents/GitHub/dfx/api
git pull
git checkout feat/mros-person-overrides
npm run migration AddMrosPersonOverrides
git add migration/*-AddMrosPersonOverrides.js
git commit -m "feat: add migration for mros personOverrides"
git push
\`\`\`

## Roadmap
- PR 1.1 (merged): core report fields
- **PR 1.2 (this one): personOverrides JSON column**
- PR 1.3: Mros ↔ Transaction many-to-many
- PR 1.4: frontend edit page
- Phase 2: XML export + XSD validation + download endpoint

## Test plan
- [ ] Migration generated locally, applies cleanly (up + down)
- [ ] POST /mros with personOverrides object → stored as JSON, readable via personOverridesObject
- [ ] PUT /mros/:id with personOverrides → updates; absent → existing preserved
- [ ] Nested DTO validation rejects wrong types (e.g. gender: 123)