### PR TITLE
feat: support BIP-322 P2WSH multisig signatures in auth

### DIFF
--- a/src/integration/blockchain/bitcoin/utils/__tests__/bip322-p2wsh.util.spec.ts
+++ b/src/integration/blockchain/bitcoin/utils/__tests__/bip322-p2wsh.util.spec.ts
@@ -1,0 +1,240 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
+import { bech32 } from 'bech32';
+import { isP2wshAddress, verifyBip322P2wshSignature } from '../bip322-p2wsh.util';
+
+describe('bip322-p2wsh.util', () => {
+  const p2wshAddress = 'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep';
+  const p2wpkhAddress = 'bc1qd9jvcd4l64q09kkj2q0qpf58umrryknyqmdp47';
+  const legacyAddress = '1AcGhh1oYJTqaPgmWThc7EvKBRjRLe3Go9';
+
+  describe('isP2wshAddress', () => {
+    it('detects native P2WSH', () => {
+      expect(isP2wshAddress(p2wshAddress)).toBe(true);
+    });
+
+    it('rejects P2WPKH', () => {
+      expect(isP2wshAddress(p2wpkhAddress)).toBe(false);
+    });
+
+    it('rejects legacy P2PKH', () => {
+      expect(isP2wshAddress(legacyAddress)).toBe(false);
+    });
+
+    it('rejects testnet bech32', () => {
+      expect(isP2wshAddress('tb1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep')).toBe(false);
+    });
+
+    it('rejects malformed bech32', () => {
+      expect(isP2wshAddress('bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3xxx')).toBe(false);
+    });
+
+    it('rejects empty input', () => {
+      expect(isP2wshAddress('')).toBe(false);
+    });
+  });
+
+  describe('verifyBip322P2wshSignature - structural negatives', () => {
+    const message = 'test';
+
+    it('returns false on empty signature', () => {
+      expect(verifyBip322P2wshSignature(message, p2wshAddress, '')).toBe(false);
+    });
+
+    it('returns false on garbage base64', () => {
+      expect(verifyBip322P2wshSignature(message, p2wshAddress, 'AAAAAAAAAAAAAAAA')).toBe(false);
+    });
+
+    it('returns false on non-P2WSH address', () => {
+      expect(verifyBip322P2wshSignature(message, p2wpkhAddress, 'AAAAAAAA')).toBe(false);
+    });
+  });
+
+  describe('verifyBip322P2wshSignature - synthetic 2-of-3 sortedmulti roundtrip', () => {
+    const messages = ['hello world', 'DFX challenge: ' + 'x'.repeat(80), ''];
+
+    it.each(messages)('signs and verifies (msg length=%s)', (message) => {
+      const { address, witnessScript, privateKeys } = buildSyntheticMultisig();
+      const signature = signSyntheticMultisig(message, address, witnessScript, [privateKeys[0], privateKeys[2]]);
+
+      expect(isP2wshAddress(address)).toBe(true);
+      expect(verifyBip322P2wshSignature(message, address, signature)).toBe(true);
+    });
+
+    it('rejects signature when only 1 of required 2 sigs provided', () => {
+      const { address, witnessScript, privateKeys } = buildSyntheticMultisig();
+      const message = 'short';
+      const sig = signSyntheticMultisig(message, address, witnessScript, [privateKeys[0]]);
+      expect(verifyBip322P2wshSignature(message, address, sig)).toBe(false);
+    });
+
+    it('rejects signature signed for different message', () => {
+      const { address, witnessScript, privateKeys } = buildSyntheticMultisig();
+      const sig = signSyntheticMultisig('msg-a', address, witnessScript, [privateKeys[0], privateKeys[1]]);
+      expect(verifyBip322P2wshSignature('msg-b', address, sig)).toBe(false);
+    });
+
+    it('rejects signature signed by foreign key (not in script)', () => {
+      const { address, witnessScript, privateKeys } = buildSyntheticMultisig();
+      const intruder = makePrivateKey(99);
+      const sig = signSyntheticMultisig('m', address, witnessScript, [privateKeys[0], intruder]);
+      expect(verifyBip322P2wshSignature('m', address, sig)).toBe(false);
+    });
+  });
+
+  describe('verifyBip322P2wshSignature - real Sparrow fixture', () => {
+    it.todo('verifies a real Sparrow BIP-322 simple signature for the 2-of-3 multisig (fixture pending)');
+  });
+});
+
+// --- test helpers --- //
+
+function makePrivateKey(seed: number): Buffer {
+  const k = Buffer.alloc(32);
+  k.writeUInt32BE(seed + 1, 28);
+  return k;
+}
+
+function pubkeyOf(priv: Buffer): Buffer {
+  return Buffer.from(secp256k1.getPublicKey(priv, true));
+}
+
+function buildSyntheticMultisig(): { address: string; witnessScript: Buffer; privateKeys: Buffer[] } {
+  const privateKeys = [makePrivateKey(1), makePrivateKey(2), makePrivateKey(3)];
+  const pubkeys = privateKeys.map(pubkeyOf);
+  pubkeys.sort(Buffer.compare);
+  privateKeys.sort((a, b) => Buffer.compare(pubkeyOf(a), pubkeyOf(b)));
+
+  const parts: Buffer[] = [Buffer.from([0x52])]; // OP_2
+  for (const pk of pubkeys) parts.push(Buffer.from([0x21]), pk);
+  parts.push(Buffer.from([0x53, 0xae])); // OP_3 OP_CHECKMULTISIG
+  const witnessScript = Buffer.concat(parts);
+
+  const program = Buffer.from(sha256(witnessScript));
+  const words = [0, ...bech32.toWords(program)];
+  const address = bech32.encode('bc', words);
+
+  return { address, witnessScript, privateKeys };
+}
+
+function signSyntheticMultisig(message: string, address: string, witnessScript: Buffer, signingKeys: Buffer[]): string {
+  const program = decodeProgram(address);
+  const sighash = computeBip143Sighash(message, program, witnessScript);
+
+  const signersByPubkey = new Map(signingKeys.map((k) => [pubkeyOf(k).toString('hex'), k]));
+  const scriptPubkeys = extractScriptPubkeys(witnessScript);
+  const orderedSigs: Buffer[] = [];
+  for (const pk of scriptPubkeys) {
+    const priv = signersByPubkey.get(pk.toString('hex'));
+    if (!priv) continue;
+    const sig = secp256k1.sign(sighash, priv, { lowS: true });
+    const der = Buffer.from(sig.toDERRawBytes());
+    orderedSigs.push(Buffer.concat([der, Buffer.from([0x01])]));
+  }
+
+  const witness = [Buffer.alloc(0), ...orderedSigs, witnessScript];
+  return encodeWitness(witness).toString('base64');
+}
+
+function decodeProgram(address: string): Buffer {
+  const decoded = bech32.decode(address);
+  return Buffer.from(bech32.fromWords(decoded.words.slice(1)));
+}
+
+function extractScriptPubkeys(script: Buffer): Buffer[] {
+  const pubkeys: Buffer[] = [];
+  let offset = 1;
+  const end = script.length - 2;
+  while (offset < end) {
+    offset += 1;
+    pubkeys.push(script.subarray(offset, offset + 33));
+    offset += 33;
+  }
+  return pubkeys;
+}
+
+function computeBip143Sighash(message: string, program: Buffer, witnessScript: Buffer): Buffer {
+  const tag = Buffer.from('BIP0322-signed-message', 'utf8');
+  const tagHash = sha256(tag);
+  const messageHash = Buffer.from(
+    sha256(Buffer.concat([Buffer.from(tagHash), Buffer.from(tagHash), Buffer.from(message, 'utf8')])),
+  );
+
+  const scriptPubKey = Buffer.concat([Buffer.from([0x00, 0x20]), program]);
+  const scriptSig = Buffer.concat([Buffer.from([0x00, 0x20]), messageHash]);
+
+  const toSpend = Buffer.concat([
+    u32le(0),
+    varInt(1),
+    Buffer.alloc(32),
+    u32le(0xffffffff),
+    varBytes(scriptSig),
+    u32le(0),
+    varInt(1),
+    u64le(0n),
+    varBytes(scriptPubKey),
+    u32le(0),
+  ]);
+  const toSpendTxid = hash256(toSpend);
+
+  const outpoint = Buffer.concat([toSpendTxid, u32le(0)]);
+  const sequence = u32le(0);
+  const hashPrevouts = hash256(outpoint);
+  const hashSequence = hash256(sequence);
+  const output = Buffer.concat([u64le(0n), Buffer.from([0x01, 0x6a])]);
+  const hashOutputs = hash256(output);
+
+  const preimage = Buffer.concat([
+    u32le(0),
+    hashPrevouts,
+    hashSequence,
+    outpoint,
+    varBytes(witnessScript),
+    u64le(0n),
+    sequence,
+    hashOutputs,
+    u32le(0),
+    u32le(1),
+  ]);
+  return hash256(preimage);
+}
+
+function encodeWitness(items: Buffer[]): Buffer {
+  const parts: Buffer[] = [varInt(items.length)];
+  for (const item of items) parts.push(varBytes(item));
+  return Buffer.concat(parts);
+}
+
+function hash256(b: Buffer): Buffer {
+  return Buffer.from(sha256(sha256(b)));
+}
+
+function u32le(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(n >>> 0, 0);
+  return b;
+}
+
+function u64le(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(n, 0);
+  return b;
+}
+
+function varInt(n: number): Buffer {
+  if (n < 0xfd) return Buffer.from([n]);
+  if (n <= 0xffff) {
+    const b = Buffer.alloc(3);
+    b[0] = 0xfd;
+    b.writeUInt16LE(n, 1);
+    return b;
+  }
+  const b = Buffer.alloc(5);
+  b[0] = 0xfe;
+  b.writeUInt32LE(n, 1);
+  return b;
+}
+
+function varBytes(b: Buffer): Buffer {
+  return Buffer.concat([varInt(b.length), b]);
+}

--- a/src/integration/blockchain/bitcoin/utils/bip322-p2wsh.util.ts
+++ b/src/integration/blockchain/bitcoin/utils/bip322-p2wsh.util.ts
@@ -1,0 +1,275 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
+import { bech32 } from 'bech32';
+
+const OP_0 = 0x00;
+const OP_1 = 0x51;
+const OP_16 = 0x60;
+const OP_CHECKMULTISIG = 0xae;
+const OP_RETURN = 0x6a;
+const OP_PUSH_33 = 0x21;
+const SIGHASH_ALL = 0x01;
+
+const TAG = Buffer.from('BIP0322-signed-message', 'utf8');
+
+interface ParsedMultisig {
+  m: number;
+  pubkeys: Buffer[];
+}
+
+export function isP2wshAddress(address: string): boolean {
+  if (!address.startsWith('bc1q') || address.length !== 62) return false;
+  try {
+    const decoded = bech32.decode(address);
+    if (decoded.prefix !== 'bc' || decoded.words[0] !== 0) return false;
+    const program = bech32.fromWords(decoded.words.slice(1));
+    return program.length === 32;
+  } catch {
+    return false;
+  }
+}
+
+export function verifyBip322P2wshSignature(message: string, address: string, signatureBase64: string): boolean {
+  try {
+    const program = decodeP2wshAddress(address);
+    if (!program) return false;
+
+    const witness = decodeSimpleSignature(signatureBase64);
+    if (!witness) return false;
+    if (witness.length < 3) return false;
+
+    const witnessScript = witness[witness.length - 1];
+    if (!Buffer.from(sha256(witnessScript)).equals(program)) return false;
+
+    const parsed = parseStandardMultisigScript(witnessScript);
+    if (!parsed) return false;
+
+    const dummy = witness[0];
+    if (dummy.length !== 0) return false;
+
+    const sigs = witness.slice(1, witness.length - 1);
+    if (sigs.length !== parsed.m) return false;
+
+    const sighash = computeBip143Sighash(message, program, witnessScript);
+
+    return verifyMultisig(sigs, parsed.pubkeys, sighash);
+  } catch {
+    return false;
+  }
+}
+
+function decodeP2wshAddress(address: string): Buffer | null {
+  if (!address.startsWith('bc1q') || address.length !== 62) return null;
+
+  const decoded = bech32.decode(address);
+  if (decoded.prefix !== 'bc') return null;
+  if (decoded.words[0] !== 0) return null;
+
+  const program = Buffer.from(bech32.fromWords(decoded.words.slice(1)));
+  if (program.length !== 32) return null;
+
+  return program;
+}
+
+function decodeSimpleSignature(signatureBase64: string): Buffer[] | null {
+  const buf = Buffer.from(signatureBase64, 'base64');
+  if (buf.length === 0) return null;
+
+  let offset = 0;
+  const count = readVarInt(buf, offset);
+  if (!count) return null;
+  offset = count.next;
+
+  const items: Buffer[] = [];
+  for (let i = 0; i < count.value; i++) {
+    const len = readVarInt(buf, offset);
+    if (!len) return null;
+    offset = len.next;
+
+    if (offset + len.value > buf.length) return null;
+    items.push(buf.subarray(offset, offset + len.value));
+    offset += len.value;
+  }
+
+  if (offset !== buf.length) return null;
+
+  return items;
+}
+
+function parseStandardMultisigScript(script: Buffer): ParsedMultisig | null {
+  if (script.length < 1 + 1 + 1) return null;
+
+  const mOp = script[0];
+  if (mOp < OP_1 || mOp > OP_16) return null;
+  const m = mOp - OP_1 + 1;
+
+  const lastTwo = script.subarray(script.length - 2);
+  if (lastTwo[1] !== OP_CHECKMULTISIG) return null;
+
+  const nOp = lastTwo[0];
+  if (nOp < OP_1 || nOp > OP_16) return null;
+  const n = nOp - OP_1 + 1;
+
+  if (m > n) return null;
+
+  const pubkeys: Buffer[] = [];
+  let offset = 1;
+  const end = script.length - 2;
+
+  while (offset < end) {
+    if (script[offset] !== OP_PUSH_33) return null;
+    offset += 1;
+    if (offset + 33 > end) return null;
+    const pk = script.subarray(offset, offset + 33);
+    if (pk[0] !== 0x02 && pk[0] !== 0x03) return null;
+    pubkeys.push(pk);
+    offset += 33;
+  }
+
+  if (offset !== end) return null;
+  if (pubkeys.length !== n) return null;
+
+  return { m, pubkeys };
+}
+
+function computeBip143Sighash(message: string, program: Buffer, witnessScript: Buffer): Buffer {
+  const messageHash = hashMessage(message);
+  const scriptPubKey = Buffer.concat([Buffer.from([OP_0, 0x20]), program]);
+  const toSpendTxid = computeToSpendTxid(messageHash, scriptPubKey);
+
+  const outpoint = Buffer.concat([toSpendTxid, uint32LE(0)]);
+  const sequence = uint32LE(0);
+
+  const hashPrevouts = hash256(outpoint);
+  const hashSequence = hash256(sequence);
+
+  const output = Buffer.concat([uint64LE(0n), Buffer.from([0x01, OP_RETURN])]);
+  const hashOutputs = hash256(output);
+
+  const preimage = Buffer.concat([
+    uint32LE(0),
+    hashPrevouts,
+    hashSequence,
+    outpoint,
+    encodeVarBytes(witnessScript),
+    uint64LE(0n),
+    sequence,
+    hashOutputs,
+    uint32LE(0),
+    uint32LE(SIGHASH_ALL),
+  ]);
+
+  return hash256(preimage);
+}
+
+function hashMessage(message: string): Buffer {
+  const tagHash = sha256(TAG);
+  const inner = Buffer.concat([Buffer.from(tagHash), Buffer.from(tagHash), Buffer.from(message, 'utf8')]);
+  return Buffer.from(sha256(inner));
+}
+
+function computeToSpendTxid(messageHash: Buffer, scriptPubKey: Buffer): Buffer {
+  const scriptSig = Buffer.concat([Buffer.from([OP_0, 0x20]), messageHash]);
+  const tx = Buffer.concat([
+    uint32LE(0),
+    encodeVarInt(1),
+    Buffer.alloc(32),
+    uint32LE(0xffffffff),
+    encodeVarBytes(scriptSig),
+    uint32LE(0),
+    encodeVarInt(1),
+    uint64LE(0n),
+    encodeVarBytes(scriptPubKey),
+    uint32LE(0),
+  ]);
+  return hash256(tx);
+}
+
+function verifyMultisig(sigs: Buffer[], pubkeys: Buffer[], sighash: Buffer): boolean {
+  let pkIdx = 0;
+  for (const sig of sigs) {
+    if (sig.length === 0) return false;
+    const sighashType = sig[sig.length - 1];
+    if (sighashType !== SIGHASH_ALL) return false;
+    const der = sig.subarray(0, sig.length - 1);
+
+    let matched = false;
+    while (pkIdx < pubkeys.length) {
+      const pk = pubkeys[pkIdx];
+      pkIdx += 1;
+      if (verifyEcdsa(der, sighash, pk)) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) return false;
+  }
+  return true;
+}
+
+function verifyEcdsa(derSignature: Buffer, sighash: Buffer, pubkey: Buffer): boolean {
+  try {
+    const compact = secp256k1.Signature.fromDER(derSignature).normalizeS().toCompactRawBytes();
+    return secp256k1.verify(compact, sighash, pubkey);
+  } catch {
+    return false;
+  }
+}
+
+function hash256(buf: Buffer): Buffer {
+  return Buffer.from(sha256(sha256(buf)));
+}
+
+function uint32LE(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(n >>> 0, 0);
+  return b;
+}
+
+function uint64LE(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(n, 0);
+  return b;
+}
+
+function encodeVarInt(n: number): Buffer {
+  if (n < 0xfd) return Buffer.from([n]);
+  if (n <= 0xffff) {
+    const b = Buffer.alloc(3);
+    b[0] = 0xfd;
+    b.writeUInt16LE(n, 1);
+    return b;
+  }
+  if (n <= 0xffffffff) {
+    const b = Buffer.alloc(5);
+    b[0] = 0xfe;
+    b.writeUInt32LE(n, 1);
+    return b;
+  }
+  const b = Buffer.alloc(9);
+  b[0] = 0xff;
+  b.writeBigUInt64LE(BigInt(n), 1);
+  return b;
+}
+
+function encodeVarBytes(bytes: Buffer): Buffer {
+  return Buffer.concat([encodeVarInt(bytes.length), bytes]);
+}
+
+function readVarInt(buf: Buffer, offset: number): { value: number; next: number } | null {
+  if (offset >= buf.length) return null;
+  const first = buf[offset];
+  if (first < 0xfd) return { value: first, next: offset + 1 };
+  if (first === 0xfd) {
+    if (offset + 3 > buf.length) return null;
+    return { value: buf.readUInt16LE(offset + 1), next: offset + 3 };
+  }
+  if (first === 0xfe) {
+    if (offset + 5 > buf.length) return null;
+    return { value: buf.readUInt32LE(offset + 1), next: offset + 5 };
+  }
+  if (offset + 9 > buf.length) return null;
+  const big = buf.readBigUInt64LE(offset + 1);
+  if (big > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  return { value: Number(big), next: offset + 9 };
+}

--- a/src/integration/blockchain/bitcoin/utils/bip322-p2wsh.util.ts
+++ b/src/integration/blockchain/bitcoin/utils/bip322-p2wsh.util.ts
@@ -18,6 +18,7 @@ interface ParsedMultisig {
 }
 
 export function isP2wshAddress(address: string): boolean {
+  if (typeof address !== 'string') return false;
   if (!address.startsWith('bc1q') || address.length !== 62) return false;
   try {
     const decoded = bech32.decode(address);
@@ -59,6 +60,7 @@ export function verifyBip322P2wshSignature(message: string, address: string, sig
 }
 
 function decodeP2wshAddress(address: string): Buffer | null {
+  if (typeof address !== 'string') return null;
   if (!address.startsWith('bc1q') || address.length !== 62) return null;
 
   const decoded = bech32.decode(address);

--- a/src/integration/blockchain/shared/services/crypto.service.ts
+++ b/src/integration/blockchain/shared/services/crypto.service.ts
@@ -12,6 +12,7 @@ import { UserAddressType } from 'src/subdomains/generic/user/models/user/user.en
 import { ArkadeService } from '../../arkade/arkade.service';
 import { ArweaveService } from '../../arweave/services/arweave.service';
 import { BitcoinService } from '../../bitcoin/services/bitcoin.service';
+import { isP2wshAddress, verifyBip322P2wshSignature } from '../../bitcoin/utils/bip322-p2wsh.util';
 import { CardanoService } from '../../cardano/services/cardano.service';
 import { FiroService } from '../../firo/services/firo.service';
 import { InternetComputerService } from '../../icp/services/icp.service';
@@ -375,8 +376,12 @@ export class CryptoService {
       try {
         isValid = verify(message, address, signature, prefix);
       } catch {
-        // ignore - verification failed
+        // ignore - try next verification method
       }
+    }
+
+    if (!isValid && prefix === null && isP2wshAddress(address)) {
+      isValid = verifyBip322P2wshSignature(message, address, signature);
     }
 
     return isValid;


### PR DESCRIPTION
## Summary
- Adds BIP-322 *full* signature verification for native P2WSH multisig addresses (`bc1q…` 62 chars) in the auth flow, so users can sign in with `wsh(sortedmulti(t, …))` / `wsh(multi(t, …))` wallets (e.g. 2-of-3 cold-storage vaults via Sparrow).
- Wired in as a 4th attempt inside `crypto.service.ts:verifyBitcoinBased`, only when no message-prefix is set (Bitcoin mainnet) and the address passes the strict P2WSH detection — existing P2WPKH/P2SH-P2WPKH/P2TR/legacy paths are untouched.
- Scope is intentionally narrow: only standard `OP_M … OP_N OP_CHECKMULTISIG` witness scripts with SIGHASH_ALL signatures. Miniscript / Taproot scripts / non-standard policies are rejected.

## Implementation notes
- Pure-noble crypto (`@noble/curves`, `@noble/hashes`, `bech32` — all already in deps), no new packages.
- BIP-322 simple signature format: base64-encoded witness stack as produced by Sparrow `Tools → Sign/Verify Message → BIP-322 Simple`.
- BIP-143 sighash construction over the synthetic `to_spend` / `to_sign` pair from BIP-322.
- Pubkey iteration follows the OP_CHECKMULTISIG convention (sigs in script-pubkey order, with replay-of-pk-index after a match).

## Test plan
- [x] `bip322-p2wsh.util.spec.ts` — 15 tests:
  - 6× P2WSH address detection (incl. testnet / malformed / empty rejection)
  - 3× structural negatives (empty / garbage / wrong address type)
  - 3× synthetic 2-of-3 sortedmulti roundtrip sign+verify (3 message lengths)
  - 1× rejects under-threshold (1 of 2 sigs)
  - 1× rejects sig for different message
  - 1× rejects sig from foreign key not in script
  - 1× `it.todo` placeholder for a real Sparrow fixture (to be filled in once a wallet-produced signature is available)
- [x] `crypto.service.spec.ts` — 67 existing tests still green
- [x] type check / prettier / eslint
- [ ] End-to-end: sign DFX challenge with a 2-of-3 Sparrow wallet, post to `/auth`, expect JWT