### PR TITLE
fix: mail skip semantics + PersonalMail wallet alignment

### DIFF
--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -541,6 +541,16 @@ export class BuyCrypto extends IEntity {
     return [this.id, update];
   }
 
+  skipMail(): UpdateResult<BuyCrypto> {
+    const update: Partial<BuyCrypto> = {
+      mailSendDate: new Date(),
+    };
+
+    Object.assign(this, update);
+
+    return [this.id, update];
+  }
+
   resetSentMail(): UpdateResult<BuyCrypto> {
     const update: Partial<BuyCrypto> = {
       recipientMail: null,

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-notification.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-notification.service.ts
@@ -194,7 +194,7 @@ export class BuyCryptoNotificationService {
           entity.wallet?.name === REALUNIT_WALLET_NAME &&
           REALUNIT_DISABLED_PENDING_REASONS.includes(entity.amlReason)
         ) {
-          await this.buyCryptoRepo.update(...entity.confirmSentMail());
+          await this.buyCryptoRepo.update(...entity.skipMail());
           continue;
         }
 
@@ -284,7 +284,7 @@ export class BuyCryptoNotificationService {
       try {
         // RealUnit: chargeback mails are handled by phone, not by email
         if (entity.wallet?.name === REALUNIT_WALLET_NAME) {
-          await this.buyCryptoRepo.update(...entity.confirmSentMail());
+          await this.buyCryptoRepo.update(...entity.skipMail());
           continue;
         }
 
@@ -367,7 +367,7 @@ export class BuyCryptoNotificationService {
       try {
         // RealUnit: chargeback-unconfirmed mails are handled by phone, not by email
         if (entity.wallet?.name === REALUNIT_WALLET_NAME) {
-          await this.buyCryptoRepo.update(...entity.confirmSentMail());
+          await this.buyCryptoRepo.update(...entity.skipMail());
           continue;
         }
 

--- a/src/subdomains/core/sell-crypto/process/buy-fiat.entity.ts
+++ b/src/subdomains/core/sell-crypto/process/buy-fiat.entity.ts
@@ -274,6 +274,26 @@ export class BuyFiat extends IEntity {
     return [this.id, update];
   }
 
+  skipPendingMail(): UpdateResult<BuyFiat> {
+    const update: Partial<BuyFiat> = {
+      mail2SendDate: new Date(),
+    };
+
+    Object.assign(this, update);
+
+    return [this.id, update];
+  }
+
+  skipChargebackMail(): UpdateResult<BuyFiat> {
+    const update: Partial<BuyFiat> = {
+      mailReturnSendDate: new Date(),
+    };
+
+    Object.assign(this, update);
+
+    return [this.id, update];
+  }
+
   fiatToBankTransferInitiated(): UpdateResult<BuyFiat> {
     const update: Partial<BuyFiat> = {
       recipientMail: this.noCommunication ? null : this.userData.mail,

--- a/src/subdomains/core/sell-crypto/process/services/buy-fiat-notification.service.ts
+++ b/src/subdomains/core/sell-crypto/process/services/buy-fiat-notification.service.ts
@@ -144,7 +144,7 @@ export class BuyFiatNotificationService {
           entity.wallet?.name === REALUNIT_WALLET_NAME &&
           REALUNIT_DISABLED_PENDING_REASONS.includes(entity.amlReason)
         ) {
-          await this.buyFiatRepo.update(...entity.pendingMail());
+          await this.buyFiatRepo.update(...entity.skipPendingMail());
           continue;
         }
 
@@ -224,7 +224,7 @@ export class BuyFiatNotificationService {
       try {
         // RealUnit: chargeback mails are handled by phone, not by email
         if (entity.wallet?.name === REALUNIT_WALLET_NAME) {
-          await this.buyFiatRepo.update(...entity.chargebackMail());
+          await this.buyFiatRepo.update(...entity.skipChargebackMail());
           continue;
         }
 
@@ -309,7 +309,7 @@ export class BuyFiatNotificationService {
       try {
         // RealUnit: chargeback-unconfirmed mails are handled by phone, not by email
         if (entity.wallet?.name === REALUNIT_WALLET_NAME) {
-          await this.buyFiatRepo.update(...entity.chargebackMail());
+          await this.buyFiatRepo.update(...entity.skipChargebackMail());
           continue;
         }
 

--- a/src/subdomains/supporting/notification/factories/mail.factory.ts
+++ b/src/subdomains/supporting/notification/factories/mail.factory.ts
@@ -183,7 +183,9 @@ export class MailFactory {
 
     const walletName = wallet?.name;
     const walletMailConfig = walletName ? Config.mail.wallet[walletName] : undefined;
-    const lang = walletMailConfig?.forcedLang ? walletMailConfig.forcedLang.toLowerCase() : userData.language.symbol.toLowerCase();
+    const lang = walletMailConfig?.forcedLang
+      ? walletMailConfig.forcedLang.toLowerCase()
+      : userData.language.symbol.toLowerCase();
 
     const welcomeTexts = this.getCentralizedWelcomeTexts(userData, walletMailConfig);
     const walletBodyTexts = this.getWalletBodyTexts(title, lang, walletName);

--- a/src/subdomains/supporting/notification/factories/mail.factory.ts
+++ b/src/subdomains/supporting/notification/factories/mail.factory.ts
@@ -183,16 +183,17 @@ export class MailFactory {
 
     const walletName = wallet?.name;
     const walletMailConfig = walletName ? Config.mail.wallet[walletName] : undefined;
-    const lang = userData.language.symbol;
+    const lang = walletMailConfig?.forcedLang ? walletMailConfig.forcedLang.toLowerCase() : userData.language.symbol.toLowerCase();
 
     const welcomeTexts = this.getCentralizedWelcomeTexts(userData, walletMailConfig);
-    const merged = [...welcomeTexts, ...(prefix ?? [])];
+    const walletBodyTexts = this.getWalletBodyTexts(title, lang, walletName);
+    const merged = [...welcomeTexts, ...walletBodyTexts, ...(prefix ?? [])];
 
     return new PersonalMail({
       to: userData.mail,
       bcc,
-      subject: this.translate(title, lang),
-      prefix: this.getMailAffix(merged, lang),
+      subject: this.translate(title, lang, undefined, walletName),
+      prefix: this.getMailAffix(merged, lang, walletName),
       banner,
       from,
       displayName,

--- a/src/subdomains/supporting/support-issue/entities/limit-request.entity.ts
+++ b/src/subdomains/supporting/support-issue/entities/limit-request.entity.ts
@@ -76,6 +76,12 @@ export class LimitRequest extends IEntity {
     return [this.id, { recipientMail: this.recipientMail, mailSendDate: this.mailSendDate }];
   }
 
+  skipMail(): UpdateResult<LimitRequest> {
+    this.mailSendDate = new Date();
+
+    return [this.id, { mailSendDate: this.mailSendDate }];
+  }
+
   get userData(): UserData {
     return this.supportIssue.userData;
   }

--- a/src/subdomains/supporting/support-issue/services/limit-request-notification.service.ts
+++ b/src/subdomains/supporting/support-issue/services/limit-request-notification.service.ts
@@ -44,7 +44,7 @@ export class LimitRequestNotificationService {
       try {
         // RealUnit: limit-request approval is handled by phone, not by email
         if (entity.userData.wallet?.name === REALUNIT_WALLET_NAME) {
-          await this.limitRequestRepo.update(...entity.sendMail());
+          await this.limitRequestRepo.update(...entity.skipMail());
           continue;
         }
 


### PR DESCRIPTION
## Summary

Fixes from #3654 (RealUnit Mail PR #3598 follow-ups):

- **F2**: Skipped RealUnit mails no longer falsely set `recipientMail` — new `skipMail()` / `skipPendingMail()` / `skipChargebackMail()` entity methods only write the date field to prevent re-processing, without implying a mail was sent. Fixes data integrity issue in audit/monitoring.
- **F10**: `createPersonalMail` now respects `forcedLang` from wallet config and passes `walletName` through the translation chain, consistent with `createUserV2Mail`.
- **F6**: `createPersonalMail` now calls `getWalletBodyTexts()` so wallet-specific body overrides apply.

## Changed files

| File | Change |
|------|--------|
| `buy-crypto.entity.ts` | Add `skipMail()` |
| `buy-fiat.entity.ts` | Add `skipPendingMail()`, `skipChargebackMail()` |
| `limit-request.entity.ts` | Add `skipMail()` |
| `buy-crypto-notification.service.ts` | Use skip methods in 3 RealUnit guard paths |
| `buy-fiat-notification.service.ts` | Use skip methods in 3 RealUnit guard paths |
| `limit-request-notification.service.ts` | Use skip method in RealUnit guard path |
| `mail.factory.ts` | Align `createPersonalMail` with `createUserV2Mail` |

## Test plan

- [ ] Verify RealUnit pending/chargeback flows still advance state machine (mailSendDate set, record not re-picked)
- [ ] Verify `recipientMail` stays NULL for skipped RealUnit mails
- [ ] Verify non-RealUnit mail flows are unchanged (still call `confirmSentMail` etc.)
- [ ] If a PersonalMail is triggered for a wallet with `forcedLang`, verify correct language is used

Closes #3654 (F2, F6, F10)