### PR TITLE
feat: extend compliance user details with new tabs

### DIFF
--- a/src/subdomains/core/buy-crypto/routes/swap/swap.service.ts
+++ b/src/subdomains/core/buy-crypto/routes/swap/swap.service.ts
@@ -178,6 +178,13 @@ export class SwapService {
     });
   }
 
+  async getSwapsByUserDataId(userDataId: number): Promise<Swap[]> {
+    return this.swapRepo.find({
+      where: { user: { userData: { id: userDataId } } },
+      relations: { asset: true, deposit: true, user: true },
+    });
+  }
+
   async createSwapPaymentInfo(
     userId: number,
     dto: GetSwapPaymentInfoDto,

--- a/src/subdomains/core/referral/reward/services/ref-reward.service.ts
+++ b/src/subdomains/core/referral/reward/services/ref-reward.service.ts
@@ -201,6 +201,14 @@ export class RefRewardService {
     });
   }
 
+  async getRefRewardsByUserDataId(userDataId: number): Promise<RefReward[]> {
+    return this.rewardRepo.find({
+      where: { user: { userData: { id: userDataId } } },
+      relations: { user: true },
+      order: { id: 'DESC' },
+    });
+  }
+
   async getRefRewardVolume(from: Date): Promise<number> {
     const { volume } = await this.rewardRepo
       .createQueryBuilder('refReward')

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -201,6 +201,8 @@ export class BuySupportInfo {
   bankUsage: string;
   assetName: string;
   blockchain: string;
+  targetAddress?: string;
+  targetAddressExplorerUrl?: string;
   volume: number;
   active: boolean;
   created: Date;
@@ -212,6 +214,64 @@ export class SellSupportInfo {
   fiatName?: string;
   volume: number;
   active: boolean;
+  created: Date;
+}
+
+export class SwapSupportInfo {
+  id: number;
+  assetName?: string;
+  blockchain?: string;
+  depositAddress?: string;
+  depositAddressExplorerUrl?: string;
+  volume: number;
+  annualVolume: number;
+  active: boolean;
+  created: Date;
+}
+
+export class VirtualIbanSupportInfo {
+  id: number;
+  iban: string;
+  bban?: string;
+  currency?: string;
+  bank?: string;
+  status?: string;
+  active: boolean;
+  label?: string;
+  buyId?: number;
+  reservedUntil?: Date;
+  activatedAt?: Date;
+  deactivatedAt?: Date;
+  created: Date;
+}
+
+export class NotificationSupportInfo {
+  id: number;
+  type: string;
+  context: string;
+  correlationId?: string;
+  isComplete: boolean;
+  error?: string;
+  suppressRecurring: boolean;
+  lastTryDate: Date;
+  created: Date;
+}
+
+export class RefRewardSupportInfo {
+  id: number;
+  status?: string;
+  outputAmount?: number;
+  outputAsset?: string;
+  outputBlockchain?: string;
+  amountInChf?: number;
+  amountInEur?: number;
+  targetAddress?: string;
+  targetAddressExplorerUrl?: string;
+  txId?: string;
+  txExplorerUrl?: string;
+  outputDate?: Date;
+  recipientMail?: string;
+  mailSendDate?: Date;
   created: Date;
 }
 
@@ -358,6 +418,10 @@ export class UserDataSupportInfoDetails {
   bankDatas: BankDataSupportInfo[];
   buyRoutes: BuySupportInfo[];
   sellRoutes: SellSupportInfo[];
+  swapRoutes: SwapSupportInfo[];
+  virtualIbans: VirtualIbanSupportInfo[];
+  refRewards: RefRewardSupportInfo[];
+  notifications: NotificationSupportInfo[];
 }
 
 export class UserDataSupportQuery {

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -404,16 +404,26 @@ export class IpLogSupportInfo {
   created: Date;
 }
 
+export class SupportPermissions {
+  viewKycFiles: boolean;
+  viewKycLogs: boolean;
+  viewIpLogs: boolean;
+  viewSupportIssues: boolean;
+  canRequestLimit: boolean;
+  canPerformTransactionActions: boolean;
+  viewRecommendation: boolean;
+}
+
 export class UserDataSupportInfoDetails {
   userData: UserData;
-  kycFiles: KycFile[];
+  kycFiles?: KycFile[];
   kycSteps: KycStepSupportInfo[];
-  kycLogs: KycLogSupportInfo[];
+  kycLogs?: KycLogSupportInfo[];
   transactions: TransactionSupportInfo[];
   bankTxs: BankTxSupportInfo[];
   cryptoInputs: CryptoInputSupportInfo[];
-  ipLogs: IpLogSupportInfo[];
-  supportIssues: SupportIssueSupportInfo[];
+  ipLogs?: IpLogSupportInfo[];
+  supportIssues?: SupportIssueSupportInfo[];
   users: UserSupportInfo[];
   bankDatas: BankDataSupportInfo[];
   buyRoutes: BuySupportInfo[];
@@ -422,6 +432,7 @@ export class UserDataSupportInfoDetails {
   virtualIbans: VirtualIbanSupportInfo[];
   refRewards: RefRewardSupportInfo[];
   notifications: NotificationSupportInfo[];
+  permissions: SupportPermissions;
 }
 
 export class UserDataSupportQuery {

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -168,9 +168,9 @@ export class SupportController {
   @Get(':id')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
-  async getUserData(@Param('id') id: string): Promise<UserDataSupportInfoDetails> {
-    return this.supportService.getUserDataDetails(+id);
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.SUPPORT), UserActiveGuard())
+  async getUserData(@Param('id') id: string, @GetJwt() jwt: JwtPayload): Promise<UserDataSupportInfoDetails> {
+    return this.supportService.getUserDataDetails(+id, jwt.role);
   }
 
   @Get('transaction/:id/refund')

--- a/src/subdomains/generic/support/support.module.ts
+++ b/src/subdomains/generic/support/support.module.ts
@@ -1,9 +1,11 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { SharedModule } from 'src/shared/shared.module';
 import { BuyCryptoModule } from 'src/subdomains/core/buy-crypto/buy-crypto.module';
+import { ReferralModule } from 'src/subdomains/core/referral/referral.module';
 import { SellCryptoModule } from 'src/subdomains/core/sell-crypto/sell-crypto.module';
 import { BankModule } from 'src/subdomains/supporting/bank/bank.module';
 import { BankTxModule } from 'src/subdomains/supporting/bank-tx/bank-tx.module';
+import { NotificationModule } from 'src/subdomains/supporting/notification/notification.module';
 import { PayInModule } from 'src/subdomains/supporting/payin/payin.module';
 import { PaymentModule } from 'src/subdomains/supporting/payment/payment.module';
 import { TransactionModule } from 'src/subdomains/supporting/payment/transaction.module';
@@ -21,6 +23,7 @@ import { SupportService } from './support.service';
     UserModule,
     BuyCryptoModule,
     SellCryptoModule,
+    ReferralModule,
     PayInModule,
     BankModule,
     BankTxModule,
@@ -28,6 +31,7 @@ import { SupportService } from './support.service';
     TransactionModule,
     SupportIssueModule,
     RecallModule,
+    NotificationModule,
     forwardRef(() => PaymentModule),
   ],
   controllers: [SupportController],

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -18,6 +18,11 @@ import { CardBankName } from 'src/subdomains/supporting/bank/bank/dto/bank.dto';
 import { BuyFiatService } from 'src/subdomains/core/sell-crypto/process/services/buy-fiat.service';
 import { Sell } from 'src/subdomains/core/sell-crypto/route/sell.entity';
 import { SellService } from 'src/subdomains/core/sell-crypto/route/sell.service';
+import { Swap } from 'src/subdomains/core/buy-crypto/routes/swap/swap.entity';
+import { RefReward } from 'src/subdomains/core/referral/reward/ref-reward.entity';
+import { RefRewardService } from 'src/subdomains/core/referral/reward/services/ref-reward.service';
+import { Notification } from 'src/subdomains/supporting/notification/entities/notification.entity';
+import { NotificationService } from 'src/subdomains/supporting/notification/services/notification.service';
 import { BankTxReturnService } from 'src/subdomains/supporting/bank-tx/bank-tx-return/bank-tx-return.service';
 import { Recall } from 'src/subdomains/supporting/recall/recall.entity';
 import { RecallService } from 'src/subdomains/supporting/recall/recall.service';
@@ -29,12 +34,13 @@ import {
 } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/bank-tx.entity';
 import { BankTxService } from 'src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service';
 import { BankService } from 'src/subdomains/supporting/bank/bank/bank.service';
+import { VirtualIban } from 'src/subdomains/supporting/bank/virtual-iban/virtual-iban.entity';
 import { VirtualIbanService } from 'src/subdomains/supporting/bank/virtual-iban/virtual-iban.service';
 import { PayInService } from 'src/subdomains/supporting/payin/services/payin.service';
 import { Transaction } from 'src/subdomains/supporting/payment/entities/transaction.entity';
 import { IpLog } from 'src/shared/models/ip-log/ip-log.entity';
 import { IpLogService } from 'src/shared/models/ip-log/ip-log.service';
-import { txExplorerUrl } from 'src/integration/blockchain/shared/util/blockchain.util';
+import { addressExplorerUrl, txExplorerUrl } from 'src/integration/blockchain/shared/util/blockchain.util';
 import { CryptoInput } from 'src/subdomains/supporting/payin/entities/crypto-input.entity';
 import { SupportIssue } from 'src/subdomains/supporting/support-issue/entities/support-issue.entity';
 import { SupportIssueService } from 'src/subdomains/supporting/support-issue/services/support-issue.service';
@@ -82,6 +88,10 @@ import {
   RecommendationGraphNode,
   RecommendationUserInfo,
   SellSupportInfo,
+  SwapSupportInfo,
+  VirtualIbanSupportInfo,
+  RefRewardSupportInfo,
+  NotificationSupportInfo,
   TransactionListEntry,
   TransactionSupportInfo,
   CallQueue,
@@ -125,6 +135,8 @@ export class SupportService {
     private readonly buyService: BuyService,
     private readonly sellService: SellService,
     private readonly swapService: SwapService,
+    private readonly refRewardService: RefRewardService,
+    private readonly notificationService: NotificationService,
     private readonly buyCryptoService: BuyCryptoService,
     private readonly buyFiatService: BuyFiatService,
     private readonly bankTxService: BankTxService,
@@ -204,19 +216,37 @@ export class SupportService {
     if (!userData) throw new NotFoundException(`User not found`);
 
     // Load all related data in parallel
-    const [kycFiles, kycSteps, kycLogs, transactions, users, bankDatas, buyRoutes, sellRoutes, ipLogs, supportIssues] =
-      await Promise.all([
-        this.kycFileService.getUserDataKycFiles(id),
-        this.kycService.getStepsByUserData(id),
-        this.kycLogService.getLogsByUserDataId(id),
-        this.transactionService.getTransactionsByUserDataId(id),
-        this.userService.getAllUserDataUsers(id, { wallet: true }),
-        this.bankDataService.getBankDatasByUserData(id),
-        this.buyService.getUserDataBuys(id),
-        this.sellService.getSellsByUserDataId(id),
-        this.ipLogService.getByUserDataId(id),
-        this.supportIssueService.getIssueEntities(id),
-      ]);
+    const [
+      kycFiles,
+      kycSteps,
+      kycLogs,
+      transactions,
+      users,
+      bankDatas,
+      buyRoutes,
+      sellRoutes,
+      swapRoutes,
+      virtualIbans,
+      refRewards,
+      notifications,
+      ipLogs,
+      supportIssues,
+    ] = await Promise.all([
+      this.kycFileService.getUserDataKycFiles(id),
+      this.kycService.getStepsByUserData(id),
+      this.kycLogService.getLogsByUserDataId(id),
+      this.transactionService.getTransactionsByUserDataId(id),
+      this.userService.getAllUserDataUsers(id, { wallet: true }),
+      this.bankDataService.getBankDatasByUserData(id),
+      this.buyService.getUserDataBuys(id),
+      this.sellService.getSellsByUserDataId(id),
+      this.swapService.getSwapsByUserDataId(id),
+      this.virtualIbanService.getVirtualIbansForAccount(id),
+      this.refRewardService.getRefRewardsByUserDataId(id),
+      this.notificationService.getMails(id),
+      this.ipLogService.getByUserDataId(id),
+      this.supportIssueService.getIssueEntities(id),
+    ]);
 
     // Load bank transactions for the loaded transactions (incoming + outgoing)
     const transactionIds = transactions.map((t) => t.id);
@@ -275,6 +305,10 @@ export class SupportService {
       bankDatas: bankDatas.map((b) => this.toBankDataSupportInfo(b)),
       buyRoutes: buyRoutes.map((b) => this.toBuySupportInfo(b)),
       sellRoutes: sellRoutes.map((s) => this.toSellSupportInfo(s)),
+      swapRoutes: swapRoutes.map((s) => this.toSwapSupportInfo(s)),
+      virtualIbans: virtualIbans.map((v) => this.toVirtualIbanSupportInfo(v)),
+      refRewards: refRewards.map((r) => this.toRefRewardSupportInfo(r)),
+      notifications: notifications.map((n) => this.toNotificationSupportInfo(n)),
     };
   }
 
@@ -485,12 +519,16 @@ export class SupportService {
   }
 
   private toBuySupportInfo(buy: Buy): BuySupportInfo {
+    const address = buy.user?.address;
     return {
       id: buy.id,
       iban: buy.iban,
       bankUsage: buy.bankUsage,
       assetName: buy.asset?.name,
       blockchain: buy.asset?.blockchain,
+      targetAddress: address,
+      targetAddressExplorerUrl:
+        buy.asset?.blockchain && address ? addressExplorerUrl(buy.asset.blockchain, address) : undefined,
       volume: buy.volume,
       active: buy.active,
       created: buy.created,
@@ -505,6 +543,80 @@ export class SupportService {
       volume: sell.annualVolume,
       active: sell.active,
       created: sell.created,
+    };
+  }
+
+  private toSwapSupportInfo(swap: Swap): SwapSupportInfo {
+    const depositBlockchain = swap.deposit?.blockchainList?.[0];
+    return {
+      id: swap.id,
+      assetName: swap.asset?.name,
+      blockchain: swap.asset?.blockchain,
+      depositAddress: swap.deposit?.address,
+      depositAddressExplorerUrl:
+        depositBlockchain && swap.deposit?.address
+          ? addressExplorerUrl(depositBlockchain, swap.deposit.address)
+          : undefined,
+      volume: swap.volume,
+      annualVolume: swap.annualVolume,
+      active: swap.active,
+      created: swap.created,
+    };
+  }
+
+  private toNotificationSupportInfo(n: Notification): NotificationSupportInfo {
+    return {
+      id: n.id,
+      type: n.type,
+      context: n.context,
+      correlationId: n.correlationId,
+      isComplete: n.isComplete,
+      error: n.error,
+      suppressRecurring: n.suppressRecurring,
+      lastTryDate: n.lastTryDate,
+      created: n.created,
+    };
+  }
+
+  private toRefRewardSupportInfo(reward: RefReward): RefRewardSupportInfo {
+    return {
+      id: reward.id,
+      status: reward.status,
+      outputAmount: reward.outputAmount,
+      outputAsset: reward.outputAsset?.name,
+      outputBlockchain: reward.targetBlockchain,
+      amountInChf: reward.amountInChf,
+      amountInEur: reward.amountInEur,
+      targetAddress: reward.targetAddress,
+      targetAddressExplorerUrl:
+        reward.targetBlockchain && reward.targetAddress
+          ? addressExplorerUrl(reward.targetBlockchain, reward.targetAddress)
+          : undefined,
+      txId: reward.txId,
+      txExplorerUrl:
+        reward.targetBlockchain && reward.txId ? txExplorerUrl(reward.targetBlockchain, reward.txId) : undefined,
+      outputDate: reward.outputDate,
+      recipientMail: reward.recipientMail,
+      mailSendDate: reward.mailSendDate,
+      created: reward.created,
+    };
+  }
+
+  private toVirtualIbanSupportInfo(viban: VirtualIban): VirtualIbanSupportInfo {
+    return {
+      id: viban.id,
+      iban: viban.iban,
+      bban: viban.bban,
+      currency: viban.currency?.name,
+      bank: viban.bank?.name,
+      status: viban.status,
+      active: viban.active,
+      label: viban.label,
+      buyId: viban.buy?.id,
+      reservedUntil: viban.reservedUntil,
+      activatedAt: viban.activatedAt,
+      deactivatedAt: viban.deactivatedAt,
+      created: viban.created,
     };
   }
 

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -3,6 +3,7 @@ import { isIP } from 'class-validator';
 import * as IbanTools from 'ibantools';
 import { Config } from 'src/config/config';
 import { SettingService } from 'src/shared/models/setting/setting.service';
+import { UserRole } from 'src/shared/auth/user-role.enum';
 import { AmountType, Util } from 'src/shared/utils/util';
 import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
 import { AmlReason, NotRefundableAmlReasons } from 'src/subdomains/core/aml/enums/aml-reason.enum';
@@ -125,6 +126,13 @@ const CallQueueTxReasonMap: Partial<Record<CallQueue, AmlReason>> = {
   [CallQueue.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE]: AmlReason.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE,
 };
 
+// Fields of UserDataSupportInfoDetails that are returned as empty arrays for the given role.
+// Mirrored on the frontend by PANELS_HIDDEN_BY_ROLE in compliance-user.screen.tsx.
+const FIELDS_HIDDEN_BY_ROLE: Partial<Record<UserRole, (keyof UserDataSupportInfoDetails)[]>> = {
+  [UserRole.SUPPORT]: ['kycFiles', 'ipLogs'],
+  [UserRole.MARKETING]: ['kycFiles', 'ipLogs'],
+};
+
 @Injectable()
 export class SupportService {
   private readonly refundList = new Map<number, RefundDataDto>();
@@ -211,11 +219,13 @@ export class SupportService {
     return { pdfData, fileName };
   }
 
-  async getUserDataDetails(id: number): Promise<UserDataSupportInfoDetails> {
+  async getUserDataDetails(id: number, role: UserRole): Promise<UserDataSupportInfoDetails> {
     const userData = await this.userDataService.getUserData(id, { wallet: true, bankDatas: true });
     if (!userData) throw new NotFoundException(`User not found`);
 
-    // Load all related data in parallel
+    const hidden = FIELDS_HIDDEN_BY_ROLE[role] ?? [];
+
+    // Load all related data in parallel — skip queries for fields hidden for this role
     const [
       kycFiles,
       kycSteps,
@@ -232,7 +242,7 @@ export class SupportService {
       ipLogs,
       supportIssues,
     ] = await Promise.all([
-      this.kycFileService.getUserDataKycFiles(id),
+      hidden.includes('kycFiles') ? Promise.resolve([]) : this.kycFileService.getUserDataKycFiles(id),
       this.kycService.getStepsByUserData(id),
       this.kycLogService.getLogsByUserDataId(id),
       this.transactionService.getTransactionsByUserDataId(id),
@@ -244,7 +254,7 @@ export class SupportService {
       this.virtualIbanService.getVirtualIbansForAccount(id),
       this.refRewardService.getRefRewardsByUserDataId(id),
       this.notificationService.getMails(id),
-      this.ipLogService.getByUserDataId(id),
+      hidden.includes('ipLogs') ? Promise.resolve([]) : this.ipLogService.getByUserDataId(id),
       this.supportIssueService.getIssueEntities(id),
     ]);
 

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -47,6 +47,7 @@ import { SupportIssue } from 'src/subdomains/supporting/support-issue/entities/s
 import { SupportIssueService } from 'src/subdomains/supporting/support-issue/services/support-issue.service';
 import { TransactionHelper } from 'src/subdomains/supporting/payment/services/transaction-helper';
 import { TransactionService } from 'src/subdomains/supporting/payment/services/transaction.service';
+import { KycFile } from '../kyc/entities/kyc-file.entity';
 import { KycLog } from '../kyc/entities/kyc-log.entity';
 import { KycStep } from '../kyc/entities/kyc-step.entity';
 import { KycStepName } from '../kyc/enums/kyc-step-name.enum';
@@ -93,6 +94,7 @@ import {
   VirtualIbanSupportInfo,
   RefRewardSupportInfo,
   NotificationSupportInfo,
+  SupportPermissions,
   TransactionListEntry,
   TransactionSupportInfo,
   CallQueue,
@@ -126,12 +128,9 @@ const CallQueueTxReasonMap: Partial<Record<CallQueue, AmlReason>> = {
   [CallQueue.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE]: AmlReason.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE,
 };
 
-// Fields of UserDataSupportInfoDetails that are returned as empty arrays for the given role.
-// Mirrored on the frontend by PANELS_HIDDEN_BY_ROLE in compliance-user.screen.tsx.
-const FIELDS_HIDDEN_BY_ROLE: Partial<Record<UserRole, (keyof UserDataSupportInfoDetails)[]>> = {
-  [UserRole.SUPPORT]: ['kycFiles', 'ipLogs'],
-  [UserRole.MARKETING]: ['kycFiles', 'ipLogs'],
-};
+// Roles with restricted access to compliance user details.
+// Drives the permissions block returned to the frontend (which gates panels, actions and tabs).
+const RESTRICTED_ROLES: UserRole[] = [UserRole.SUPPORT, UserRole.MARKETING];
 
 @Injectable()
 export class SupportService {
@@ -223,9 +222,18 @@ export class SupportService {
     const userData = await this.userDataService.getUserData(id, { wallet: true, bankDatas: true });
     if (!userData) throw new NotFoundException(`User not found`);
 
-    const hidden = FIELDS_HIDDEN_BY_ROLE[role] ?? [];
+    const isRestricted = RESTRICTED_ROLES.includes(role);
+    const permissions: SupportPermissions = {
+      viewKycFiles: !isRestricted,
+      viewKycLogs: !isRestricted,
+      viewIpLogs: !isRestricted,
+      viewSupportIssues: !isRestricted,
+      canRequestLimit: !isRestricted,
+      canPerformTransactionActions: !isRestricted,
+      viewRecommendation: !isRestricted,
+    };
 
-    // Load all related data in parallel — skip queries for fields hidden for this role
+    // Load all related data in parallel — skip queries for fields the role is not allowed to see
     const [
       kycFiles,
       kycSteps,
@@ -242,9 +250,13 @@ export class SupportService {
       ipLogs,
       supportIssues,
     ] = await Promise.all([
-      hidden.includes('kycFiles') ? Promise.resolve([]) : this.kycFileService.getUserDataKycFiles(id),
+      permissions.viewKycFiles
+        ? this.kycFileService.getUserDataKycFiles(id)
+        : Promise.resolve<KycFile[] | undefined>(undefined),
       this.kycService.getStepsByUserData(id),
-      this.kycLogService.getLogsByUserDataId(id),
+      permissions.viewKycLogs
+        ? this.kycLogService.getLogsByUserDataId(id)
+        : Promise.resolve<KycLog[] | undefined>(undefined),
       this.transactionService.getTransactionsByUserDataId(id),
       this.userService.getAllUserDataUsers(id, { wallet: true }),
       this.bankDataService.getBankDatasByUserData(id),
@@ -254,8 +266,10 @@ export class SupportService {
       this.virtualIbanService.getVirtualIbansForAccount(id),
       this.refRewardService.getRefRewardsByUserDataId(id),
       this.notificationService.getMails(id),
-      hidden.includes('ipLogs') ? Promise.resolve([]) : this.ipLogService.getByUserDataId(id),
-      this.supportIssueService.getIssueEntities(id),
+      permissions.viewIpLogs ? this.ipLogService.getByUserDataId(id) : Promise.resolve<IpLog[] | undefined>(undefined),
+      permissions.viewSupportIssues
+        ? this.supportIssueService.getIssueEntities(id)
+        : Promise.resolve<SupportIssue[] | undefined>(undefined),
     ]);
 
     // Load bank transactions for the loaded transactions (incoming + outgoing)
@@ -305,12 +319,12 @@ export class SupportService {
           s.name === KycStepName.RECOMMENDATION ? allByRecommender : undefined,
         ),
       ),
-      kycLogs: kycLogs.map((l) => this.toKycLogSupportInfo(l)),
+      kycLogs: kycLogs?.map((l) => this.toKycLogSupportInfo(l)),
       transactions: transactions.map((t) => this.toTransactionSupportInfo(t)),
       bankTxs: bankTxs.map((b) => this.toBankTxDto(b, recallByBankTxId.get(b.id))),
       cryptoInputs: cryptoInputs.map((c) => this.toCryptoInputSupportInfo(c)),
-      ipLogs: ipLogs.map((l) => this.toIpLogSupportInfo(l)),
-      supportIssues: supportIssues.map((s) => this.toSupportIssueSupportInfo(s)),
+      ipLogs: ipLogs?.map((l) => this.toIpLogSupportInfo(l)),
+      supportIssues: supportIssues?.map((s) => this.toSupportIssueSupportInfo(s)),
       users: await this.toUserSupportInfos(users),
       bankDatas: bankDatas.map((b) => this.toBankDataSupportInfo(b)),
       buyRoutes: buyRoutes.map((b) => this.toBuySupportInfo(b)),
@@ -319,6 +333,7 @@ export class SupportService {
       virtualIbans: virtualIbans.map((v) => this.toVirtualIbanSupportInfo(v)),
       refRewards: refRewards.map((r) => this.toRefRewardSupportInfo(r)),
       notifications: notifications.map((n) => this.toNotificationSupportInfo(n)),
+      permissions,
     };
   }
 


### PR DESCRIPTION
## Summary
- Extends `GET /support/:id` with **swap routes**, **virtual ibans**, **ref rewards** and **notifications** for the compliance user detail page
- Adds explorer URLs for buy/swap deposit addresses and ref-reward target/tx addresses (consumed by the services frontend)
- New service methods: `SwapService.getSwapsByUserDataId`, `RefRewardService.getRefRewardsByUserDataId`
- Wires `ReferralModule` and `NotificationModule` into `SupportModule`

## Test plan
- [ ] `GET /support/:id` returns the new arrays (`swapRoutes`, `virtualIbans`, `refRewards`, `notifications`)
- [ ] Explorer URLs are populated for EVM/BSC/BTC routes and missing for unsupported blockchains
- [ ] No regressions for existing fields (`buyRoutes`, `sellRoutes`, `bankDatas`, ...)
- [ ] Frontend `feature/compliance-user-detail-tabs` in `services` repo renders all new tabs