### PR TITLE
feat: link transactions to Mros via many-to-many (PR 1.3)

### DIFF
--- a/migration/1777101483212-AddMrosTransactionsRelation.js
+++ b/migration/1777101483212-AddMrosTransactionsRelation.js
@@ -1,0 +1,34 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddMrosTransactionsRelation1777101483212 {
+    name = 'AddMrosTransactionsRelation1777101483212'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`CREATE TABLE "mros_transactions_transaction" ("mrosId" int NOT NULL, "transactionId" int NOT NULL, CONSTRAINT "PK_dd31d8f58065fa662d9e73e5a88" PRIMARY KEY ("mrosId", "transactionId"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_1289fce229c942a9404926bf7e" ON "mros_transactions_transaction" ("mrosId")`);
+        await queryRunner.query(`CREATE INDEX "IDX_bdacbfc66835232ccf59ead866" ON "mros_transactions_transaction" ("transactionId")`);
+        await queryRunner.query(`ALTER TABLE "mros_transactions_transaction" ADD CONSTRAINT "FK_1289fce229c942a9404926bf7ee" FOREIGN KEY ("mrosId") REFERENCES "mros"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "mros_transactions_transaction" ADD CONSTRAINT "FK_bdacbfc66835232ccf59ead866b" FOREIGN KEY ("transactionId") REFERENCES "transaction"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "mros_transactions_transaction" DROP CONSTRAINT "FK_bdacbfc66835232ccf59ead866b"`);
+        await queryRunner.query(`ALTER TABLE "mros_transactions_transaction" DROP CONSTRAINT "FK_1289fce229c942a9404926bf7ee"`);
+        await queryRunner.query(`DROP INDEX "IDX_bdacbfc66835232ccf59ead866" ON "mros_transactions_transaction"`);
+        await queryRunner.query(`DROP INDEX "IDX_1289fce229c942a9404926bf7e" ON "mros_transactions_transaction"`);
+        await queryRunner.query(`DROP TABLE "mros_transactions_transaction"`);
+    }
+}

--- a/src/subdomains/supporting/mros/dto/create-mros.dto.ts
+++ b/src/subdomains/supporting/mros/dto/create-mros.dto.ts
@@ -38,4 +38,9 @@ export class CreateMrosDto {
   @IsArray()
   @IsString({ each: true })
   indicators?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  transactionIds?: number[];
 }

--- a/src/subdomains/supporting/mros/dto/update-mros.dto.ts
+++ b/src/subdomains/supporting/mros/dto/update-mros.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsDateString, IsEnum, IsString } from 'class-validator';
+import { IsArray, IsDateString, IsEnum, IsInt, IsString } from 'class-validator';
 import { IsOptionalButNotNull } from 'src/shared/validators/is-not-null.validator';
 import { MrosStatus } from '../mros-status.enum';
 
@@ -35,4 +35,9 @@ export class UpdateMrosDto {
   @IsArray()
   @IsString({ each: true })
   indicators?: string[];
+
+  @IsOptionalButNotNull()
+  @IsArray()
+  @IsInt({ each: true })
+  transactionIds?: number[];
 }

--- a/src/subdomains/supporting/mros/mros.entity.ts
+++ b/src/subdomains/supporting/mros/mros.entity.ts
@@ -1,6 +1,7 @@
 import { IEntity } from 'src/shared/models/entity';
 import { UserData } from 'src/subdomains/generic/user/models/user-data/user-data.entity';
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Transaction } from 'src/subdomains/supporting/payment/entities/transaction.entity';
+import { Column, Entity, JoinTable, ManyToMany, ManyToOne } from 'typeorm';
 import { MrosStatus } from './mros-status.enum';
 
 @Entity()
@@ -40,4 +41,8 @@ export class Mros extends IEntity {
   set indicatorCodes(codes: string[]) {
     this.indicators = JSON.stringify(codes);
   }
+
+  @ManyToMany(() => Transaction)
+  @JoinTable()
+  transactions: Transaction[];
 }

--- a/src/subdomains/supporting/mros/mros.module.ts
+++ b/src/subdomains/supporting/mros/mros.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SharedModule } from 'src/shared/shared.module';
 import { UserModule } from 'src/subdomains/generic/user/user.module';
+import { TransactionModule } from '../payment/transaction.module';
 import { MrosController } from './mros.controller';
 import { Mros } from './mros.entity';
 import { MrosRepository } from './mros.repository';
 import { MrosService } from './mros.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Mros]), SharedModule, UserModule],
+  imports: [TypeOrmModule.forFeature([Mros]), SharedModule, UserModule, TransactionModule],
   controllers: [MrosController],
   providers: [MrosRepository, MrosService],
   exports: [],

--- a/src/subdomains/supporting/mros/mros.service.ts
+++ b/src/subdomains/supporting/mros/mros.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { UserDataService } from 'src/subdomains/generic/user/models/user-data/user-data.service';
+import { Transaction } from '../payment/entities/transaction.entity';
+import { TransactionService } from '../payment/services/transaction.service';
 import { CreateMrosDto } from './dto/create-mros.dto';
 import { UpdateMrosDto } from './dto/update-mros.dto';
 import { Mros } from './mros.entity';
@@ -10,29 +12,38 @@ export class MrosService {
   constructor(
     private readonly repo: MrosRepository,
     private readonly userDataService: UserDataService,
+    private readonly transactionService: TransactionService,
   ) {}
 
   async create(dto: CreateMrosDto): Promise<Mros> {
-    const { userDataId, indicators, ...rest } = dto;
+    const { userDataId, indicators, transactionIds, ...rest } = dto;
     const entity = this.repo.create(rest);
 
     entity.userData = await this.userDataService.getUserData(userDataId);
     if (!entity.userData) throw new NotFoundException('UserData not found');
 
     if (indicators) entity.indicatorCodes = indicators;
+    if (transactionIds) entity.transactions = await this.resolveTransactions(transactionIds);
 
     return this.repo.save(entity);
   }
 
   async update(id: number, dto: UpdateMrosDto): Promise<Mros> {
-    const entity = await this.repo.findOneBy({ id });
+    const entity = await this.repo.findOne({ where: { id }, relations: { transactions: true } });
     if (!entity) throw new NotFoundException('Mros not found');
 
-    const { indicators, ...rest } = dto;
+    const { indicators, transactionIds, ...rest } = dto;
     Object.assign(entity, rest);
     if (indicators !== undefined) entity.indicatorCodes = indicators;
+    if (transactionIds !== undefined) entity.transactions = await this.resolveTransactions(transactionIds);
 
     return this.repo.save(entity);
+  }
+
+  private async resolveTransactions(ids: number[]): Promise<Transaction[]> {
+    const transactions = await this.transactionService.getTransactionsByIds(ids);
+    if (transactions.length !== ids.length) throw new NotFoundException('One or more transactions not found');
+    return transactions;
   }
 
   async getAll(): Promise<Mros[]> {

--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -104,6 +104,11 @@ export class TransactionService {
     return this.repo.findOne({ where: { id }, relations });
   }
 
+  async getTransactionsByIds(ids: number[]): Promise<Transaction[]> {
+    if (!ids.length) return [];
+    return this.repo.find({ where: { id: In(ids) } });
+  }
+
   async getTransactionByUid(uid: string, relations: FindOptionsRelations<Transaction> = {}): Promise<Transaction> {
     return this.repo.findOne({ where: { uid }, relations });
   }


### PR DESCRIPTION
## Summary
Third of four small API PRs preparing Mros for goAML SAR export. Adds a many-to-many relation between Mros and Transaction so a compliance officer can select which transactions belong in a report.

At XML export time (Phase 2) these become the structured transaction nodes (`t_from_my_client` / `t_to_my_client`) of the goAML schema.

## Changes
- `Mros.transactions` ManyToMany (owning side, generates a join table)
- `transactionIds: number[]` on both create and update DTO
- `TransactionService.getTransactionsByIds` for bulk resolution
- Import `TransactionModule` into `MrosModule`
- `MrosService`:
  - `create` resolves transactionIds → Transaction[] and attaches
  - `update` loads the existing transactions relation so replacing the selection works
  - `resolveTransactions` throws `NotFoundException` if any id is invalid

## Migration
Per `CONTRIBUTING.md`, the schema migration must be generated locally:

\`\`\`bash
cd ~/Documents/GitHub/dfx/api
git pull
git checkout feat/mros-transactions-relation
npm run migration AddMrosTransactionsRelation
git add migration/*-AddMrosTransactionsRelation.js
git commit -m "feat: add migration for mros transactions many-to-many"
git push
\`\`\`

## Roadmap
- PR 1.1 (merged): core report fields
- PR 1.2 (#3623 open): personOverrides JSON column
- **PR 1.3 (this one): Mros ↔ Transaction many-to-many**
- PR 1.4: frontend edit page
- Phase 2: XML export + XSD validation + download endpoint

## Test plan
- [ ] Migration generated locally, applies cleanly (up + down)
- [ ] POST /mros with transactionIds → join rows created
- [ ] PUT /mros/:id with different transactionIds → join rows replaced
- [ ] PUT /mros/:id without transactionIds → existing links preserved
- [ ] PUT /mros/:id with [] → join rows cleared
- [ ] Invalid transactionId → 404