### PR TITLE
fix(realunit): align sell endpoint Swagger doc with Level 30 enforcement

### DIFF
--- a/src/subdomains/supporting/realunit/controllers/realunit.controller.ts
+++ b/src/subdomains/supporting/realunit/controllers/realunit.controller.ts
@@ -402,10 +402,10 @@ export class RealUnitController {
   @ApiOperation({
     summary: 'Get payment info for RealUnit sell',
     description:
-      'Returns EIP-7702 delegation data for gasless REALU transfer and fallback deposit info. Requires KYC Level 20 and RealUnit registration.',
+      'Returns EIP-7702 delegation data for gasless REALU transfer and fallback deposit info. Requires KYC Level 30 and RealUnit registration.',
   })
   @ApiOkResponse({ type: RealUnitSellPaymentInfoDto })
-  @ApiBadRequestResponse({ description: 'KYC Level 20 required or registration missing' })
+  @ApiBadRequestResponse({ description: 'KYC Level 30 required or registration missing' })
   async getSellPaymentInfo(
     @GetJwt() jwt: JwtPayload,
     @Body() dto: RealUnitSellDto,


### PR DESCRIPTION
## Summary

- Controller Swagger doc advertised KYC Level 20 but service enforces Level 30 → users on Level 20–29 got 403/400 despite the docs.
- Updates `@ApiOperation.description` and `@ApiBadRequestResponse.description` on `PUT /v1/realunit/sell` to reflect the actual Level 30 requirement.
- Pure documentation alignment — no behavior change, no DTO change, no migration.

Closes #3649

## Test plan

- [x] `npm run format:check` green
- [x] `npm run type-check` green
- [x] `npm run lint` green
- [ ] Swagger UI for `PUT /v1/realunit/sell` shows "Requires KYC Level 30" in operation description and 400-response description
- [ ] Behavior unchanged: Level 30 user can quote a sell, Level 29 user gets `KycLevelRequiredException` with message `KYC Level 30 required for RealUnit sell`