### PR TITLE
feat: compliance call queue endpoints

### DIFF
--- a/src/shared/models/setting/setting-schema.registry.ts
+++ b/src/shared/models/setting/setting-schema.registry.ts
@@ -32,6 +32,9 @@ export const SettingSchemaRegistry: Record<string, SettingSchema> = {
 
   // Support
   supportClerks: 'string[]',
+
+  // Compliance
+  complianceClerks: 'string[]',
 };
 
 export function isArraySchema(schema: SettingSchema): schema is ArraySchema {

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto.service.ts
@@ -1051,4 +1051,21 @@ export class BuyCryptoService {
       cryptoCurrency: v.buy?.asset?.name,
     }));
   }
+
+  async getByAmlReason(reason: AmlReason, status: CheckStatus, limit?: number): Promise<BuyCrypto[]> {
+    return this.buyCryptoRepo.find({
+      where: { amlReason: reason, amlCheck: status },
+      relations: {
+        buy: { asset: true },
+        transaction: { user: true, userData: { organization: true, language: true, country: true } },
+      },
+      loadEagerRelations: false,
+      order: { created: 'ASC' },
+      take: limit,
+    });
+  }
+
+  async countByAmlReason(reason: AmlReason, status: CheckStatus): Promise<number> {
+    return this.buyCryptoRepo.countBy({ amlReason: reason, amlCheck: status });
+  }
 }

--- a/src/subdomains/core/sell-crypto/process/services/buy-fiat.service.ts
+++ b/src/subdomains/core/sell-crypto/process/services/buy-fiat.service.ts
@@ -27,6 +27,7 @@ import { SupportLogType } from 'src/subdomains/supporting/support-issue/enums/su
 import { SupportLogService } from 'src/subdomains/supporting/support-issue/services/support-log.service';
 import { Between, FindOptionsRelations, In, MoreThan } from 'typeorm';
 import { FiatOutputService } from '../../../../supporting/fiat-output/fiat-output.service';
+import { AmlReason } from '../../../aml/enums/aml-reason.enum';
 import { CheckStatus } from '../../../aml/enums/check-status.enum';
 import { BuyCryptoService } from '../../../buy-crypto/process/services/buy-crypto.service';
 import { PaymentStatus } from '../../../history/dto/history.dto';
@@ -621,5 +622,22 @@ export class BuyFiatService {
       cryptoAmount: v.cryptoInput?.amount,
       cryptoCurrency: v.cryptoInput?.asset?.name,
     }));
+  }
+
+  async getByAmlReason(reason: AmlReason, status: CheckStatus, limit?: number): Promise<BuyFiat[]> {
+    return this.buyFiatRepo.find({
+      where: { amlReason: reason, amlCheck: status },
+      relations: {
+        cryptoInput: { asset: true },
+        transaction: { user: true, userData: { organization: true, language: true, country: true } },
+      },
+      loadEagerRelations: false,
+      order: { created: 'ASC' },
+      take: limit,
+    });
+  }
+
+  async countByAmlReason(reason: AmlReason, status: CheckStatus): Promise<number> {
+    return this.buyFiatRepo.countBy({ amlReason: reason, amlCheck: status });
   }
 }

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -1,11 +1,12 @@
 import { IsNotEmpty } from 'class-validator';
+import { AmlReason } from 'src/subdomains/core/aml/enums/aml-reason.enum';
+import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
 import { BankTxType } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
 import { RecallReason } from 'src/subdomains/supporting/recall/recall-reason.enum';
 import { KycFile } from '../../kyc/entities/kyc-file.entity';
-import { ReviewStatus } from '../../kyc/enums/review-status.enum';
 import { AccountType } from '../../user/models/user-data/account-type.enum';
 import { UserData } from '../../user/models/user-data/user-data.entity';
-import { KycStatus } from '../../user/models/user-data/user-data.enum';
+import { KycStatus, PhoneCallStatus } from '../../user/models/user-data/user-data.enum';
 
 export class UserDataSupportInfoResult {
   type: ComplianceSearchType;
@@ -53,7 +54,39 @@ export class PendingReviewItem {
   userName?: string;
   accountType?: AccountType;
   kycLevel?: number;
-  status: ReviewStatus;
+  date: Date;
+}
+
+export enum CallQueue {
+  MANUAL_CHECK_PHONE = 'ManualCheckPhone',
+  MANUAL_CHECK_IP_PHONE = 'ManualCheckIpPhone',
+  MANUAL_CHECK_IP_COUNTRY_PHONE = 'ManualCheckIpCountryPhone',
+  MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE = 'ManualCheckExternalAccountPhone',
+  UNAVAILABLE_SUSPICIOUS = 'UnavailableSuspicious',
+}
+
+export class CallQueueSummaryEntry {
+  queue: CallQueue;
+  count: number;
+}
+
+export class CallQueueItem {
+  queue: CallQueue;
+  userDataId: number;
+  userName?: string;
+  phone?: string;
+  language?: string;
+  country?: string;
+  kycLevel?: number;
+  txId?: number;
+  sourceType?: 'BuyCrypto' | 'BuyFiat';
+  amlCheck?: CheckStatus;
+  amlReason?: AmlReason;
+  inputAmount?: number;
+  inputAsset?: string;
+  ip?: string;
+  ipCountry?: string;
+  phoneCallStatus?: PhoneCallStatus;
   date: Date;
 }
 
@@ -83,6 +116,8 @@ export class UserSupportInfo {
   id: number;
   address: string;
   ref?: string;
+  usedRef?: string;
+  refUserName?: string;
   role: string;
   status: string;
   walletName?: string;

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Get, NotFoundException, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseEnumPipe,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth, ApiExcludeEndpoint, ApiOkResponse } from '@nestjs/swagger';
 import { GetJwt } from 'src/shared/auth/get-jwt.decorator';
@@ -12,6 +23,9 @@ import { GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
 import { ReviewStatus } from '../kyc/enums/review-status.enum';
 import {
+  CallQueue,
+  CallQueueItem,
+  CallQueueSummaryEntry,
   KycFileListEntry,
   KycFileYearlyStats,
   PendingOnboardingInfo,
@@ -96,6 +110,30 @@ export class SupportController {
     @Query('name') name?: string,
   ): Promise<PendingReviewItem[]> {
     return this.supportService.getPendingReviewsList(type, name, status);
+  }
+
+  @Get('call-queues')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getCallQueues(): Promise<CallQueueSummaryEntry[]> {
+    return this.supportService.getCallQueuesSummary();
+  }
+
+  @Get('call-queues/clerks')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getCallQueueClerks(): Promise<string[]> {
+    return this.supportService.getCallQueueClerks();
+  }
+
+  @Get('call-queues/:queue/items')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getCallQueueItems(@Param('queue', new ParseEnumPipe(CallQueue)) queue: CallQueue): Promise<CallQueueItem[]> {
+    return this.supportService.getCallQueueItems(queue);
   }
 
   @Get(':id/ip-log-pdf')

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -5,7 +5,9 @@ import { Config } from 'src/config/config';
 import { SettingService } from 'src/shared/models/setting/setting.service';
 import { AmountType, Util } from 'src/shared/utils/util';
 import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
-import { NotRefundableAmlReasons } from 'src/subdomains/core/aml/enums/aml-reason.enum';
+import { AmlReason, NotRefundableAmlReasons } from 'src/subdomains/core/aml/enums/aml-reason.enum';
+import { BuyCrypto } from 'src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity';
+import { BuyFiat } from 'src/subdomains/core/sell-crypto/process/buy-fiat.entity';
 import { BuyCryptoService } from 'src/subdomains/core/buy-crypto/process/services/buy-crypto.service';
 import { Buy } from 'src/subdomains/core/buy-crypto/routes/buy/buy.entity';
 import { BuyService } from 'src/subdomains/core/buy-crypto/routes/buy/buy.service';
@@ -55,6 +57,7 @@ import { Recommendation } from '../user/models/recommendation/recommendation.ent
 import { RecommendationService } from '../user/models/recommendation/recommendation.service';
 import { AccountType } from '../user/models/user-data/account-type.enum';
 import { UserData } from '../user/models/user-data/user-data.entity';
+import { PhoneCallStatus } from '../user/models/user-data/user-data.enum';
 import { UserDataService } from '../user/models/user-data/user-data.service';
 import { User } from '../user/models/user/user.entity';
 import { UserService } from '../user/models/user/user.service';
@@ -81,6 +84,9 @@ import {
   SellSupportInfo,
   TransactionListEntry,
   TransactionSupportInfo,
+  CallQueue,
+  CallQueueItem,
+  CallQueueSummaryEntry,
   OnboardingStatus,
   PendingOnboardingInfo,
   PendingReviewItem,
@@ -97,6 +103,17 @@ interface UserDataComplianceSearchTypePair {
   type: ComplianceSearchType;
   userData: UserData;
 }
+
+const CallQueueItemsLimit = 200;
+
+const PendingReviewBankDataName = 'BankData';
+
+const CallQueueTxReasonMap: Partial<Record<CallQueue, AmlReason>> = {
+  [CallQueue.MANUAL_CHECK_PHONE]: AmlReason.MANUAL_CHECK_PHONE,
+  [CallQueue.MANUAL_CHECK_IP_PHONE]: AmlReason.MANUAL_CHECK_IP_PHONE,
+  [CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE]: AmlReason.MANUAL_CHECK_IP_COUNTRY_PHONE,
+  [CallQueue.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE]: AmlReason.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE,
+};
 
 @Injectable()
 export class SupportService {
@@ -254,7 +271,7 @@ export class SupportService {
       cryptoInputs: cryptoInputs.map((c) => this.toCryptoInputSupportInfo(c)),
       ipLogs: ipLogs.map((l) => this.toIpLogSupportInfo(l)),
       supportIssues: supportIssues.map((s) => this.toSupportIssueSupportInfo(s)),
-      users: users.map((u) => this.toUserSupportInfo(u)),
+      users: await this.toUserSupportInfos(users),
       bankDatas: bankDatas.map((b) => this.toBankDataSupportInfo(b)),
       buyRoutes: buyRoutes.map((b) => this.toBuySupportInfo(b)),
       sellRoutes: sellRoutes.map((s) => this.toSellSupportInfo(s)),
@@ -425,16 +442,31 @@ export class SupportService {
     };
   }
 
-  private toUserSupportInfo(user: User): UserSupportInfo {
-    return {
-      id: user.id,
-      address: user.address,
-      ref: user.ref,
-      role: user.role,
-      status: user.status,
-      walletName: user.wallet?.name,
-      created: user.created,
-    };
+  private async toUserSupportInfos(users: User[]): Promise<UserSupportInfo[]> {
+    const usedRefs = Array.from(
+      new Set(users.map((u) => u.usedRef).filter((r): r is string => !!r && r !== '000-000')),
+    );
+    const refUsers = await this.userService.getRefUsersByRefs(usedRefs);
+    const refUserByRef = new Map(refUsers.map((r) => [r.ref, r]));
+
+    return users.map((user) => {
+      const refUser = user.usedRef ? refUserByRef.get(user.usedRef) : undefined;
+      const refUserName = refUser?.userData
+        ? [refUser.userData.firstname, refUser.userData.surname].filter(Boolean).join(' ') || undefined
+        : undefined;
+
+      return {
+        id: user.id,
+        address: user.address,
+        ref: user.ref,
+        usedRef: user.usedRef,
+        refUserName,
+        role: user.role,
+        status: user.status,
+        walletName: user.wallet?.name,
+        created: user.created,
+      };
+    });
   }
 
   private toBankDataSupportInfo(bankData: BankData): BankDataSupportInfo {
@@ -592,20 +624,18 @@ export class SupportService {
       this.bankDataService.getPendingReviewSummary(),
     ]);
 
-    const allRows: { type: PendingReviewType; name: string; status: ReviewStatus; count: number }[] = [
-      ...kycRows.map((r) => ({ type: PendingReviewType.KYC_STEP, name: r.name, status: r.status, count: r.count })),
-      ...bankRows.map((r) => ({ type: PendingReviewType.BANK_DATA, name: r.name, status: r.status, count: r.count })),
-    ];
-
     const entries = new Map<string, PendingReviewSummaryEntry>();
 
-    for (const row of allRows) {
-      const key = `${row.type}:${row.name}`;
-      const entry = entries.get(key) ?? { type: row.type, name: row.name, manualReview: 0, internalReview: 0 };
-      if (row.status === ReviewStatus.MANUAL_REVIEW) entry.manualReview = row.count;
-      else if (row.status === ReviewStatus.INTERNAL_REVIEW) entry.internalReview = row.count;
+    const register = (type: PendingReviewType, name: string, status: ReviewStatus, count: number) => {
+      const key = `${type}:${name}`;
+      const entry = entries.get(key) ?? { type, name, manualReview: 0, internalReview: 0 };
+      if (status === ReviewStatus.MANUAL_REVIEW) entry.manualReview = count;
+      else if (status === ReviewStatus.INTERNAL_REVIEW) entry.internalReview = count;
       entries.set(key, entry);
-    }
+    };
+
+    for (const row of kycRows) register(PendingReviewType.KYC_STEP, row.name, row.status, row.count);
+    for (const row of bankRows) register(PendingReviewType.BANK_DATA, PendingReviewBankDataName, row.status, row.count);
 
     return Array.from(entries.values()).sort((a, b) => {
       if (a.type !== b.type) return a.type.localeCompare(b.type);
@@ -628,28 +658,24 @@ export class SupportService {
         throw new BadRequestException('Unknown KycStepName');
       }
       const steps = await this.kycService.getPendingReviewSteps(name as KycStepName, status);
-      return steps.map((step) => this.toPendingReviewItem(step, status));
+      return steps.map((step) => this.toPendingReviewItem(step));
     }
 
     if (type === PendingReviewType.BANK_DATA) {
       const bankDatas = await this.bankDataService.getPendingReviewList(status);
-      return bankDatas.map((bd) => this.toPendingReviewItem(bd, status));
+      return bankDatas.map((bd) => this.toPendingReviewItem(bd));
     }
 
     throw new BadRequestException('Unknown review type');
   }
 
-  private toPendingReviewItem(
-    entity: { id: number; userData: UserData; updated: Date },
-    status: ReviewStatus,
-  ): PendingReviewItem {
+  private toPendingReviewItem(entity: { id: number; userData: UserData; updated: Date }): PendingReviewItem {
     return {
       id: entity.id,
       userDataId: entity.userData.id,
       userName: this.formatUserName(entity.userData),
       accountType: entity.userData.accountType,
       kycLevel: entity.userData.kycLevel,
-      status,
       date: entity.updated,
     };
   }
@@ -658,6 +684,104 @@ export class SupportService {
     return (
       ud.verifiedName ?? ([ud.firstname, ud.surname, ud.organization?.name].filter(Boolean).join(' ') || undefined)
     );
+  }
+
+  async getCallQueueClerks(): Promise<string[]> {
+    return this.settingService.getObj<string[]>('complianceClerks', []);
+  }
+
+  async getCallQueuesSummary(): Promise<CallQueueSummaryEntry[]> {
+    const [unavailSuspicious, phone, ipPhone, ipCountryPhone, externalAccountPhone] = await Promise.all([
+      this.userDataService.countByPhoneCallStatuses([PhoneCallStatus.UNAVAILABLE, PhoneCallStatus.SUSPICIOUS]),
+      this.countTxQueue(AmlReason.MANUAL_CHECK_PHONE),
+      this.countTxQueue(AmlReason.MANUAL_CHECK_IP_PHONE),
+      this.countTxQueue(AmlReason.MANUAL_CHECK_IP_COUNTRY_PHONE),
+      this.countTxQueue(AmlReason.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE),
+    ]);
+
+    return [
+      { queue: CallQueue.UNAVAILABLE_SUSPICIOUS, count: unavailSuspicious },
+      { queue: CallQueue.MANUAL_CHECK_PHONE, count: phone },
+      { queue: CallQueue.MANUAL_CHECK_IP_PHONE, count: ipPhone },
+      { queue: CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE, count: ipCountryPhone },
+      { queue: CallQueue.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE, count: externalAccountPhone },
+    ];
+  }
+
+  async getCallQueueItems(queue: CallQueue): Promise<CallQueueItem[]> {
+    const txReason = CallQueueTxReasonMap[queue];
+    if (txReason) return this.loadTxQueue(queue, txReason);
+
+    const users = await this.userDataService.getByPhoneCallStatuses(
+      [PhoneCallStatus.UNAVAILABLE, PhoneCallStatus.SUSPICIOUS],
+      CallQueueItemsLimit,
+    );
+    return users.map((ud) => this.toUserCallQueueItem(ud));
+  }
+
+  private async countTxQueue(reason: AmlReason): Promise<number> {
+    const [crypto, fiat] = await Promise.all([
+      this.buyCryptoService.countByAmlReason(reason, CheckStatus.PENDING),
+      this.buyFiatService.countByAmlReason(reason, CheckStatus.PENDING),
+    ]);
+    return crypto + fiat;
+  }
+
+  private async loadTxQueue(queue: CallQueue, reason: AmlReason): Promise<CallQueueItem[]> {
+    const [buyCryptos, buyFiats] = await Promise.all([
+      this.buyCryptoService.getByAmlReason(reason, CheckStatus.PENDING, CallQueueItemsLimit),
+      this.buyFiatService.getByAmlReason(reason, CheckStatus.PENDING, CallQueueItemsLimit),
+    ]);
+    const items = [
+      ...buyCryptos.map((bc) => this.toTxCallQueueItem(queue, bc, 'BuyCrypto')),
+      ...buyFiats.map((bf) => this.toTxCallQueueItem(queue, bf, 'BuyFiat')),
+    ];
+    return items
+      .sort((a, b) => a.date.getTime() - b.date.getTime() || (a.txId ?? 0) - (b.txId ?? 0))
+      .slice(0, CallQueueItemsLimit);
+  }
+
+  private toTxCallQueueItem(
+    queue: CallQueue,
+    tx: BuyCrypto | BuyFiat,
+    sourceType: 'BuyCrypto' | 'BuyFiat',
+  ): CallQueueItem {
+    const ud = tx.userData;
+    const user = tx.transaction?.user;
+    const inputAsset =
+      sourceType === 'BuyCrypto' ? (tx as BuyCrypto).inputAsset : (tx as BuyFiat).cryptoInput?.asset?.name;
+    return {
+      queue,
+      userDataId: ud.id,
+      userName: this.formatUserName(ud),
+      phone: ud.phone,
+      language: ud.language?.name,
+      country: ud.country?.name,
+      kycLevel: ud.kycLevel,
+      txId: tx.id,
+      sourceType,
+      amlCheck: tx.amlCheck,
+      amlReason: tx.amlReason,
+      inputAmount: tx.inputAmount,
+      inputAsset,
+      ip: user?.ip,
+      ipCountry: user?.ipCountry,
+      date: tx.created,
+    };
+  }
+
+  private toUserCallQueueItem(ud: UserData): CallQueueItem {
+    return {
+      queue: CallQueue.UNAVAILABLE_SUSPICIOUS,
+      userDataId: ud.id,
+      userName: this.formatUserName(ud),
+      phone: ud.phone,
+      language: ud.language?.name,
+      country: ud.country?.name,
+      kycLevel: ud.kycLevel,
+      phoneCallStatus: ud.phoneCallStatus,
+      date: ud.phoneCallCheckDate ?? ud.updated,
+    };
   }
 
   //*** HELPER METHODS ***//

--- a/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
+++ b/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
@@ -468,7 +468,7 @@ export class BankDataService {
 
   // --- Pending Review Queries ---
 
-  async getPendingReviewSummary(): Promise<{ name: string; status: ReviewStatus; count: number }[]> {
+  async getPendingReviewSummary(): Promise<{ status: ReviewStatus; count: number }[]> {
     return this.bankDataRepo
       .createQueryBuilder('bankData')
       .select('bankData.status', 'status')
@@ -480,7 +480,7 @@ export class BankDataService {
       .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
       .groupBy('bankData.status')
       .getRawMany<{ status: ReviewStatus; count: string }>()
-      .then((rows) => rows.map((r) => ({ name: 'BankData', status: r.status, count: Number(r.count) })));
+      .then((rows) => rows.map((r) => ({ status: r.status, count: Number(r.count) })));
   }
 
   async getPendingReviewList(status: ReviewStatus): Promise<BankData[]> {

--- a/src/subdomains/generic/user/models/user-data/user-data.entity.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.entity.ts
@@ -836,6 +836,11 @@ export const UserDataComplianceUpdateCols = [
   'amlAccountType',
   'complexOrgStructure',
   'highRisk',
+  'phoneCallStatus',
+  'phoneCallCheckDate',
+  'phoneCallIpCheckDate',
+  'phoneCallIpCountryCheckDate',
+  'phoneCallExternalAccountCheckDate',
 ];
 
 export function KycCompleted(kycStatus?: KycStatus): boolean {

--- a/src/subdomains/generic/user/models/user-data/user-data.service.ts
+++ b/src/subdomains/generic/user/models/user-data/user-data.service.ts
@@ -1407,6 +1407,23 @@ export class UserDataService {
       .getRawOne<{ maxKycFileId: number }>()
       .then((r) => r?.maxKycFileId ?? 0);
   }
+
+  async getByPhoneCallStatuses(statuses: PhoneCallStatus[], limit?: number): Promise<UserData[]> {
+    return this.userDataRepo.find({
+      where: { phoneCallStatus: In(statuses), status: Not(UserDataStatus.MERGED) },
+      relations: { organization: true, language: true, country: true },
+      loadEagerRelations: false,
+      order: { phoneCallCheckDate: 'ASC' },
+      take: limit,
+    });
+  }
+
+  async countByPhoneCallStatuses(statuses: PhoneCallStatus[]): Promise<number> {
+    return this.userDataRepo.countBy({
+      phoneCallStatus: In(statuses),
+      status: Not(UserDataStatus.MERGED),
+    });
+  }
 }
 
 export interface KycFileYearlyStatsData {

--- a/src/subdomains/generic/user/models/user/user.service.ts
+++ b/src/subdomains/generic/user/models/user/user.service.ts
@@ -30,7 +30,7 @@ import { CardBankName, IbanBankName } from 'src/subdomains/supporting/bank/bank/
 import { FeeInfo } from 'src/subdomains/supporting/payment/dto/fee.dto';
 import { PaymentMethod } from 'src/subdomains/supporting/payment/dto/payment-method.enum';
 import { FeeService } from 'src/subdomains/supporting/payment/services/fee.service';
-import { Between, FindOptionsRelations, Not } from 'typeorm';
+import { Between, FindOptionsRelations, In, Not } from 'typeorm';
 import { UserData } from '../user-data/user-data.entity';
 import {
   KycLevel,
@@ -173,6 +173,11 @@ export class UserService {
 
   async getRefUser(ref: string): Promise<User> {
     return this.userRepo.findOne({ where: { ref }, relations: { userData: true } });
+  }
+
+  async getRefUsersByRefs(refs: string[]): Promise<User[]> {
+    if (refs.length === 0) return [];
+    return this.userRepo.find({ where: { ref: In(refs) }, relations: { userData: true } });
   }
 
   async getNexCustodyIndex(): Promise<number> {


### PR DESCRIPTION
## Summary
- Adds 3 new `support/call-queues*` endpoints (counts, clerks, items per queue), guarded by COMPLIANCE role
- New `BuyCryptoService.{get,count}ByAmlReason`, `BuyFiatService.{get,count}ByAmlReason`, `UserDataService.{get,count}ByPhoneCallStatuses` — all use `find()` with `loadEagerRelations: false`, consistent with the pending-review refactor in #3599
- Registers `complianceClerks` string[] setting; extends `UserDataComplianceUpdateCols` with `phoneCallStatus` and the four `phoneCall*CheckDate` fields
- Drops redundant `name` field from `BankDataService.getPendingReviewSummary` return type (unused after #3599)
- `ParseEnumPipe` on the queue path-param to fail fast on invalid values

## Test plan
- [ ] `npm run build && npm run lint` clean
- [ ] `GET /v1/support/call-queues` returns counts for the five queues
- [ ] `GET /v1/support/call-queues/clerks` returns clerks from `setting:complianceClerks` (fallback empty)
- [ ] `GET /v1/support/call-queues/ManualCheckPhone/items` returns at most 200 items, sorted by date asc
- [ ] `GET /v1/support/call-queues/UnavailableSuspicious/items` returns userData with phoneCallStatus in (Unavailable, Suspicious)
- [ ] `GET /v1/support/call-queues/foo/items` returns 400 (ParseEnumPipe)
- [ ] Setting `phoneCall*CheckDate` via existing admin userData PUT works (whitelist now includes them)

## Depends on
- DFXswiss/packages#162 — adds the shared `CallQueue`/`CallQueueItem`/`PhoneCallStatus` definitions consumed by the matching frontend PR