### PR TITLE
fix: exclude fiat_output 80741 from pending balance calculation

### DIFF
--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -223,7 +223,7 @@ export class FiatOutputJobService {
 
       const pendingFiatOutputs = accountIbanGroup.filter((tx) => {
         if (!tx.isReadyDate) return false;
-        if (tx.id === 79958) return false; // TODO: excluded from pending balance calculation
+        if (tx.id === 80741) return false; // TODO: excluded from pending balance calculation
 
         switch (tx.bank?.name) {
           case IbanBankName.YAPEAL:


### PR DESCRIPTION
## Summary
- Replaces the obsolete exclusion of `fiat_output` 79958 (already `isComplete=true`) with 80741, which is currently blocking `isReadyDate` assignment for other outputs on the same source IBAN.
- Same pattern as #3390.

## Test plan
- [ ] Verify `setReadyDate` job no longer counts 80741 in `pendingBalance`
- [ ] Confirm queued outputs on the affected source IBAN get their `isReadyDate` set