### PR TITLE
fix: treat Scrypt WS Connection closed as transient

### DIFF
--- a/src/integration/exchange/services/scrypt-websocket-connection.ts
+++ b/src/integration/exchange/services/scrypt-websocket-connection.ts
@@ -89,14 +89,18 @@ export class ScryptWebSocketConnection {
   }
 
   async fetch<T>(streamName: ScryptMessageType, filters?: Record<string, unknown>): Promise<T[]> {
-    const response = await this.request({
-      type: ScryptRequestType.SUBSCRIBE,
-      streams: [{ name: streamName, ...filters }],
-    });
+    const doFetch = async (): Promise<T[]> => {
+      const response = await this.request({
+        type: ScryptRequestType.SUBSCRIBE,
+        streams: [{ name: streamName, ...filters }],
+      });
 
-    if (!response.initial) throw new Error(`Expected initial ${streamName} message`);
+      if (!response.initial) throw new Error(`Expected initial ${streamName} message`);
 
-    return (response.data ?? []) as T[];
+      return (response.data ?? []) as T[];
+    };
+
+    return this.retryOnTransientWsError(doFetch, `fetch ${streamName}`);
   }
 
   async fetchAll<T>(streamName: ScryptMessageType, filters?: Record<string, unknown>): Promise<T[]> {
@@ -127,13 +131,16 @@ export class ScryptWebSocketConnection {
       return allData;
     };
 
-    // Retry once on connection/session errors
+    return this.retryOnTransientWsError(doFetch, `fetchAll ${streamName}`);
+  }
+
+  private async retryOnTransientWsError<T>(operation: () => Promise<T>, label: string): Promise<T> {
     try {
-      return await doFetch();
+      return await operation();
     } catch (error) {
       if (error.message?.includes('unknown reqid') || error.message?.includes('Connection closed')) {
-        this.logger.warn(`Retrying fetchAll for ${streamName} after error: ${error.message}`);
-        return doFetch();
+        this.logger.warn(`Retrying ${label} after transient error: ${error.message}`);
+        return operation();
       }
       throw error;
     }

--- a/src/integration/exchange/services/scrypt-websocket-connection.ts
+++ b/src/integration/exchange/services/scrypt-websocket-connection.ts
@@ -43,6 +43,12 @@ enum ScryptRequestType {
   PAGE = 'page',
 }
 
+export const TRANSIENT_WS_ERROR_MARKERS = ['Connection closed', 'unknown reqid'];
+
+export function isTransientWsError(e: Error): boolean {
+  return TRANSIENT_WS_ERROR_MARKERS.some((m) => e.message?.toLowerCase().includes(m.toLowerCase()));
+}
+
 interface ScryptRequest {
   reqid?: number;
   type: ScryptRequestType | ScryptMessageType;
@@ -138,7 +144,7 @@ export class ScryptWebSocketConnection {
     try {
       return await operation();
     } catch (error) {
-      if (error.message?.includes('unknown reqid') || error.message?.includes('Connection closed')) {
+      if (isTransientWsError(error)) {
         this.logger.warn(`Retrying ${label} after transient error: ${error.message}`);
         return operation();
       }

--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { ScryptOrderInfo, ScryptOrderSide, ScryptTransactionStatus } from 'src/integration/exchange/dto/scrypt.dto';
 import { TradeChangedException } from 'src/integration/exchange/exceptions/trade-changed.exception';
+import { isTransientWsError } from 'src/integration/exchange/services/scrypt-websocket-connection';
 import { ScryptService } from 'src/integration/exchange/services/scrypt.service';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { AssetService } from 'src/shared/models/asset/asset.service';
@@ -288,17 +289,13 @@ export class ScryptAdapter extends LiquidityActionAdapter {
         return false;
       }
 
-      if (this.isTransientWsError(e)) {
+      if (isTransientWsError(e)) {
         this.logger.warn(`Transient WS error checking order ${order.id}, will retry next tick: ${e.message}`);
         return false;
       }
 
       throw new OrderFailedException(e.message);
     }
-  }
-
-  private isTransientWsError(e: Error): boolean {
-    return ['Connection closed', 'unknown reqid'].some((m) => e.message?.includes(m));
   }
 
   private async aggregateTradeOutput(order: LiquidityManagementOrder): Promise<number> {

--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -288,8 +288,17 @@ export class ScryptAdapter extends LiquidityActionAdapter {
         return false;
       }
 
+      if (this.isTransientWsError(e)) {
+        this.logger.warn(`Transient WS error checking order ${order.id}, will retry next tick: ${e.message}`);
+        return false;
+      }
+
       throw new OrderFailedException(e.message);
     }
+  }
+
+  private isTransientWsError(e: Error): boolean {
+    return ['Connection closed', 'unknown reqid'].some((m) => e.message?.includes(m));
   }
 
   private async aggregateTradeOutput(order: LiquidityManagementOrder): Promise<number> {


### PR DESCRIPTION
## Summary

Fixes liquidity-management pipelines being permanently FAILED on transient Scrypt WebSocket disconnects.

When the Scrypt WS drops, all pending requests are rejected with `new Error('Connection closed')`. This was surfaced as `OrderFailedException` in `ScryptAdapter.checkTradeCompletion`, marking the order Failed → action 233 has no `onFail` → pipeline FAILED → rule auto-paused → mail. Meanwhile the underlying order on Scrypt is unaffected and the funds are not moved.

## Changes

- **`scrypt-websocket-connection.ts`**: Extract the retry logic added in #3594 into a private helper `retryOnTransientWsError` and apply it to `fetch` (was previously only on `fetchAll`). `fetch` is used by `fetchExecutionReports` and `fetchOrderBook`, both on the hot path of `checkTrade`.
- **`scrypt.adapter.ts`**: In `checkTradeCompletion`, classify `Connection closed` / `unknown reqid` as transient → return `false` so the order stays `IN_PROGRESS` and is retried on the next 10s cron tick. Genuine errors still throw `OrderFailedException`.

## Repro / data point

- **Pipeline 60738** (2026-04-30 07:21 UTC, rule 313 Scrypt/EUR redundancy)
- Order 122805 (sell 70'003.98 EUR → USDT): 5 ClOrdIds in 3 min (4 edits), final WS drop → `Connection closed` → wrongly marked Failed
- Balance audit on Scrypt: EUR was never spent (next pipeline 60741 sold the same EUR + 40k more)
- 20+ similar incidents since 2026-03-24, all matching this pattern

## Test plan

- [ ] CI green
- [ ] After deploy: monitor next Scrypt redundancy pipeline; if WS drops mid-check, verify order stays `IN_PROGRESS` and resumes (vs. flipping to `Failed`)
- [ ] Verify no double-execution: `getOrderStatus` cache + 30-day fallback in `scrypt.service.ts:301` already dedupes by ClOrdID, so retry-on-next-tick reuses the existing correlation
- [ ] Optional: tail logs for `Retrying fetch ... after transient error` and `Transient WS error checking order` to gauge frequency