### PR TITLE
refactor(support): extract user-data-detail mapper

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -5,8 +5,19 @@ import { BankTxType } from 'src/subdomains/supporting/bank-tx/bank-tx/entities/b
 import { RecallReason } from 'src/subdomains/supporting/recall/recall-reason.enum';
 import { KycFile } from '../../kyc/entities/kyc-file.entity';
 import { AccountType } from '../../user/models/user-data/account-type.enum';
-import { UserData } from '../../user/models/user-data/user-data.entity';
-import { KycStatus, PhoneCallStatus } from '../../user/models/user-data/user-data.enum';
+import { KycIdentificationType } from '../../user/models/user-data/kyc-identification-type.enum';
+import {
+  KycLevel,
+  KycStatus,
+  KycType,
+  LegalEntity,
+  Moderator,
+  PhoneCallStatus,
+  RiskStatus,
+  SignatoryPower,
+  UserDataStatus,
+} from '../../user/models/user-data/user-data.enum';
+import { AccountOpenerAuthorization } from '../../user/models/organization/organization.entity';
 
 export class UserDataSupportInfoResult {
   type: ComplianceSearchType;
@@ -414,8 +425,113 @@ export class SupportPermissions {
   viewRecommendation: boolean;
 }
 
+export class CountrySupportInfo {
+  name: string;
+  symbol?: string;
+}
+
+export class LanguageSupportInfo {
+  name: string;
+  symbol?: string;
+}
+
+export class WalletSupportInfo {
+  name: string;
+}
+
+export class OrganizationSupportInfo {
+  id: number;
+  name?: string;
+  street?: string;
+  houseNumber?: string;
+  zip?: string;
+  location?: string;
+  country?: CountrySupportInfo;
+  legalEntity?: LegalEntity;
+  signatoryPower?: SignatoryPower;
+  complexOrgStructure?: boolean;
+  allBeneficialOwnersName?: string;
+  allBeneficialOwnersDomicile?: string;
+  accountOpenerAuthorization?: AccountOpenerAuthorization;
+}
+
+export class UserDataDetailDto {
+  // UserData
+  id: number;
+  created: Date;
+  status: UserDataStatus;
+  riskStatus: RiskStatus;
+  kycStatus: KycStatus;
+  kycLevel: KycLevel;
+  depositLimit?: number;
+  wallet?: WalletSupportInfo;
+
+  // Personal Data
+  accountType?: AccountType;
+  mail?: string;
+  verifiedName?: string;
+  verifiedCountry?: CountrySupportInfo;
+  firstname?: string;
+  surname?: string;
+  street?: string;
+  houseNumber?: string;
+  zip?: string;
+  location?: string;
+  country?: CountrySupportInfo;
+  nationality?: CountrySupportInfo;
+  language?: LanguageSupportInfo;
+  birthday?: Date;
+  phone?: string;
+
+  // Organization Data
+  organization?: OrganizationSupportInfo;
+
+  // KYC / AML
+  kycType?: KycType;
+  kycHash: string;
+  kycFileId?: number;
+  identDocumentId?: string;
+  identDocumentType?: string;
+  identificationType?: KycIdentificationType;
+  highRisk?: boolean;
+  pep?: boolean;
+  bankTransactionVerification?: CheckStatus;
+  olkypayAllowed?: boolean;
+
+  // PaymentLink Data
+  paymentLinksAllowed: boolean;
+  paymentLinksConfig?: string;
+  paymentLinksName?: string;
+
+  // PhoneCall
+  phoneCallStatus?: PhoneCallStatus;
+  phoneCallAccepted?: boolean;
+  phoneCallCheckDate?: Date;
+  phoneCallExternalAccountCheckDate?: Date;
+  phoneCallExternalAccountCheckValues?: string;
+  phoneCallIpCheckDate?: Date;
+  phoneCallIpCountryCheckDate?: Date;
+  phoneCallTimes?: string;
+
+  // Volumes
+  buyVolume: number;
+  annualBuyVolume: number;
+  sellVolume: number;
+  annualSellVolume: number;
+  cryptoVolume: number;
+  annualCryptoVolume: number;
+
+  // Other
+  isTrustedReferrer: boolean;
+  tradeApprovalDate?: Date;
+  deactivationDate?: Date;
+  lastNameCheckDate?: Date;
+  letterSentDate?: Date;
+  moderator?: Moderator;
+}
+
 export class UserDataSupportInfoDetails {
-  userData: UserData;
+  userData: UserDataDetailDto;
   kycFiles?: KycFile[];
   kycSteps: KycStepSupportInfo[];
   kycLogs?: KycLogSupportInfo[];

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -111,6 +111,7 @@ import {
   UserDataSupportQuery,
   UserSupportInfo,
 } from './dto/user-data-support.dto';
+import { toUserDataDetailDto } from './user-data-detail.mapper';
 
 interface UserDataComplianceSearchTypePair {
   type: ComplianceSearchType;
@@ -227,7 +228,7 @@ export class SupportService {
       viewKycFiles: !isRestricted,
       viewKycLogs: !isRestricted,
       viewIpLogs: !isRestricted,
-      viewSupportIssues: !isRestricted,
+      viewSupportIssues: !isRestricted || role === UserRole.SUPPORT,
       canRequestLimit: !isRestricted,
       canPerformTransactionActions: !isRestricted,
       viewRecommendation: !isRestricted,
@@ -308,7 +309,7 @@ export class SupportService {
       : [];
 
     return {
-      userData,
+      userData: toUserDataDetailDto(userData),
       kycFiles,
       kycSteps: kycSteps.map((s) =>
         this.toKycStepSupportInfo(

--- a/src/subdomains/generic/support/user-data-detail.mapper.ts
+++ b/src/subdomains/generic/support/user-data-detail.mapper.ts
@@ -1,0 +1,112 @@
+import { Country } from 'src/shared/models/country/country.entity';
+import { Language } from 'src/shared/models/language/language.entity';
+import { Organization } from '../user/models/organization/organization.entity';
+import { UserData } from '../user/models/user-data/user-data.entity';
+import { Wallet } from '../user/models/wallet/wallet.entity';
+import {
+  CountrySupportInfo,
+  LanguageSupportInfo,
+  OrganizationSupportInfo,
+  UserDataDetailDto,
+  WalletSupportInfo,
+} from './dto/user-data-support.dto';
+
+export function toCountryDto(country: Country | undefined): CountrySupportInfo | undefined {
+  return country && { name: country.name, symbol: country.symbol };
+}
+
+export function toLanguageDto(language: Language | undefined): LanguageSupportInfo | undefined {
+  return language && { name: language.name, symbol: language.symbol };
+}
+
+export function toWalletDto(wallet: Wallet | undefined): WalletSupportInfo | undefined {
+  return wallet && { name: wallet.name };
+}
+
+export function toOrganizationDto(org: Organization | undefined): OrganizationSupportInfo | undefined {
+  if (!org) return undefined;
+  return {
+    id: org.id,
+    name: org.name,
+    street: org.street,
+    houseNumber: org.houseNumber,
+    zip: org.zip,
+    location: org.location,
+    country: toCountryDto(org.country),
+    legalEntity: org.legalEntity,
+    signatoryPower: org.signatoryPower,
+    complexOrgStructure: org.complexOrgStructure,
+    allBeneficialOwnersName: org.allBeneficialOwnersName,
+    allBeneficialOwnersDomicile: org.allBeneficialOwnersDomicile,
+    accountOpenerAuthorization: org.accountOpenerAuthorization,
+  };
+}
+
+export function toUserDataDetailDto(u: UserData): UserDataDetailDto {
+  return {
+    id: u.id,
+    created: u.created,
+    status: u.status,
+    riskStatus: u.riskStatus,
+    kycStatus: u.kycStatus,
+    kycLevel: u.kycLevel,
+    depositLimit: u.depositLimit,
+    wallet: toWalletDto(u.wallet),
+
+    accountType: u.accountType,
+    mail: u.mail,
+    verifiedName: u.verifiedName,
+    verifiedCountry: toCountryDto(u.verifiedCountry),
+    firstname: u.firstname,
+    surname: u.surname,
+    street: u.street,
+    houseNumber: u.houseNumber,
+    zip: u.zip,
+    location: u.location,
+    country: toCountryDto(u.country),
+    nationality: toCountryDto(u.nationality),
+    language: toLanguageDto(u.language),
+    birthday: u.birthday,
+    phone: u.phone,
+
+    organization: toOrganizationDto(u.organization),
+
+    kycType: u.kycType,
+    kycHash: u.kycHash,
+    kycFileId: u.kycFileId,
+    identDocumentId: u.identDocumentId,
+    identDocumentType: u.identDocumentType,
+    identificationType: u.identificationType,
+    highRisk: u.highRisk,
+    pep: u.pep,
+    bankTransactionVerification: u.bankTransactionVerification,
+    olkypayAllowed: u.olkypayAllowed,
+
+    paymentLinksAllowed: u.paymentLinksAllowed,
+    paymentLinksConfig: u.paymentLinksConfig,
+    paymentLinksName: u.paymentLinksName,
+
+    phoneCallStatus: u.phoneCallStatus,
+    phoneCallAccepted: u.phoneCallAccepted,
+    phoneCallCheckDate: u.phoneCallCheckDate,
+    phoneCallExternalAccountCheckDate: u.phoneCallExternalAccountCheckDate,
+    phoneCallExternalAccountCheckValues: u.phoneCallExternalAccountCheckValues,
+    phoneCallIpCheckDate: u.phoneCallIpCheckDate,
+    phoneCallIpCountryCheckDate: u.phoneCallIpCountryCheckDate,
+    phoneCallTimes: u.phoneCallTimes,
+
+    buyVolume: u.buyVolume,
+    annualBuyVolume: u.annualBuyVolume,
+    sellVolume: u.sellVolume,
+    annualSellVolume: u.annualSellVolume,
+    cryptoVolume: u.cryptoVolume,
+    annualCryptoVolume: u.annualCryptoVolume,
+
+    isTrustedReferrer: u.isTrustedReferrer,
+    tradeApprovalDate: u.tradeApprovalDate,
+    deactivationDate: u.deactivationDate,
+    lastNameCheckDate: u.lastNameCheckDate,
+    letterSentDate: u.letterSentDate,
+    moderator: u.moderator,
+  };
+}


### PR DESCRIPTION
## Summary

- Move the inline `UserData` -> `UserDataDetailDto` conversion out of `SupportService` into a dedicated `user-data-detail.mapper.ts` module.
- Split nested object construction into small per-relation helpers (`toCountryDto`, `toLanguageDto`, `toWalletDto`, `toOrganizationDto`) so that adding new fields no longer requires touching three layers of inline literals.
- Enable `viewSupportIssues` permission for the SUPPORT role.

## Test plan

- [ ] `GET /support/user/:id` returns the same `userData` payload shape as before
- [ ] Personal and Organization accounts both serialize correctly (country, nationality, language, wallet, organization)
- [ ] SUPPORT role sees support issues in the compliance user screen