### PR TITLE
Fix: per-token error handling in EVM balance queries

### DIFF
--- a/src/integration/blockchain/shared/evm/citrea-base-client.ts
+++ b/src/integration/blockchain/shared/evm/citrea-base-client.ts
@@ -78,14 +78,18 @@ export abstract class CitreaBaseClient extends EvmClient {
     const balances: BlockchainTokenBalance[] = [];
 
     for (const asset of assets) {
-      const balance = isPoolBalance
-        ? await this.getPoolTokenBalance(asset, owner)
-        : await this.getTokenBalance(asset, owner);
-      balances.push({
-        owner,
-        contractAddress: asset.chainId,
-        balance,
-      });
+      try {
+        const balance = isPoolBalance
+          ? await this.getPoolTokenBalance(asset, owner)
+          : await this.getTokenBalance(asset, owner);
+        balances.push({
+          owner,
+          contractAddress: asset.chainId,
+          balance,
+        });
+      } catch (e) {
+        this.logger.error(`Failed to process token balance for ${asset.uniqueName}:`, e);
+      }
     }
 
     return balances;

--- a/src/integration/blockchain/shared/evm/evm-client.ts
+++ b/src/integration/blockchain/shared/evm/evm-client.ts
@@ -150,10 +150,14 @@ export abstract class EvmClient extends BlockchainClient {
     const tokenBalances = await this.alchemyService.getTokenBalances(this.chainId, owner, assets);
 
     for (const tokenBalance of tokenBalances) {
-      const token = await this.getTokenByAddress(tokenBalance.contractAddress);
-      const balance = EvmUtil.fromWeiAmount(tokenBalance.tokenBalance ?? 0, token.decimals);
+      try {
+        const token = await this.getTokenByAddress(tokenBalance.contractAddress);
+        const balance = EvmUtil.fromWeiAmount(tokenBalance.tokenBalance ?? 0, token.decimals);
 
-      evmTokenBalances.push({ owner, contractAddress: tokenBalance.contractAddress, balance: balance });
+        evmTokenBalances.push({ owner, contractAddress: tokenBalance.contractAddress, balance: balance });
+      } catch (e) {
+        this.logger.error(`Failed to process token balance for ${tokenBalance.contractAddress}:`, e);
+      }
     }
 
     return evmTokenBalances;


### PR DESCRIPTION
## Summary
- A single failing token in `getTokenBalances()` (e.g. broken `decimals()` call) could abort the entire loop, preventing balance updates for **all** tokens on that chain
- Added per-token try/catch in `evm-client.ts` and `citrea-base-client.ts` so other tokens continue processing when one fails

## Context
Investigation of BBTC (Asset 394) plus balance showing 0.001 instead of 1.73 BBTC (on-chain). The `liquidity_balance` hasn't been updated since 2026-04-30 despite the cron running every minute. Production logs show no Ethereum-specific errors, pointing to either an Alchemy indexing lag or a silent token processing failure that goes unlogged due to missing error handling in the loop.

## Test plan
- [ ] Verify build passes
- [ ] Monitor BBTC balance updates after deploy
- [ ] Check logs for any newly surfaced per-token errors