### PR TITLE
fix: use transaction id in user data support payload

### DIFF
--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -758,7 +758,7 @@ export class SupportService {
       language: ud.language?.name,
       country: ud.country?.name,
       kycLevel: ud.kycLevel,
-      txId: tx.id,
+      txId: tx.transaction.id,
       sourceType,
       amlCheck: tx.amlCheck,
       amlReason: tx.amlReason,


### PR DESCRIPTION
## Summary
- In `SupportService` user-data-support payload was using `tx.id` (BuyCrypto/BuyFiat entity id) instead of the underlying transaction id.
- Replaced with `tx.transaction.id` so the consumer receives the actual transaction id.

## Test plan
- [ ] Verify support payload contains the correct `txId` (matches `transaction.id`, not the buy-crypto/buy-fiat entity id).