### PR TITLE
feat: per-wallet mail text overrides for RealUnit

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -636,7 +636,7 @@ export class Configuration {
           pass: process.env.REALUNIT_MAIL_PASS,
           fromAddress: process.env.REALUNIT_MAIL_USER,
           displayName: 'RealUnit',
-          template: 'user-v2',
+          template: 'realUnit',
         },
       }),
     },

--- a/src/shared/i18n/de/mail.json
+++ b/src/shared/i18n/de/mail.json
@@ -414,5 +414,75 @@
         },
         "message": "Dein Verifizierungscode lautet:<br>{code}",
         "closing": "Der Verifizierungscode ist für {expiration} Minuten gültig. Bitte teile diesen Verifizierungscode nicht mit anderen Personen. Wenn du keinen Verifizierungscode angefordert hast, kontaktiere bitte unverzüglich den Support unter [url:https://app.dfx.swiss/support]."
+    },
+    "wallets": {
+        "realunit": {
+            "general": {
+                "dfx_team_closing": "RealUnit Schweiz AG",
+                "dfx_closing_message": "",
+                "support": "Bei technischen Problemen mit der App wenden Sie sich bitte an<br>[url:https://support.realunit.ch]",
+                "thanks": "Vielen Dank für Ihr Vertrauen",
+                "welcome": "Guten Tag {name}",
+                "team_questions": "Sollten Sie Fragen haben, steht Ihnen das RealUnit-Team gerne unter info@realunit.ch zur Verfügung.",
+                "personal_closing": "Freundliche Grüsse,<br>{closingName}"
+            },
+            "payment": {
+                "crypto_output": {
+                    "title": "Transfer Ihrer RealUnit-Token",
+                    "salutation": "Wir haben Ihnen die RealUnit-Token in Ihr Wallet überwiesen"
+                },
+                "fiat_output": {
+                    "title": "Verkauf RealUnit-Token – Überweisung erfolgt",
+                    "salutation": "Sie haben Ihre RealUnit-Token erfolgreich verkauft"
+                },
+                "processing": {
+                    "title": "Verkauf Ihrer RealUnit-Token",
+                    "salutation": "Ihre Verkaufstransaktion wird nun verarbeitet"
+                },
+                "fiat_input": {
+                    "title": "Kauf RealUnit-Token – Einzahlung wird geprüft",
+                    "salutation": "Vielen Dank für den Kauf unserer RealUnit-Aktientoken"
+                },
+                "chargeback": {
+                    "fiat": {
+                        "title": "Verkauf RealUnit-Token – Rückerstattung",
+                        "salutation": "Ihr Verkaufsauftrag konnte nicht durchgeführt werden"
+                    },
+                    "crypto": {
+                        "title": "Verkauf RealUnit-Token aktuell nicht möglich",
+                        "salutation": "Ihre RealUnit-Token wurden Ihrem Wallet zurückerstattet"
+                    },
+                    "introduction": "Grund:<br>{reason}",
+                    "reasons": {
+                        "monthly_limit": "Sie haben die monatliche Limite von CHF 1'000.– ohne vollständige Verifizierung überschritten",
+                        "annual_limit": "Sie haben die jährliche Limite von CHF 100'000.– ohne erweiterte Verifizierung überschritten",
+                        "annual_limit_without_kyc": "Sie haben die Jahreslimite ohne KYC-Verifizierung überschritten",
+                        "kyc_data_needed": "Für den Verkauf werden Ihre vollständigen KYC-Daten benötigt",
+                        "video_ident_needed": "Für den Verkauf ist eine Video-Verifizierung nötig",
+                        "high_risk_kyc_needed": "Aus regulatorischen Gründen ist eine vollständige Verifizierung nötig"
+                    }
+                }
+            },
+            "kyc": {
+                "failed": {
+                    "title": "Verkauf RealUnit-Token – Video-Verifizierung erforderlich",
+                    "salutation": "Aus regulatorischen Gründen ist eine Video-Verifizierung erforderlich"
+                },
+                "missing_data": {
+                    "title": "Verkauf RealUnit-Token – Bitte vervollständigen Sie Ihre Stammdaten",
+                    "salutation": "In Ihrem Profil fehlen einzelne Stammdaten"
+                },
+                "reminder": {
+                    "title": "Erinnerung: Ihr Verkauf wartet auf Verifizierung",
+                    "salutation": "Ihr Verkaufsauftrag wartet weiterhin auf Ihre Verifizierung"
+                }
+            },
+            "verification_code": {
+                "email": {
+                    "title": "Erinnerung: Bestätigung Ihrer E-Mailadresse",
+                    "salutation": "Bitte bestätigen Sie Ihre E-Mailadresse"
+                }
+            }
+        }
     }
 }

--- a/src/shared/i18n/en/mail.json
+++ b/src/shared/i18n/en/mail.json
@@ -414,5 +414,75 @@
         },
         "message": "Your verification code is:<br>{code}",
         "closing": "The verification code is valid for {expiration} minutes. Please do not share this verification code with other people. If you have not requested a verification code, please contact support immediately via [url:https://app.dfx.swiss/support]."
+    },
+    "wallets": {
+        "realunit": {
+            "general": {
+                "dfx_team_closing": "RealUnit Schweiz AG",
+                "dfx_closing_message": "",
+                "support": "For technical issues with the app, please contact<br>[url:https://support.realunit.ch]",
+                "thanks": "Thank you for your trust",
+                "welcome": "Dear {name}",
+                "team_questions": "Should you have any questions, the RealUnit team is happy to assist at info@realunit.ch.",
+                "personal_closing": "Kind regards,<br>{closingName}"
+            },
+            "payment": {
+                "crypto_output": {
+                    "title": "Transfer of your RealUnit tokens",
+                    "salutation": "We have transferred the RealUnit tokens to your wallet"
+                },
+                "fiat_output": {
+                    "title": "Sale of RealUnit tokens – Payout completed",
+                    "salutation": "You have successfully sold your RealUnit tokens"
+                },
+                "processing": {
+                    "title": "Sale of your RealUnit tokens",
+                    "salutation": "Your sell transaction is now being processed"
+                },
+                "fiat_input": {
+                    "title": "Purchase of RealUnit tokens – Payment under review",
+                    "salutation": "Thank you for purchasing our RealUnit equity tokens"
+                },
+                "chargeback": {
+                    "fiat": {
+                        "title": "Sale of RealUnit tokens – Refund",
+                        "salutation": "Your sell order could not be executed"
+                    },
+                    "crypto": {
+                        "title": "Sale of RealUnit tokens currently not possible",
+                        "salutation": "Your RealUnit tokens have been returned to your wallet"
+                    },
+                    "introduction": "Reason:<br>{reason}",
+                    "reasons": {
+                        "monthly_limit": "You have exceeded the monthly limit of CHF 1'000 without full verification",
+                        "annual_limit": "You have exceeded the annual limit of CHF 100'000 without extended verification",
+                        "annual_limit_without_kyc": "You have exceeded the annual limit without KYC verification",
+                        "kyc_data_needed": "Full KYC data is required for the sale",
+                        "video_ident_needed": "A video verification is required for the sale",
+                        "high_risk_kyc_needed": "Full verification is required for regulatory reasons"
+                    }
+                }
+            },
+            "kyc": {
+                "failed": {
+                    "title": "Sale of RealUnit tokens – Video verification required",
+                    "salutation": "Video verification is required for regulatory reasons"
+                },
+                "missing_data": {
+                    "title": "Sale of RealUnit tokens – Please complete your profile data",
+                    "salutation": "Some profile data is missing"
+                },
+                "reminder": {
+                    "title": "Reminder: Your sale is waiting for verification",
+                    "salutation": "Your sell order is still waiting for your verification"
+                }
+            },
+            "verification_code": {
+                "email": {
+                    "title": "Reminder: Confirm your email address",
+                    "salutation": "Please confirm your email address"
+                }
+            }
+        }
     }
 }

--- a/src/subdomains/supporting/notification/factories/mail.factory.ts
+++ b/src/subdomains/supporting/notification/factories/mail.factory.ts
@@ -148,13 +148,14 @@ export class MailFactory {
     if (this.isDisabledMailWallet(context, wallet)) return undefined;
 
     const lang = userData.language.symbol.toLowerCase();
+    const walletName = wallet?.name;
 
     return new UserMailV2(
       {
         to: userData.mail,
-        subject: this.translate(title, lang),
-        salutation: salutation && this.translate(salutation.key, lang, salutation.params),
-        texts: texts && this.getMailAffix(texts, lang),
+        subject: this.translate(title, lang, undefined, walletName),
+        salutation: salutation && this.translate(salutation.key, lang, salutation.params, walletName),
+        texts: texts && this.getMailAffix(texts, lang, walletName),
         correlationId,
         options,
       },
@@ -170,12 +171,13 @@ export class MailFactory {
     if (this.isDisabledMailWallet(context, wallet)) return undefined;
 
     const lang = userData.language.symbol;
+    const walletName = wallet?.name;
 
     return new PersonalMail({
       to: userData.mail,
       bcc,
-      subject: this.translate(title, lang),
-      prefix: prefix && this.getMailAffix(prefix, lang),
+      subject: this.translate(title, lang, undefined, walletName),
+      prefix: prefix && this.getMailAffix(prefix, lang, walletName),
       banner,
       from,
       displayName,
@@ -186,8 +188,15 @@ export class MailFactory {
 
   //*** TRANSLATION METHODS ***//
 
-  public translate(key: string, lang: string, args?: any): string {
-    return this.i18n.translate(key, { lang: lang.toLowerCase(), args });
+  public translate(key: string, lang: string, args?: any, walletName?: string): string {
+    const lowerLang = lang.toLowerCase();
+    if (walletName) {
+      const innerKey = key.replace(/^mail\./, '');
+      const walletKey = `mail.wallets.${walletName.toLowerCase()}.${innerKey}`;
+      const walletValue = this.i18n.translate(walletKey, { lang: lowerLang, args }) as string;
+      if (walletValue !== walletKey) return walletValue;
+    }
+    return this.i18n.translate(key, { lang: lowerLang, args });
   }
 
   //*** MAIL BUILDING METHODS ***//
@@ -201,14 +210,14 @@ export class MailFactory {
     );
   }
 
-  private getMailAffix(affix: TranslationItem[], lang = 'en'): MailAffix[] {
+  private getMailAffix(affix: TranslationItem[], lang = 'en', walletName?: string): MailAffix[] {
     return affix
       .filter((i) => i)
-      .map((i) => this.mapMailAffix(i, lang).flat())
+      .map((i) => this.mapMailAffix(i, lang, walletName).flat())
       .flat();
   }
 
-  private mapMailAffix(element: TranslationItem, lang: string): MailAffix[] {
+  private mapMailAffix(element: TranslationItem, lang: string, walletName?: string): MailAffix[] {
     switch (element.key) {
       case MailKey.SPACE:
         return [DefaultEmptyLine];
@@ -217,18 +226,21 @@ export class MailFactory {
         return [
           DefaultEmptyLine,
           {
-            text: this.translate(`${MailTranslationKey.GENERAL}.dfx_team_closing`, lang),
+            text: this.translate(`${MailTranslationKey.GENERAL}.dfx_team_closing`, lang, undefined, walletName),
             style: UserMailDefaultStyle,
           },
-          { text: this.translate(`${MailTranslationKey.GENERAL}.dfx_closing_message`, lang), style: 'Zapfino' },
+          {
+            text: this.translate(`${MailTranslationKey.GENERAL}.dfx_closing_message`, lang, undefined, walletName),
+            style: 'Zapfino',
+          },
           DefaultEmptyLine,
           DefaultEmptyLine,
         ];
 
       default: {
         const params = Util.removeNullFields(element.params);
-        const translatedParams = this.translateParams(params, lang);
-        const text = this.translate(element.key, lang, translatedParams);
+        const translatedParams = this.translateParams(params, lang, walletName);
+        const text = this.translate(element.key, lang, translatedParams, walletName);
         const specialTag = this.parseSpecialTag(text);
 
         return [
@@ -266,10 +278,10 @@ export class MailFactory {
     return match ? { text: match[1], textSuffix: match[4], tag: match[2], value: match[3] } : undefined;
   }
 
-  private translateParams(params: TranslationParams, lang: string): TranslationParams {
+  private translateParams(params: TranslationParams, lang: string, walletName?: string): TranslationParams {
     return params
       ? Object.entries(params)
-          .map(([key, value]) => [key, this.translate(value, lang, params)])
+          .map(([key, value]) => [key, this.translate(value, lang, params, walletName)])
           .reduce((prev, [key, value]) => {
             prev[key] = value;
             return prev;

--- a/src/subdomains/supporting/notification/templates/realUnit.hbs
+++ b/src/subdomains/supporting/notification/templates/realUnit.hbs
@@ -1,0 +1,390 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+    <head>
+        <!--[if gte mso 9]>
+        <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="x-apple-disable-message-reformatting">
+        <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+        <title></title>
+    
+        <style type="text/css">
+        
+            @media only screen and (min-width: 520px) {
+                .u-row {
+                width: 500px !important;
+                }
+
+                .u-row .u-col {
+                vertical-align: top;
+                }
+    
+                .u-row .u-col-100 {
+                width: 500px !important;
+                }            
+            }
+
+            @media only screen and (max-width: 520px) {
+                .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+                }
+
+                .u-row {
+                width: 100% !important;
+                }
+
+                .u-row .u-col {
+                display: block !important;
+                width: 100% !important;
+                min-width: 320px !important;
+                max-width: 100% !important;
+                }
+
+                .u-row .u-col > div {
+                margin: 0 auto;
+                }
+
+
+                .u-row .u-col img {
+                max-width: 100% !important;
+                }
+            }
+            
+            body {
+                margin:0;
+                padding:0
+            }
+            
+            table,td,tr {
+                border-collapse:collapse;
+                vertical-align:top
+            }
+
+            p {
+                margin:0
+            }
+
+            .ie-container table,.mso-container table {
+                table-layout:fixed
+            }
+
+            * {
+                line-height:inherit
+            }
+
+            a[x-apple-data-detectors=true] {
+                color:inherit!important;text-decoration:none!important
+            }
+
+
+            table, td { 
+                color: #000000; 
+            }
+
+            #u_body a { 
+                color: #0000ee; 
+                text-decoration: underline; 
+            }
+
+        </style>
+    
+    
+
+    </head>
+
+    <body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #F7F8F9;color: #000000">
+        <div class='hidden' style='display:none'>
+        <div class='pre-header'>
+            <span>{{subject}}</span>
+        </div>
+        </div>
+        
+        <!--[if IE]><div class="ie-container"><![endif]-->
+        <!--[if mso]><div class="mso-container"><![endif]-->
+        <table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #F7F8F9;width:100%" cellpadding="0" cellspacing="0">
+            <tbody>
+                <tr style="vertical-align: top">
+                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+                    <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #F7F8F9;"><![endif]-->
+
+
+
+                        {{!-- Logo Block --}}
+                        <div class="u-row-container" style="padding: 0px;background-color: #1e1a2e">
+                        <div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                        <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: #1e1a2e;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+                            
+                        <!--[if (mso)|(IE)]><td align="center" width="500" style="background-color: #1e1a2e;width: 500px;padding: 12px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+                        <div style="background-color: #1e1a2e;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                        <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 24px 12px 12px 12px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+                        
+                        <table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                            <tbody>
+                                <tr>
+                                    <td style="overflow-wrap:break-word;word-break:break-word;padding:50px 0px 0px 0px;font-family:arial,helvetica,sans-serif;" align="left">
+                                        <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                            <tr>
+                                                <td style="padding-right: 0px;padding-left: 0px;" align="center">
+                                                    <img align="center" border="0" src="https://dfx.swiss/images/mails/realunit.png" alt="RealUnit Schweiz AG" title="RealUnit Schweiz AG" style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 100%;max-width: 500px;" width="500"/>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                        </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                        </div>
+                        </div>
+                        </div>
+
+
+
+
+                        {{!-- Salutation Block --}}
+                        <div class="u-row-container" style="padding: 0px;background-color: #1e1a2e">
+                        <div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                        <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: #1e1a2e;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+                            
+                        <!--[if (mso)|(IE)]><td align="center" width="500" style="width: 500px;padding: 23px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+                        <div style="height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                        <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 23px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+                        
+                        <table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                            <tbody>
+                                <tr>
+                                    <td style="overflow-wrap:break-word;word-break:break-word;padding:20px 0px 0px 0px;font-family:arial,helvetica,sans-serif;" align="left">
+                                        <div style="font-size: 18px; color: #f7f8f9; line-height: 140%; text-align: center; word-wrap: break-word;">
+                                            <p style="line-height: 140%;"><strong>{{salutation}}</strong></p>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                        </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                        </div>
+                        </div>
+                        </div>
+
+
+
+
+                        {{!-- Prefix Block --}}
+                        {{#each prefix}}
+                        <div class="u-row-container" style="padding: 0px;background-color: #1e1a2e">
+                        <div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                        <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: #1e1a2e;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+                            
+                        <!--[if (mso)|(IE)]><td align="center" width="500" style="width: 500px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+                        <div style="height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                        <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+                        
+                        <table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                            <tbody>
+                                <tr style='font-family:{{this.style}}'>
+                                    <td style="overflow-wrap:break-word;word-break:break-word;padding:20px 0px 0px 0px;font-family:arial,helvetica,sans-serif;" align="left"> 
+                                        <div style="font-size: 13px; color: #f7f8f9; line-height: 140%; text-align: center; word-wrap: break-word;">
+                                            
+                                            {{!-- Future Button --}}
+                                            {{!-- <a href="" target="_blank" class="v-button" style="box-sizing: border-box;display: inline-block;text-decoration: none;-webkit-text-size-adjust: none;text-align: center;color: #FFFFFF; background-color: #0000ee; border-radius: 4px;-webkit-border-radius: 4px; -moz-border-radius: 4px; width:54%; max-width:100%; overflow-wrap: break-word; word-break: break-word; word-wrap:break-word; mso-border-alt: none;font-size: 10px;">
+                                            <span style="display:block;padding:10px 20px;line-height:120%;"><strong><span style="line-height: 12px;">{{SEE DETAILS}}</span></strong></span>
+                                            </a> --}}
+
+                                            <p style="line-height: 140%;">{{{this.text}}}</p>
+                                            {{#if this.url}}<a target="_blank" style='color:white' href='{{this.url.link}}'><span style="display:block;padding:10px 20px;line-height:120%;"><strong><span style="line-height: 12px;">{{this.url.text}}</span></strong></span></a>
+                                            {{#if this.url.textSuffix}}{{this.url.textSuffix}}{{/if}}
+                                            {{/if}}
+                                            {{#if this.mail}}<a style='color:white' href='mailto:{{this.mail.address}}'>{{this.mail.address}}</a>
+                                            {{#if this.mail.textSuffix}}{{this.mail.textSuffix}}{{/if}}
+                                            {{/if}}
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                        </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                        </div>
+                        </div>
+                        </div>
+                        {{/each}}
+
+
+
+
+                        {{!-- Table Block --}}
+                        {{#each table}}
+                        <div class="u-row-container" style="padding: 0px;background-color: #1e1a2e">
+                        <div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                        <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: #1e1a2e;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+                            
+                        <!--[if (mso)|(IE)]><td align="center" width="500" style="width: 500px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+                        <div style="height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                        <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+                        
+                        <table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                            <tbody>
+                                <tr style='font-family:{{this.style}};padding:20px 0px 0px 0px'>
+                                    <td align="right" style="padding: 8px; font-size: 85%; width: 40%; color: white;">
+                                        {{this.text}}
+                                    </td>
+                                    <td style="width: 2%;"></td>
+                                    <td align="left" style="padding: 8px; font-size: 85%; color: white;">
+                                        {{this.value}}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                        </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                        </div>
+                        </div>
+                        </div>
+                        {{/each}}
+
+
+
+
+                        {{!-- Suffix Block --}}
+                        {{#each suffix}}
+                        <div class="u-row-container" style="padding: 0px;background-color: #1e1a2e">
+                        <div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                        <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: #1e1a2e;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+                            
+                        <!--[if (mso)|(IE)]><td align="center" width="500" style="width: 500px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+                        <div style="height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                        <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+                        
+                        <table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                            <tbody>
+                                <tr style='font-family:{{this.style}}'>
+                                    <td style="overflow-wrap:break-word;word-break:break-word;padding:20px 0px 0px 0px;font-family:arial,helvetica,sans-serif;" align="left"> 
+                                        <div style="font-size: 13px; color: #f7f8f9; line-height: 140%; text-align: center; word-wrap: break-word;">
+                                            
+                                            {{!-- Future Button --}}
+                                            {{!-- <a href="" target="_blank" class="v-button" style="box-sizing: border-box;display: inline-block;text-decoration: none;-webkit-text-size-adjust: none;text-align: center;color: #FFFFFF; background-color: #0000ee; border-radius: 4px;-webkit-border-radius: 4px; -moz-border-radius: 4px; width:54%; max-width:100%; overflow-wrap: break-word; word-break: break-word; word-wrap:break-word; mso-border-alt: none;font-size: 10px;">
+                                            <span style="display:block;padding:10px 20px;line-height:120%;"><strong><span style="line-height: 12px;">{{SEE DETAILS}}</span></strong></span>
+                                            </a> --}}
+
+                                            <p style="line-height: 140%;">{{{this.text}}}</p>
+                                            {{#if this.url}}<a target="_blank" style='color:white' href='{{this.url.link}}'><span style="display:block;padding:10px 20px;line-height:120%;"><strong><span style="line-height: 12px;">{{this.url.text}}</span></strong></span></a>
+                                            {{#if this.url.textSuffix}}{{this.url.textSuffix}}{{/if}}
+                                            {{/if}}
+                                            {{#if this.mail}}<a style='color:white' href='mailto:{{this.mail.address}}'>{{this.mail.address}}</a>
+                                            {{#if this.mail.textSuffix}}{{this.mail.textSuffix}}{{/if}}
+                                            {{/if}}
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                        </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                        </div>
+                        </div>
+                        </div>
+                        {{/each}}
+
+
+
+
+                        {{!-- Texts Block --}}
+                        {{#each texts}}
+                        <div class="u-row-container" style="padding: 0px;background-color: #1e1a2e">
+                        <div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                        <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: #1e1a2e;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+                            
+                        <!--[if (mso)|(IE)]><td align="center" width="500" style="width: 500px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+                        <div style="height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                        <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+                        
+                        <table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                            <tbody>
+                                <tr style='font-family:{{this.style}}'>
+                                    <td style="overflow-wrap:break-word;word-break:break-word;padding:20px 0px 0px 0px;font-family:arial,helvetica,sans-serif;" align="left"> 
+                                        <div style="font-size: 13px; color: #f7f8f9; line-height: 140%; text-align: center; word-wrap: break-word;">
+                                            <p style="line-height: 140%;">{{{this.text}}}</p>
+                                            {{#if this.url}}
+                                                {{#if this.url.button}}<!--[if mso]><style>.v-button {background: transparent !important;}</style><![endif]-->{{/if}}
+                                                {{#if this.url.button}}<!--[if mso]><v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href='{{this.url.link}}' style="height:32px; v-text-anchor:middle; width:200px;" arcsize="12.5%"  stroke="f" fillcolor="#0000ee"><w:anchorlock/><center style="color:#FFFFFF;"><![endif]-->{{/if}}
+                                                {{#if this.url.button}}<a href='{{this.url.link}}' target="_blank" class='v-button btn' style="box-sizing: border-box;display: inline-block;text-decoration: none;-webkit-text-size-adjust: none;text-align: center;color: #FFFFFF; background-color: #0000ee; border-radius: 4px;-webkit-border-radius: 4px; -moz-border-radius: 4px; width:54%; max-width:100%; overflow-wrap: break-word; word-break: break-word; word-wrap:break-word; mso-border-alt: none;font-size: 10px;">{{else}}<a href='{{this.url.link}}' target="_blank" style="color: #FFFFFF;">{{/if}}
+                                                <span style="display:block;padding:10px 20px;line-height:120%;"><strong><span style="line-height: 12px;">{{this.url.text}}</span></strong></span>
+                                                </a>
+                                                {{#if this.url.button}}<!--[if mso]></center></v:roundrect><![endif]-->{{/if}}
+                                                {{#if this.url.textSuffix}} {{this.url.textSuffix}} {{/if}}
+                                            {{/if}}
+                                            {{#if this.mail}}<a style='color:white' href='mailto:{{this.mail.address}}'>{{this.mail.address}}</a>
+                                            {{#if this.mail.textSuffix}}{{this.mail.textSuffix}}{{/if}}
+                                            {{/if}}
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                        </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                        </div>
+                        </div>
+                        </div>
+                        {{/each}}
+
+
+
+
+                        <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <!--[if mso]></div><![endif]-->
+        <!--[if IE]></div><![endif]-->
+    </body>
+
+</html>


### PR DESCRIPTION
## Summary

Adds per-wallet override mechanism for user-mail texts so partner wallets (RealUnit being the first) can ship their own subjects, salutations and body texts without forking the trigger services or introducing new MailType values.

## What changed

- **`MailFactory.translate(...)`** is now wallet-aware. When a `walletName` is passed it tries `mail.wallets.<walletname>.<key>` first and falls back to the default key. `getMailAffix`, `mapMailAffix` and `translateParams` propagate the `walletName`, and `createUserV2Mail` / `createPersonalMail` pull it from `wallet.name` automatically.
- **`mail.json` (DE + EN)** gets a new `wallets.realunit` block with overrides for `general` (closing / support / welcome / thanks), purchase / sale / refund / processing flows plus KYC failure, missing-data, reminder, and email-verification reminder. All texts use formal *Sie* and the RealUnit Schweiz AG closing.
- **`realUnit.hbs`** mail layout (copy of `onChainLabs.hbs` with RealUnit logo URL swapped). Layout/colors are unchanged for now — RealUnit branding can be tuned in a follow-up once they hand over the assets.
- **`config.ts`** flips `mail.wallet.RealUnit.template` from `'user-v2'` to `'realUnit'`.

## What this maps to (RealUnit template doc v1.1)

| Doc # | Trigger / DFX-Event | Override key |
|---|---|---|
| #1 Kauf abgeschlossen | `BUY_CRYPTO_COMPLETED` | `payment.crypto_output.*` |
| #2 Verkauf gestartet | `BUY_FIAT_PROCESSING` | `payment.processing.*` |
| #3 Monatslimit | `BUY_FIAT_PENDING` | `payment.chargeback.reasons.monthly_limit` |
| #4 Jahreslimit | `BUY_FIAT_PENDING` | `payment.chargeback.reasons.annual_limit` |
| #5 Einzahlung in Prüfung | `BUY_CRYPTO_PENDING` | `payment.fiat_input.*` |
| #7 Video-KYC | `KYC_FAILED` | `kyc.failed.*` |
| #8 KYC-Daten fehlen | `KYC_MISSING_DATA` | `kyc.missing_data.*` |
| #9 Mail-Bestätigung Reminder | `EMAIL_VERIFICATION_REMINDER` | `verification_code.email.*` |
| #11 KYC-Reminder | `KYC_REMINDER` | `kyc.reminder.*` |
| #12 Rückerstattung Limite | `BUY_FIAT_RETURN` | `payment.chargeback.fiat.*` |
| #15 Verkauf nicht möglich | `BUY_FIAT_RETURN` | `payment.chargeback.crypto.*` |
| #17 Verkaufserlös ausgezahlt | `BUY_FIAT_COMPLETED` | `payment.fiat_output.*` |

#6 (Zahlungsproblem) and #13 (Aktion ausstehend) are intentionally NOT overridden — they should be disabled per-wallet via `wallet.disabledMailTypes` once this lands.

## Open points (waiting on RealUnit / DAS)

- Final support URL — currently assumed `https://support.realunit.ch`.
- App path for KYC/flow-of-funds entry — currently text says "Menü → Profil → Verifizierung".
- Consolidation of #8 / #10 / #11 (kept as three separate texts for now).
- Slots #14 and #16 in the v1.0 doc (numbering gap, no template provided).
- RealUnit branding assets for the HBS layout (logo URL is a placeholder, layout colours still match onChainLabs).
- Whether EN should ship in phase 1 alongside DE (added preemptively).

## Test plan

- [ ] DEV deploy: trigger a #1-style buy completion mail for a RealUnit user and verify subject, salutation and closing render with RealUnit overrides.
- [ ] Trigger a non-RealUnit user mail and verify default DFX texts are unchanged.
- [ ] Trigger a #11 KYC-reminder for a RealUnit user and verify both `kyc.reminder.title` and `general.support` come from the override block.
- [ ] Inspect rendered HTML in Outlook/Gmail/iOS Mail (RealUnit logo loads, layout intact).
- [ ] EN-language RealUnit user receives the EN override texts.

## Out of scope

- DB schema changes — none needed; everything is config-/i18n-driven.
- Refactor of `MailFactory` beyond the override hook.
- New `MailType` or `MailContext` values.
- FR/IT translations (phase 2).