### PR TITLE
Debug: trace BBTC balance through refresh pipeline

### DIFF
--- a/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
@@ -63,6 +63,13 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
       await this.updateCacheFor(blockchain, assets);
     }
 
+    const uncachedAssets = assets.filter((a) => !this.balanceCache.has(a.id));
+    if (uncachedAssets.length > 0) {
+      this.logger.verbose(
+        `${blockchain}: ${uncachedAssets.length} asset(s) missing from cache after update: ${uncachedAssets.map((a) => `${a.uniqueName}(${a.id})`).join(', ')}`,
+      );
+    }
+
     return assets
       .filter((a) => this.balanceCache.has(a.id))
       .map((a) => LiquidityBalance.create(a, this.balanceCache.get(a.id)));
@@ -201,6 +208,13 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
 
       const previousBalance = this.balanceCache.get(asset.id);
       if (previousBalance && !balance) this.logger.error(`Balance for ${asset.uniqueName} went to ${null}`);
+
+      // DEBUG: trace balance pipeline for Ethereum tokens
+      if (asset.blockchain === 'Ethereum' && balance !== previousBalance) {
+        this.logger.verbose(
+          `Balance change for ${asset.uniqueName} (${asset.id}): ${previousBalance} -> ${balance} (inMap: ${tokenToBalanceMap.has(asset.chainId?.toLowerCase())}, chainId: ${asset.chainId})`,
+        );
+      }
 
       if (balance != null) this.balanceCache.set(asset.id, balance);
     }

--- a/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
@@ -61,13 +61,13 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
 
     if (!hasCache) {
       await this.updateCacheFor(blockchain, assets);
-    }
 
-    const uncachedAssets = assets.filter((a) => !this.balanceCache.has(a.id));
-    if (uncachedAssets.length > 0) {
-      this.logger.verbose(
-        `${blockchain}: ${uncachedAssets.length} asset(s) missing from cache after update: ${uncachedAssets.map((a) => `${a.uniqueName}(${a.id})`).join(', ')}`,
-      );
+      const uncachedAssets = assets.filter((a) => !this.balanceCache.has(a.id));
+      if (uncachedAssets.length > 0) {
+        this.logger.verbose(
+          `${blockchain}: ${uncachedAssets.length} asset(s) missing from cache after update: ${uncachedAssets.map((a) => `${a.uniqueName}(${a.id})`).join(', ')}`,
+        );
+      }
     }
 
     return assets
@@ -209,10 +209,10 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
       const previousBalance = this.balanceCache.get(asset.id);
       if (previousBalance && !balance) this.logger.error(`Balance for ${asset.uniqueName} went to ${null}`);
 
-      // DEBUG: trace balance pipeline for Ethereum tokens
-      if (asset.blockchain === 'Ethereum' && balance !== previousBalance) {
+      // DEBUG: trace balance pipeline
+      if (balance !== previousBalance) {
         this.logger.verbose(
-          `Balance change for ${asset.uniqueName} (${asset.id}): ${previousBalance} -> ${balance} (inMap: ${tokenToBalanceMap.has(asset.chainId?.toLowerCase())}, chainId: ${asset.chainId})`,
+          `Balance change for ${asset.uniqueName} (${asset.id}): ${previousBalance} -> ${balance} (inMap: ${tokenToBalanceMap.has(asset.chainId?.toLowerCase())})`,
         );
       }
 

--- a/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
@@ -218,7 +218,9 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
 
       // DEBUG: always log BBTC balance for investigation
       if (asset.id === 394) {
-        this.logger.verbose(`BBTC balance trace: alchemy=${balance}, cache=${previousBalance}, inMap=${tokenToBalanceMap.has(asset.chainId?.toLowerCase())}`);
+        this.logger.verbose(
+          `BBTC balance trace: alchemy=${balance}, cache=${previousBalance}, inMap=${tokenToBalanceMap.has(asset.chainId?.toLowerCase())}`,
+        );
       }
 
       if (balance != null) this.balanceCache.set(asset.id, balance);

--- a/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/balances/blockchain.adapter.ts
@@ -210,10 +210,15 @@ export class BlockchainAdapter implements LiquidityBalanceIntegration {
       if (previousBalance && !balance) this.logger.error(`Balance for ${asset.uniqueName} went to ${null}`);
 
       // DEBUG: trace balance pipeline
-      if (balance !== previousBalance) {
+      if (previousBalance != null && balance !== previousBalance) {
         this.logger.verbose(
           `Balance change for ${asset.uniqueName} (${asset.id}): ${previousBalance} -> ${balance} (inMap: ${tokenToBalanceMap.has(asset.chainId?.toLowerCase())})`,
         );
+      }
+
+      // DEBUG: always log BBTC balance for investigation
+      if (asset.id === 394) {
+        this.logger.verbose(`BBTC balance trace: alchemy=${balance}, cache=${previousBalance}, inMap=${tokenToBalanceMap.has(asset.chainId?.toLowerCase())}`);
       }
 
       if (balance != null) this.balanceCache.set(asset.id, balance);

--- a/src/subdomains/core/liquidity-management/services/liquidity-management-balance.service.ts
+++ b/src/subdomains/core/liquidity-management/services/liquidity-management-balance.service.ts
@@ -84,7 +84,22 @@ export class LiquidityManagementBalanceService implements OnModuleInit {
         const existingBalance = await this.balanceRepo.findOneBy({ asset: { id: balance.asset?.id } });
 
         if (existingBalance) {
-          if (existingBalance.updated > startDate) continue;
+          if (existingBalance.updated > startDate) {
+            // DEBUG: log skipped saves
+            if (balance.amount !== existingBalance.amount) {
+              this.logger.verbose(
+                `Skipping save for ${balance.asset.uniqueName}: updated(${existingBalance.updated.toISOString()}) > startDate(${startDate.toISOString()}), amount: ${existingBalance.amount} -> ${balance.amount}`,
+              );
+            }
+            continue;
+          }
+
+          // DEBUG: log balance changes
+          if (balance.amount !== existingBalance.amount) {
+            this.logger.verbose(
+              `Saving balance for ${balance.asset.uniqueName}: ${existingBalance.amount} -> ${balance.amount ?? 0}`,
+            );
+          }
 
           existingBalance.updateBalance(balance.amount ?? 0, balance.availableAmount);
           await this.balanceRepo.save(existingBalance);


### PR DESCRIPTION
## Summary
- BBTC (Asset 394) `liquidity_balance` shows 0.001 while on-chain balance is 1.73 BBTC
- Direct Alchemy SDK calls return the correct value (1.73)
- No errors in production logs
- Root cause unknown — need to trace the actual values in production

## Debug logging added
1. **BlockchainAdapter** `updateCoinAndTokenBalance`: logs when a balance value changes between cache updates (old → new), including whether the chainId was found in the Alchemy response map
2. **BlockchainAdapter** `getForBlockchain`: logs any assets missing from cache after an update cycle
3. **BalanceService** `saveBalanceResults`: logs when saves are skipped due to `updated > startDate`, and when balance values actually change

All logs are `verbose` level — they'll appear in Application Insights but won't spam error channels.

## After deploy
Search traces for:
- `"Balance change for Ethereum/BBTC"` — confirms Alchemy returns different value than cache
- `"missing from cache after update"` — confirms BBTC is dropped from cache
- `"Skipping save for Ethereum/BBTC"` — confirms save is skipped due to timing
- `"Saving balance for Ethereum/BBTC"` — confirms save goes through