### PR TITLE
fix: chunk support issue message stats query to avoid SQL parameter limit

### DIFF
--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -321,41 +321,52 @@ export class SupportIssueService {
   ): Promise<Map<number, { count: number; lastDate?: Date; lastAuthor?: string }>> {
     if (issueIds.length === 0) return new Map();
 
-    const rows: { issueId: string; count: string; lastDate: Date | null; lastAuthor: string | null }[] =
-      await this.messageRepo
-        .createQueryBuilder('m')
-        .select('m.issueId', 'issueId')
-        .addSelect('COUNT(*)', 'count')
-        .addSelect(
-          (sub) =>
-            sub
-              .select('m2.created')
-              .from(SupportMessage, 'm2')
-              .where('m2.issueId = m.issueId')
-              .orderBy('m2.id', 'DESC')
-              .limit(1),
-          'lastDate',
-        )
-        .addSelect(
-          (sub) =>
-            sub
-              .select('m2.author')
-              .from(SupportMessage, 'm2')
-              .where('m2.issueId = m.issueId')
-              .orderBy('m2.id', 'DESC')
-              .limit(1),
-          'lastAuthor',
-        )
-        .where('m.issueId IN (:...ids)', { ids: issueIds })
-        .groupBy('m.issueId')
-        .getRawMany();
+    // chunked to stay below SQL Server's 2100 parameter limit
+    const chunkSize = 1000;
+    const result = new Map<number, { count: number; lastDate?: Date; lastAuthor?: string }>();
 
-    return new Map(
-      rows.map((r) => [
-        +r.issueId,
-        { count: +r.count, lastDate: r.lastDate ?? undefined, lastAuthor: r.lastAuthor ?? undefined },
-      ]),
-    );
+    for (let i = 0; i < issueIds.length; i += chunkSize) {
+      const chunk = issueIds.slice(i, i + chunkSize);
+
+      const rows: { issueId: string; count: string; lastDate: Date | null; lastAuthor: string | null }[] =
+        await this.messageRepo
+          .createQueryBuilder('m')
+          .select('m.issueId', 'issueId')
+          .addSelect('COUNT(*)', 'count')
+          .addSelect(
+            (sub) =>
+              sub
+                .select('m2.created')
+                .from(SupportMessage, 'm2')
+                .where('m2.issueId = m.issueId')
+                .orderBy('m2.id', 'DESC')
+                .limit(1),
+            'lastDate',
+          )
+          .addSelect(
+            (sub) =>
+              sub
+                .select('m2.author')
+                .from(SupportMessage, 'm2')
+                .where('m2.issueId = m.issueId')
+                .orderBy('m2.id', 'DESC')
+                .limit(1),
+            'lastAuthor',
+          )
+          .where('m.issueId IN (:...ids)', { ids: chunk })
+          .groupBy('m.issueId')
+          .getRawMany();
+
+      for (const r of rows) {
+        result.set(+r.issueId, {
+          count: +r.count,
+          lastDate: r.lastDate ?? undefined,
+          lastAuthor: r.lastAuthor ?? undefined,
+        });
+      }
+    }
+
+    return result;
   }
 
   async getIssueEntities(userDataId: number): Promise<SupportIssue[]> {

--- a/src/subdomains/supporting/support-issue/services/support-issue.service.ts
+++ b/src/subdomains/supporting/support-issue/services/support-issue.service.ts
@@ -321,15 +321,11 @@ export class SupportIssueService {
   ): Promise<Map<number, { count: number; lastDate?: Date; lastAuthor?: string }>> {
     if (issueIds.length === 0) return new Map();
 
-    // chunked to stay below SQL Server's 2100 parameter limit
-    const chunkSize = 1000;
-    const result = new Map<number, { count: number; lastDate?: Date; lastAuthor?: string }>();
-
-    for (let i = 0; i < issueIds.length; i += chunkSize) {
-      const chunk = issueIds.slice(i, i + chunkSize);
-
-      const rows: { issueId: string; count: string; lastDate: Date | null; lastAuthor: string | null }[] =
-        await this.messageRepo
+    // batched to stay below SQL Server's 2100 parameter limit
+    const rows = await Util.doInBatchesAndJoin(
+      issueIds,
+      (chunk): Promise<{ issueId: string; count: string; lastDate: Date | null; lastAuthor: string | null }[]> =>
+        this.messageRepo
           .createQueryBuilder('m')
           .select('m.issueId', 'issueId')
           .addSelect('COUNT(*)', 'count')
@@ -355,18 +351,16 @@ export class SupportIssueService {
           )
           .where('m.issueId IN (:...ids)', { ids: chunk })
           .groupBy('m.issueId')
-          .getRawMany();
+          .getRawMany(),
+      1000,
+    );
 
-      for (const r of rows) {
-        result.set(+r.issueId, {
-          count: +r.count,
-          lastDate: r.lastDate ?? undefined,
-          lastAuthor: r.lastAuthor ?? undefined,
-        });
-      }
-    }
-
-    return result;
+    return new Map(
+      rows.map((r) => [
+        +r.issueId,
+        { count: +r.count, lastDate: r.lastDate ?? undefined, lastAuthor: r.lastAuthor ?? undefined },
+      ]),
+    );
   }
 
   async getIssueEntities(userDataId: number): Promise<SupportIssue[]> {


### PR DESCRIPTION
## Summary
- `GET /v1/support/issue/list` failed with `The incoming request has too many parameters. The server supports a maximum of 2100 parameters` when more than ~2100 issues matched the filter.
- Root cause: `getMessageStats` passed all issue IDs into a single `IN (:...ids)` clause; TypeORM emits one parameter per ID and SQL Server rejects the query above 2100.
- Fix: chunk the message stats query in batches of 1000 IDs and merge the results into a single map. No API change, identical result set per issue.

## Test plan
- [x] `npx prettier --check` on the changed file
- [x] `npx eslint` on the changed file
- [x] `npm test` (927 passed, 0 failed)
- [ ] Verify `/v1/support/issue/list` succeeds on a dataset with >2100 matching issues