### PR TITLE
feat: throw TfaRequiredException with stable code for 2FA responses

### DIFF
--- a/src/subdomains/generic/kyc/exceptions/tfa-required.exception.ts
+++ b/src/subdomains/generic/kyc/exceptions/tfa-required.exception.ts
@@ -1,0 +1,11 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export class TfaRequiredException extends ForbiddenException {
+  constructor(public readonly level?: string) {
+    super({
+      code: '2FA_REQUIRED',
+      message: `2FA required${level ? ` (${level.toLowerCase()})` : ''}`,
+      level: level?.toLowerCase(),
+    });
+  }
+}

--- a/src/subdomains/generic/kyc/exceptions/tfa-required.exception.ts
+++ b/src/subdomains/generic/kyc/exceptions/tfa-required.exception.ts
@@ -1,11 +1,13 @@
 import { ForbiddenException } from '@nestjs/common';
+import type { TfaLevel } from '../services/tfa.service';
 
 export class TfaRequiredException extends ForbiddenException {
-  constructor(public readonly level?: string) {
+  constructor(public readonly level?: TfaLevel) {
+    const lowerLevel = level?.toLowerCase();
     super({
-      code: '2FA_REQUIRED',
-      message: `2FA required${level ? ` (${level.toLowerCase()})` : ''}`,
-      level: level?.toLowerCase(),
+      code: 'TFA_REQUIRED',
+      message: `2FA required${lowerLevel ? ` (${lowerLevel})` : ''}`,
+      level: lowerLevel,
     });
   }
 }

--- a/src/subdomains/generic/kyc/services/tfa.service.ts
+++ b/src/subdomains/generic/kyc/services/tfa.service.ts
@@ -7,6 +7,7 @@ import {
   ServiceUnavailableException,
   forwardRef,
 } from '@nestjs/common';
+import { TfaRequiredException } from '../exceptions/tfa-required.exception';
 import { CronExpression } from '@nestjs/schedule';
 import { generateSecret, verifyToken } from 'node-2fa';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
@@ -157,7 +158,7 @@ export class TfaService {
     const isVerified = logs.some(
       (log) => allowedLevels.some((l) => log.comment.includes(l)) || log.comment === 'Verified', // TODO: remove compatibility code
     );
-    if (!isVerified) throw new ForbiddenException(`2FA required${level ? ` (${level.toLowerCase()})` : ''}`);
+    if (!isVerified) throw new TfaRequiredException(level);
   }
 
   // --- HELPER METHODS --- //


### PR DESCRIPTION
## Summary
Introduces a dedicated `TfaRequiredException` thrown by `TfaService.checkVerification` instead of a generic `ForbiddenException`. The new exception carries `code: "TFA_REQUIRED"` and exposes the 2FA `level`, matching the existing pattern used for `KycLevelRequiredException` and `RegistrationRequiredException`.

## Why this is needed

Today `tfa.service.ts:160` throws:

```ts
throw new ForbiddenException(`2FA required${level ? ` (${level.toLowerCase()})` : ''}`);
```

This produces a `403` with no machine-readable `code` — the response surfaces as `code: "UNKNOWN"` on the client. Clients (e.g. `realunit-app`) therefore have no clean way to distinguish *2FA required* from any other `403`, of which there are many in this codebase:

- `Account is blocked/deactivated`
- `Country of IP address is not allowed`
- `Account not verified`
- `Permission denied` / `Not your transaction` / `You can only refund your own transaction`
- `Invalid API key`
- `Invalid or expired 2FA token`
- (and others)

Falling back to a `statusCode == 403` heuristic on the client would route all of these into the 2FA verification flow, which is wrong.

## Change

1. **New file** `src/subdomains/generic/kyc/exceptions/tfa-required.exception.ts` — `TfaRequiredException extends ForbiddenException` with `code: "TFA_REQUIRED"` and the optional `level` field (typed as `TfaLevel`) on the response payload. Imported via `import type` to avoid a runtime circular dependency with `tfa.service.ts`.
2. **`tfa.service.ts:160`** now throws `TfaRequiredException(level)` instead of the generic `ForbiddenException`. The original message text is preserved verbatim by the new exception's constructor.

### Code-style notes
- `code` follows the alphabetic SCREAMING_SNAKE_CASE convention used by `KYC_LEVEL_REQUIRED` and `REGISTRATION_REQUIRED`. The codebase consistently uses `Tfa` for machine-readable identifiers (`TfaService`, `TfaLevel`, `TfaType`); the user-facing `2FA` wording stays in the message text.
- File naming matches the dominant `*.exception.ts` convention in this repo.

## Compatibility

- **HTTP status code:** unchanged (`403`).
- **Message text:** unchanged (`2FA required` / `2FA required (strict)` / `2FA required (basic)`).
- **New fields in the response body:** `code: "TFA_REQUIRED"` and `level: "strict" | "basic" | undefined`.

Existing clients that rely on the message text or status code keep working. New clients can match on `code`.

## Follow-ups (separate PRs in `realunit-app`)

- DFXswiss/realunit-app#274 — Settings KYC cubits don't handle 2FA-required (403) responses
- DFXswiss/realunit-app#275 — Buy/Sell payment-info cubits don't surface 2FA-required (403) — falls into generic 'unknown' error

Both will match on the new `code` introduced here.

## Test plan
- [ ] Hit any endpoint guarded by `TfaService.checkVerification` without a verified 2FA log entry. Verify the response body contains `{"statusCode": 403, "code": "TFA_REQUIRED", "message": "2FA required (strict)", "level": "strict"}` (or `basic`, depending on context).
- [ ] Verify other `ForbiddenException` paths (blocked account, IP country block, permission denied, etc.) still return their original responses unchanged — no regression.
- [ ] Confirm clients still relying on the message text continue to receive the same string.