### PR TITLE
fix: add missing migration for mros report fields

### DIFF
--- a/migration/1777101222447-AddMrosReportFields.js
+++ b/migration/1777101222447-AddMrosReportFields.js
@@ -1,0 +1,33 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddMrosReportFields1777101222447 {
+    name = 'AddMrosReportFields1777101222447'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "mros" ADD "reportCode" nvarchar(256) NOT NULL CONSTRAINT "DF_34ee1d4c60de41c251fe14b9426" DEFAULT 'SAR'`);
+        await queryRunner.query(`ALTER TABLE "mros" ADD "reason" nvarchar(MAX)`);
+        await queryRunner.query(`ALTER TABLE "mros" ADD "action" nvarchar(MAX)`);
+        await queryRunner.query(`ALTER TABLE "mros" ADD "indicators" nvarchar(MAX)`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "mros" DROP COLUMN "indicators"`);
+        await queryRunner.query(`ALTER TABLE "mros" DROP COLUMN "action"`);
+        await queryRunner.query(`ALTER TABLE "mros" DROP COLUMN "reason"`);
+        await queryRunner.query(`ALTER TABLE "mros" DROP CONSTRAINT "DF_34ee1d4c60de41c251fe14b9426"`);
+        await queryRunner.query(`ALTER TABLE "mros" DROP COLUMN "reportCode"`);
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to **#3621**, which merged the entity columns `reportCode`, `reason`, `action`, `indicators` on `Mros` without a corresponding DB migration (caught by @davidleomay in https://github.com/DFXswiss/api/pull/3621#issuecomment-4313831297).

Adds the missing migration so any environment where #3621 has run code-side without DB-schema can be brought back in sync.

## Constraint names
TypeORM's auto-generated naming algorithm is `<prefix>_ + sha1(tableName + "_" + columnName).substring(0, 27)`. Verified against the existing `AddMros` migration (all four `DF_/PK_/FK_` constraints match). Used the same formula for the new `DF_*` constraint on `reportCode`:

\`\`\`
DF_34ee1d4c60de41c251fe14b9426  // sha1('mros_reportCode').substring(0, 27)
\`\`\`

So future `npm run migration` runs against this schema won't detect a drift.

## Down
Removes the four columns and the named DEFAULT constraint in reverse order.

## Test plan
- [ ] Migration applies cleanly on DEV (existing row gets `reportCode='SAR'`, others NULL)
- [ ] `down()` reverts cleanly
- [ ] `npm run migration` after this migration generates no schema diff