### PR TITLE
Add EUR bank fee differentiation (Olky 0.5%, Yapeal 2%)

### DIFF
--- a/migration/1777456992700-DifferentiateEurBankFeeByBank.js
+++ b/migration/1777456992700-DifferentiateEurBankFeeByBank.js
@@ -14,9 +14,18 @@ module.exports = class DifferentiateEurBankFeeByBank1777456992700 {
             INSERT INTO "dbo"."fee" ("label", "type", "rate", "fixed", "blockchainFactor", "payoutRefBonus", "active", "fiats", "bankId")
             VALUES ('Bank Fee EUR Yapeal 2%', 'Bank', 0.02, 0, 1, 1, 1, '2', 16)
         `);
+
+    // Preserve 0.5% EUR bank fee for Raiffeisen (bank id 12)
+    await queryRunner.query(`
+            INSERT INTO "dbo"."fee" ("label", "type", "rate", "fixed", "blockchainFactor", "payoutRefBonus", "active", "fiats", "bankId")
+            VALUES ('Bank Fee EUR Raiffeisen 0.5%', 'Bank', 0.005, 0, 1, 1, 1, '2', 12)
+        `);
   }
 
   async down(queryRunner) {
+    await queryRunner.query(`
+            DELETE FROM "dbo"."fee" WHERE "label" = 'Bank Fee EUR Raiffeisen 0.5%' AND "type" = 'Bank'
+        `);
     await queryRunner.query(`
             DELETE FROM "dbo"."fee" WHERE "label" = 'Bank Fee EUR Yapeal 2%' AND "type" = 'Bank'
         `);

--- a/migration/1777456992700-DifferentiateEurBankFeeByBank.js
+++ b/migration/1777456992700-DifferentiateEurBankFeeByBank.js
@@ -1,0 +1,44 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class DifferentiateEurBankFeeByBank1777456992700 {
+    name = 'DifferentiateEurBankFeeByBank1777456992700'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        // Scope existing 0.5% EUR bank fee to Olkypay (bank id 4)
+        await queryRunner.query(`
+            UPDATE "fee"
+            SET "bankId" = 4, "label" = 'Bank Fee EUR Olky 0.5%'
+            WHERE "label" = 'Bank Fee EUR 0.5%' AND "type" = 'Bank' AND "bankId" IS NULL
+        `);
+
+        // Add Yapeal-specific 2% EUR bank fee (bank id 16)
+        await queryRunner.query(`
+            INSERT INTO "fee" ("label", "type", "rate", "fixed", "blockchainFactor", "payoutRefBonus", "active", "fiats", "bankId")
+            VALUES ('Bank Fee EUR Yapeal 2%', 'Bank', 0.02, 0, 1, true, true, '2', 16)
+        `);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        await queryRunner.query(`
+            DELETE FROM "fee" WHERE "label" = 'Bank Fee EUR Yapeal 2%' AND "type" = 'Bank'
+        `);
+        await queryRunner.query(`
+            UPDATE "fee"
+            SET "bankId" = NULL, "label" = 'Bank Fee EUR 0.5%'
+            WHERE "label" = 'Bank Fee EUR Olky 0.5%' AND "type" = 'Bank' AND "bankId" = 4
+        `);
+    }
+}

--- a/migration/1777456992700-DifferentiateEurBankFeeByBank.js
+++ b/migration/1777456992700-DifferentiateEurBankFeeByBank.js
@@ -1,44 +1,29 @@
-/**
- * @typedef {import('typeorm').MigrationInterface} MigrationInterface
- * @typedef {import('typeorm').QueryRunner} QueryRunner
- */
-
-/**
- * @class
- * @implements {MigrationInterface}
- */
 module.exports = class DifferentiateEurBankFeeByBank1777456992700 {
-    name = 'DifferentiateEurBankFeeByBank1777456992700'
+  name = 'DifferentiateEurBankFeeByBank1777456992700';
 
-    /**
-     * @param {QueryRunner} queryRunner
-     */
-    async up(queryRunner) {
-        // Scope existing 0.5% EUR bank fee to Olkypay (bank id 4)
-        await queryRunner.query(`
-            UPDATE "fee"
+  async up(queryRunner) {
+    // Scope existing 0.5% EUR bank fee to Olkypay (bank id 4)
+    await queryRunner.query(`
+            UPDATE "dbo"."fee"
             SET "bankId" = 4, "label" = 'Bank Fee EUR Olky 0.5%'
             WHERE "label" = 'Bank Fee EUR 0.5%' AND "type" = 'Bank' AND "bankId" IS NULL
         `);
 
-        // Add Yapeal-specific 2% EUR bank fee (bank id 16)
-        await queryRunner.query(`
-            INSERT INTO "fee" ("label", "type", "rate", "fixed", "blockchainFactor", "payoutRefBonus", "active", "fiats", "bankId")
-            VALUES ('Bank Fee EUR Yapeal 2%', 'Bank', 0.02, 0, 1, true, true, '2', 16)
+    // Add Yapeal-specific 2% EUR bank fee (bank id 16)
+    await queryRunner.query(`
+            INSERT INTO "dbo"."fee" ("label", "type", "rate", "fixed", "blockchainFactor", "payoutRefBonus", "active", "fiats", "bankId")
+            VALUES ('Bank Fee EUR Yapeal 2%', 'Bank', 0.02, 0, 1, 1, 1, '2', 16)
         `);
-    }
+  }
 
-    /**
-     * @param {QueryRunner} queryRunner
-     */
-    async down(queryRunner) {
-        await queryRunner.query(`
-            DELETE FROM "fee" WHERE "label" = 'Bank Fee EUR Yapeal 2%' AND "type" = 'Bank'
+  async down(queryRunner) {
+    await queryRunner.query(`
+            DELETE FROM "dbo"."fee" WHERE "label" = 'Bank Fee EUR Yapeal 2%' AND "type" = 'Bank'
         `);
-        await queryRunner.query(`
-            UPDATE "fee"
+    await queryRunner.query(`
+            UPDATE "dbo"."fee"
             SET "bankId" = NULL, "label" = 'Bank Fee EUR 0.5%'
             WHERE "label" = 'Bank Fee EUR Olky 0.5%' AND "type" = 'Bank' AND "bankId" = 4
         `);
-    }
-}
+  }
+};


### PR DESCRIPTION
## Summary
- Existing `Bank Fee EUR 0.5%` (fee id 141) has `bankId = NULL` and applies to every EUR bank input regardless of bank
- Differentiate per bank for the three banks with active EUR deposit volume in 2026:

| Fee ID | Label | Rate | Bank |
|---|---|---|---|
| 141 | Bank Fee EUR Olky 0.5% (renamed) | 0.5% | Olkypay (id 4) |
| _new_ | Bank Fee EUR Yapeal 2% | 2% | Yapeal (id 16, matches both Yapeal IBANs by name) |
| _new_ | Bank Fee EUR Raiffeisen 0.5% | 0.5% | Raiffeisen (id 12) |

Other EUR-denominated bank accounts (Bank Frick, Maerki Baumann, Revolut, Kaleido) had no or near-zero deposit volume in 2026 and lose the bank fee. New deposit channels via these banks must be re-evaluated explicitly before activation.

In-flight `buy_crypto` rows whose fees have not been calculated yet (`percentFee IS NULL`) will pick up the new rates on the next preparation run.

## Test plan
- [ ] Verify migration runs successfully on staging
- [ ] Confirm fee 141 has `bankId = 4` and renamed label after deployment
- [ ] Confirm new Yapeal fee (rate 0.02, `bankId = 16`, `fiats = '2'`) is active
- [ ] Confirm new Raiffeisen fee (rate 0.005, `bankId = 12`, `fiats = '2'`) is active
- [ ] Quote a EUR buy via Olkypay account — `bankPercent` rate is 0.5%
- [ ] Quote a EUR buy via Yapeal account — `bankPercent` rate is 2%
- [ ] Quote a EUR buy via Raiffeisen account — `bankPercent` rate is 0.5%