### PR TITLE
feat: refund-deposit script for manual EVM deposit forwarding

### DIFF
--- a/scripts/refund-deposit.js
+++ b/scripts/refund-deposit.js
@@ -1,8 +1,21 @@
 #!/usr/bin/env node
 //
-// Refund / forward funds from a DFX EVM deposit address.
+// Refund / forward funds from a DFX EVM deposit address — LAST-RESORT TOOL.
 //
-// Bootstraps the NestJS application context and uses the existing
+// Prefer the support endpoint for normal refund cases:
+//
+//   PUT /support/crypto-input/:id/return
+//   Body: { destinationAddress, chargebackAmount }
+//
+// That endpoint calls payInService.returnPayIn(), which sets the correct
+// status/action on the crypto_input record and lets the existing send-strategy
+// cron broadcast the tx, update returnTxId and track confirmations — full
+// audit trail.
+//
+// This script bypasses all of that. Use it ONLY when a CryptoInput record
+// cannot be processed by the pipeline at all (asset is null, not confirmed,
+// or no record exists), and the funds need to come back without a clean
+// audit trail. Bootstraps the NestJS application context and uses the existing
 // BlockchainRegistryService + EvmClient to derive the deposit wallet
 // (EVM_DEPOSIT_SEED + accountIndex) and forward a chosen asset to a chosen
 // recipient. Recipient can be derived from a deposit transaction (sender of

--- a/scripts/refund-deposit.js
+++ b/scripts/refund-deposit.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable */
 //
 // Refund / forward funds from a DFX EVM deposit address.
 //
@@ -38,106 +37,14 @@
 //
 
 const { ethers } = require('ethers');
-
-// Heavy NestJS / dist requires are deferred to main() so that --help and
-// argument validation work without bootstrapping the application context.
-
-const CHAIN_NAMES = ['ethereum', 'optimism', 'arbitrum', 'polygon', 'base', 'bsc', 'gnosis', 'citrea'];
-
-const EXPLORERS = {
-  Ethereum: 'https://etherscan.io',
-  Optimism: 'https://optimistic.etherscan.io',
-  Arbitrum: 'https://arbiscan.io',
-  Polygon: 'https://polygonscan.com',
-  Base: 'https://basescan.org',
-  BinanceSmartChain: 'https://bscscan.com',
-  Gnosis: 'https://gnosisscan.io',
-  Citrea: 'https://citreascan.com',
-};
-
-function parseArgs(argv) {
-  const args = {};
-  for (let i = 2; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === '--execute') { args.execute = true; continue; }
-    if (a === '-h' || a === '--help') { args.help = true; continue; }
-    if (a.startsWith('--')) {
-      const key = a.slice(2);
-      const val = argv[i + 1];
-      if (val === undefined || val.startsWith('--')) {
-        throw new Error(`Missing value for --${key}`);
-      }
-      args[key] = val;
-      i++;
-    }
-  }
-  return args;
-}
-
-function printHelp() {
-  console.log(`Refund / forward funds from a DFX EVM deposit address.
-
-Required:
-  --chain <name>           ${CHAIN_NAMES.join(', ')}
-  --account-index <N>      Deposit address slot (BIP-44 m/44'/60'/0'/0/N)
-  --asset native|<addr>    'native' or ERC20 contract address
-  --amount all|<float>     'all' to sweep everything
-
-One of:
-  --to <address>           Explicit recipient
-  --to-sender-of <txHash>  Use the 'from' of that transaction as recipient
-
-Optional:
-  --execute                Broadcast (default: dry-run)
-  -h, --help               This help
-`);
-}
-
-function validateArgs(args) {
-  const chainName = args.chain;
-  if (!chainName || !CHAIN_NAMES.includes(chainName)) {
-    throw new Error(`Unknown --chain (have: ${CHAIN_NAMES.join(', ')})`);
-  }
-
-  const accountIndex = args['account-index'];
-  if (accountIndex == null || !/^\d+$/.test(accountIndex)) {
-    throw new Error('--account-index must be a non-negative integer');
-  }
-
-  const asset = args.asset;
-  if (!asset) throw new Error('--asset is required (native|<contract>)');
-  const isNative = asset === 'native';
-  if (!isNative && !ethers.utils.isAddress(asset)) {
-    throw new Error('--asset must be "native" or a valid contract address');
-  }
-
-  const amountArg = args.amount;
-  if (!amountArg) throw new Error('--amount is required (all|<float>)');
-
-  const explicitTo = args.to;
-  const toSenderOfTx = args['to-sender-of'];
-  if (!explicitTo && !toSenderOfTx) {
-    throw new Error('Need --to <addr> OR --to-sender-of <txHash>');
-  }
-  if (explicitTo && toSenderOfTx) {
-    throw new Error('--to and --to-sender-of are mutually exclusive');
-  }
-  if (explicitTo && !ethers.utils.isAddress(explicitTo)) {
-    throw new Error('--to must be a valid address');
-  }
-
-  return {
-    chainName,
-    accountIndex: parseInt(accountIndex, 10),
-    asset,
-    isNative,
-    amountArg,
-    sweepAll: amountArg === 'all',
-    explicitTo,
-    toSenderOfTx,
-    execute: !!args.execute,
-  };
-}
+const {
+  parseArgs,
+  validateArgs,
+  helpText,
+  computeNativeSweepAmount,
+  EXPLORERS,
+  SWEEP_FEE_SAFETY_FACTOR,
+} = require('../dist/src/scripts/refund-deposit.util');
 
 async function resolveRecipient(provider, opts) {
   if (opts.explicitTo) return ethers.utils.getAddress(opts.explicitTo);
@@ -150,21 +57,38 @@ async function resolveRecipient(provider, opts) {
   return sender;
 }
 
-async function resolveAsset(assetService, AssetType, blockchain, opts) {
+async function resolveAsset(assetService, AssetType, opts) {
   if (opts.isNative) {
-    const native = await assetService.getNativeAsset(blockchain);
-    if (!native) throw new Error(`No native asset configured for ${blockchain}`);
+    const native = await assetService.getNativeAsset(opts.blockchain);
+    if (!native) throw new Error(`No native asset configured for ${opts.blockchain}`);
     return native;
   }
-  const token = await assetService.getAssetByChainId(blockchain, opts.asset);
-  if (!token) throw new Error(`No asset entity for contract ${opts.asset} on ${blockchain}`);
+  const token = await assetService.getAssetByChainId(opts.blockchain, opts.asset);
+  if (!token) throw new Error(`No asset entity for contract ${opts.asset} on ${opts.blockchain}`);
   if (token.type !== AssetType.TOKEN) throw new Error(`Asset ${token.name} is not a TOKEN`);
   return token;
 }
 
+async function estimateNativeFee(provider, fromAddress, recipient, gasPrice) {
+  // Use value=0 for the probe so providers that reject estimateGas with
+  // value > balance don't fail — gas for a plain transfer is value-independent.
+  const estimated = await provider.estimateGas({ from: fromAddress, to: recipient, value: 0 });
+  return +ethers.utils.formatEther(estimated.mul(gasPrice));
+}
+
+async function estimateTokenFee(provider, fromAddress, contractAddress, recipient, amountWei, gasPrice) {
+  const iface = new ethers.utils.Interface(['function transfer(address,uint256)']);
+  const data = iface.encodeFunctionData('transfer', [recipient, amountWei]);
+  const estimated = await provider.estimateGas({ from: fromAddress, to: contractAddress, data });
+  return +ethers.utils.formatEther(estimated.mul(gasPrice));
+}
+
 async function main() {
   const rawArgs = parseArgs(process.argv);
-  if (rawArgs.help) { printHelp(); return; }
+  if (rawArgs.help) {
+    console.log(helpText());
+    return;
+  }
   const opts = validateArgs(rawArgs);
 
   if (!process.env.EVM_DEPOSIT_SEED) {
@@ -179,35 +103,22 @@ async function main() {
     BlockchainRegistryService,
   } = require('../dist/src/integration/blockchain/shared/services/blockchain-registry.service');
   const { AssetService } = require('../dist/src/shared/models/asset/asset.service');
-  const { Blockchain } = require('../dist/src/integration/blockchain/shared/enums/blockchain.enum');
   const { AssetType } = require('../dist/src/shared/models/asset/asset.entity');
   const { EvmUtil } = require('../dist/src/integration/blockchain/shared/evm/evm.util');
   const { GetConfig } = require('../dist/src/config/config');
-
-  const CHAIN_TO_ENUM = {
-    ethereum: Blockchain.ETHEREUM,
-    optimism: Blockchain.OPTIMISM,
-    arbitrum: Blockchain.ARBITRUM,
-    polygon: Blockchain.POLYGON,
-    base: Blockchain.BASE,
-    bsc: Blockchain.BINANCE_SMART_CHAIN,
-    gnosis: Blockchain.GNOSIS,
-    citrea: Blockchain.CITREA,
-  };
-  const blockchain = CHAIN_TO_ENUM[opts.chainName];
 
   const app = await NestFactory.createApplicationContext(AppModule, { logger: false });
   try {
     const registry = app.get(BlockchainRegistryService);
     const assetService = app.get(AssetService);
 
-    const client = registry.getEvmClient(blockchain);
+    const client = registry.getEvmClient(opts.blockchain);
     const account = GetConfig().blockchain.evm.walletAccount(opts.accountIndex);
     const wallet = EvmUtil.createWallet(account);
     const fromAddress = wallet.address;
 
     console.log('=== DFX Deposit Refund ===');
-    console.log(`Chain:           ${opts.chainName} (${blockchain})`);
+    console.log(`Chain:           ${opts.chainName} (${opts.blockchain})`);
     console.log(`Account index:   ${opts.accountIndex}`);
     console.log(`Deposit address: ${fromAddress}`);
 
@@ -217,21 +128,17 @@ async function main() {
     }
     console.log(`Recipient:       ${recipient}`);
 
-    const asset = await resolveAsset(assetService, AssetType, blockchain, opts);
+    const asset = await resolveAsset(assetService, AssetType, opts);
+    const gasPrice = await client.getRecommendedGasPrice();
     const nativeBalance = await client.getNativeCoinBalanceForAddress(fromAddress);
 
     let sendAmount;
+    let fee;
     if (opts.isNative) {
       if (nativeBalance <= 0) throw new Error(`Native balance is 0 ${asset.name}`);
-      // Estimate fee, then sweep balance - fee (with safety buffer) when sweepAll.
-      const gasPrice = await client.getRecommendedGasPrice();
-      const provider = client.provider;
-      const probeValue = ethers.utils.parseEther(nativeBalance.toString());
-      const estimated = await provider.estimateGas({ from: fromAddress, to: recipient, value: probeValue });
-      const fee = +ethers.utils.formatEther(estimated.mul(gasPrice));
+      fee = await estimateNativeFee(client.provider, fromAddress, recipient, gasPrice);
       if (opts.sweepAll) {
-        sendAmount = nativeBalance - fee;
-        if (sendAmount <= 0) throw new Error(`Native balance ${nativeBalance} ${asset.name} ≤ tx fee ${fee} ${asset.name}`);
+        sendAmount = computeNativeSweepAmount(nativeBalance, fee, SWEEP_FEE_SAFETY_FACTOR);
       } else {
         sendAmount = parseFloat(opts.amountArg);
         if (sendAmount + fee > nativeBalance) {
@@ -243,13 +150,21 @@ async function main() {
     } else {
       const tokenBalance = await client.getTokenBalance(asset, fromAddress);
       if (tokenBalance <= 0) throw new Error(`Token balance is 0 for ${asset.name}`);
+
       sendAmount = opts.sweepAll ? tokenBalance : parseFloat(opts.amountArg);
       if (sendAmount > tokenBalance) {
         throw new Error(`Need ${sendAmount} ${asset.name}, have ${tokenBalance} ${asset.name}`);
       }
-      if (nativeBalance <= 0) throw new Error(`Native balance is 0 — cannot pay gas for token transfer`);
+
+      const amountWei = ethers.utils.parseUnits(sendAmount.toString(), asset.decimals);
+      fee = await estimateTokenFee(client.provider, fromAddress, asset.chainId, recipient, amountWei, gasPrice);
+      if (fee > nativeBalance) {
+        throw new Error(`Estimated gas fee ${fee} exceeds native balance ${nativeBalance} — fund the deposit address first`);
+      }
+
       console.log(`\nToken balance:   ${tokenBalance} ${asset.name}`);
       console.log(`Native balance:  ${nativeBalance} (for gas)`);
+      console.log(`Estimated fee:   ${fee}`);
     }
 
     console.log('\n--- Plan ---');
@@ -265,9 +180,9 @@ async function main() {
       ? await client.sendNativeCoinFromAccount(account, recipient, sendAmount)
       : await client.sendTokenFromAccount(account, recipient, asset, sendAmount);
 
-    const explorer = EXPLORERS[blockchain];
+    const explorer = EXPLORERS[opts.blockchain];
     console.log(`Tx hash:         ${txHash}`);
-    console.log(`Explorer:        ${explorer}/tx/${txHash}`);
+    if (explorer) console.log(`Explorer:        ${explorer}/tx/${txHash}`);
     console.log('Waiting for 1 confirmation...');
     const receipt = await client.provider.waitForTransaction(txHash, 1);
     console.log(`Confirmed in block ${receipt.blockNumber}, status=${receipt.status === 1 ? 'OK' : 'FAILED'}`);
@@ -276,7 +191,9 @@ async function main() {
   }
 }
 
-main().catch((e) => {
-  console.error(`\nERROR: ${e.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(`\nERROR: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/refund-deposit.js
+++ b/scripts/refund-deposit.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/* eslint-disable */
+//
+// Refund / forward funds from a DFX EVM deposit address.
+//
+// Bootstraps the NestJS application context and uses the existing
+// BlockchainRegistryService + EvmClient to derive the deposit wallet
+// (EVM_DEPOSIT_SEED + accountIndex) and forward a chosen asset to a chosen
+// recipient. Recipient can be derived from a deposit transaction (sender of
+// that tx).
+//
+// Default behaviour is DRY-RUN. Pass --execute to broadcast.
+//
+// Where to run:
+//   The deposit seed only lives in the api container env. On prd this is the
+//   Azure App Service `app-dfx-api-prd`. SSH in and run from /home/site/wwwroot:
+//
+//     az webapp ssh -g <rg> -n app-dfx-api-prd
+//     cd /home/site/wwwroot
+//     node scripts/refund-deposit.js --help
+//
+// Usage:
+//   node scripts/refund-deposit.js \
+//     --chain citrea \
+//     --account-index 4486 \
+//     --asset native \
+//     --amount all \
+//     --to-sender-of 0x8b3bbec3... \
+//     [--execute]
+//
+//   node scripts/refund-deposit.js \
+//     --chain ethereum \
+//     --account-index 4486 \
+//     --asset 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
+//     --amount 100 \
+//     --to 0xRECIPIENT \
+//     [--execute]
+//
+
+const { ethers } = require('ethers');
+
+// Heavy NestJS / dist requires are deferred to main() so that --help and
+// argument validation work without bootstrapping the application context.
+
+const CHAIN_NAMES = ['ethereum', 'optimism', 'arbitrum', 'polygon', 'base', 'bsc', 'gnosis', 'citrea'];
+
+const EXPLORERS = {
+  Ethereum: 'https://etherscan.io',
+  Optimism: 'https://optimistic.etherscan.io',
+  Arbitrum: 'https://arbiscan.io',
+  Polygon: 'https://polygonscan.com',
+  Base: 'https://basescan.org',
+  BinanceSmartChain: 'https://bscscan.com',
+  Gnosis: 'https://gnosisscan.io',
+  Citrea: 'https://citreascan.com',
+};
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--execute') { args.execute = true; continue; }
+    if (a === '-h' || a === '--help') { args.help = true; continue; }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const val = argv[i + 1];
+      if (val === undefined || val.startsWith('--')) {
+        throw new Error(`Missing value for --${key}`);
+      }
+      args[key] = val;
+      i++;
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Refund / forward funds from a DFX EVM deposit address.
+
+Required:
+  --chain <name>           ${CHAIN_NAMES.join(', ')}
+  --account-index <N>      Deposit address slot (BIP-44 m/44'/60'/0'/0/N)
+  --asset native|<addr>    'native' or ERC20 contract address
+  --amount all|<float>     'all' to sweep everything
+
+One of:
+  --to <address>           Explicit recipient
+  --to-sender-of <txHash>  Use the 'from' of that transaction as recipient
+
+Optional:
+  --execute                Broadcast (default: dry-run)
+  -h, --help               This help
+`);
+}
+
+function validateArgs(args) {
+  const chainName = args.chain;
+  if (!chainName || !CHAIN_NAMES.includes(chainName)) {
+    throw new Error(`Unknown --chain (have: ${CHAIN_NAMES.join(', ')})`);
+  }
+
+  const accountIndex = args['account-index'];
+  if (accountIndex == null || !/^\d+$/.test(accountIndex)) {
+    throw new Error('--account-index must be a non-negative integer');
+  }
+
+  const asset = args.asset;
+  if (!asset) throw new Error('--asset is required (native|<contract>)');
+  const isNative = asset === 'native';
+  if (!isNative && !ethers.utils.isAddress(asset)) {
+    throw new Error('--asset must be "native" or a valid contract address');
+  }
+
+  const amountArg = args.amount;
+  if (!amountArg) throw new Error('--amount is required (all|<float>)');
+
+  const explicitTo = args.to;
+  const toSenderOfTx = args['to-sender-of'];
+  if (!explicitTo && !toSenderOfTx) {
+    throw new Error('Need --to <addr> OR --to-sender-of <txHash>');
+  }
+  if (explicitTo && toSenderOfTx) {
+    throw new Error('--to and --to-sender-of are mutually exclusive');
+  }
+  if (explicitTo && !ethers.utils.isAddress(explicitTo)) {
+    throw new Error('--to must be a valid address');
+  }
+
+  return {
+    chainName,
+    accountIndex: parseInt(accountIndex, 10),
+    asset,
+    isNative,
+    amountArg,
+    sweepAll: amountArg === 'all',
+    explicitTo,
+    toSenderOfTx,
+    execute: !!args.execute,
+  };
+}
+
+async function resolveRecipient(provider, opts) {
+  if (opts.explicitTo) return ethers.utils.getAddress(opts.explicitTo);
+
+  console.log(`\nResolving sender of tx ${opts.toSenderOfTx} ...`);
+  const tx = await provider.getTransaction(opts.toSenderOfTx);
+  if (!tx) throw new Error(`Transaction ${opts.toSenderOfTx} not found on ${opts.chainName}`);
+  const sender = ethers.utils.getAddress(tx.from);
+  console.log(`  → sender: ${sender}`);
+  return sender;
+}
+
+async function resolveAsset(assetService, AssetType, blockchain, opts) {
+  if (opts.isNative) {
+    const native = await assetService.getNativeAsset(blockchain);
+    if (!native) throw new Error(`No native asset configured for ${blockchain}`);
+    return native;
+  }
+  const token = await assetService.getAssetByChainId(blockchain, opts.asset);
+  if (!token) throw new Error(`No asset entity for contract ${opts.asset} on ${blockchain}`);
+  if (token.type !== AssetType.TOKEN) throw new Error(`Asset ${token.name} is not a TOKEN`);
+  return token;
+}
+
+async function main() {
+  const rawArgs = parseArgs(process.argv);
+  if (rawArgs.help) { printHelp(); return; }
+  const opts = validateArgs(rawArgs);
+
+  if (!process.env.EVM_DEPOSIT_SEED) {
+    throw new Error('EVM_DEPOSIT_SEED env var is not set');
+  }
+
+  // Defer heavy NestJS / dist requires until args are validated, so --help and
+  // input errors don't trigger application-context bootstrap.
+  const { NestFactory } = require('@nestjs/core');
+  const { AppModule } = require('../dist/src/app.module');
+  const {
+    BlockchainRegistryService,
+  } = require('../dist/src/integration/blockchain/shared/services/blockchain-registry.service');
+  const { AssetService } = require('../dist/src/shared/models/asset/asset.service');
+  const { Blockchain } = require('../dist/src/integration/blockchain/shared/enums/blockchain.enum');
+  const { AssetType } = require('../dist/src/shared/models/asset/asset.entity');
+  const { EvmUtil } = require('../dist/src/integration/blockchain/shared/evm/evm.util');
+  const { GetConfig } = require('../dist/src/config/config');
+
+  const CHAIN_TO_ENUM = {
+    ethereum: Blockchain.ETHEREUM,
+    optimism: Blockchain.OPTIMISM,
+    arbitrum: Blockchain.ARBITRUM,
+    polygon: Blockchain.POLYGON,
+    base: Blockchain.BASE,
+    bsc: Blockchain.BINANCE_SMART_CHAIN,
+    gnosis: Blockchain.GNOSIS,
+    citrea: Blockchain.CITREA,
+  };
+  const blockchain = CHAIN_TO_ENUM[opts.chainName];
+
+  const app = await NestFactory.createApplicationContext(AppModule, { logger: false });
+  try {
+    const registry = app.get(BlockchainRegistryService);
+    const assetService = app.get(AssetService);
+
+    const client = registry.getEvmClient(blockchain);
+    const account = GetConfig().blockchain.evm.walletAccount(opts.accountIndex);
+    const wallet = EvmUtil.createWallet(account);
+    const fromAddress = wallet.address;
+
+    console.log('=== DFX Deposit Refund ===');
+    console.log(`Chain:           ${opts.chainName} (${blockchain})`);
+    console.log(`Account index:   ${opts.accountIndex}`);
+    console.log(`Deposit address: ${fromAddress}`);
+
+    const recipient = await resolveRecipient(client.provider, opts);
+    if (recipient.toLowerCase() === fromAddress.toLowerCase()) {
+      throw new Error('Refusing to send to deposit address itself');
+    }
+    console.log(`Recipient:       ${recipient}`);
+
+    const asset = await resolveAsset(assetService, AssetType, blockchain, opts);
+    const nativeBalance = await client.getNativeCoinBalanceForAddress(fromAddress);
+
+    let sendAmount;
+    if (opts.isNative) {
+      if (nativeBalance <= 0) throw new Error(`Native balance is 0 ${asset.name}`);
+      // Estimate fee, then sweep balance - fee (with safety buffer) when sweepAll.
+      const gasPrice = await client.getRecommendedGasPrice();
+      const provider = client.provider;
+      const probeValue = ethers.utils.parseEther(nativeBalance.toString());
+      const estimated = await provider.estimateGas({ from: fromAddress, to: recipient, value: probeValue });
+      const fee = +ethers.utils.formatEther(estimated.mul(gasPrice));
+      if (opts.sweepAll) {
+        sendAmount = nativeBalance - fee;
+        if (sendAmount <= 0) throw new Error(`Native balance ${nativeBalance} ${asset.name} ≤ tx fee ${fee} ${asset.name}`);
+      } else {
+        sendAmount = parseFloat(opts.amountArg);
+        if (sendAmount + fee > nativeBalance) {
+          throw new Error(`Need ${sendAmount + fee} ${asset.name}, have ${nativeBalance} ${asset.name}`);
+        }
+      }
+      console.log(`\nNative balance:  ${nativeBalance} ${asset.name}`);
+      console.log(`Estimated fee:   ${fee} ${asset.name}`);
+    } else {
+      const tokenBalance = await client.getTokenBalance(asset, fromAddress);
+      if (tokenBalance <= 0) throw new Error(`Token balance is 0 for ${asset.name}`);
+      sendAmount = opts.sweepAll ? tokenBalance : parseFloat(opts.amountArg);
+      if (sendAmount > tokenBalance) {
+        throw new Error(`Need ${sendAmount} ${asset.name}, have ${tokenBalance} ${asset.name}`);
+      }
+      if (nativeBalance <= 0) throw new Error(`Native balance is 0 — cannot pay gas for token transfer`);
+      console.log(`\nToken balance:   ${tokenBalance} ${asset.name}`);
+      console.log(`Native balance:  ${nativeBalance} (for gas)`);
+    }
+
+    console.log('\n--- Plan ---');
+    console.log(`Send ${sendAmount} ${asset.name} from ${fromAddress} to ${recipient}`);
+
+    if (!opts.execute) {
+      console.log('\nDRY RUN — pass --execute to broadcast.');
+      return;
+    }
+
+    console.log('\nBroadcasting...');
+    const txHash = opts.isNative
+      ? await client.sendNativeCoinFromAccount(account, recipient, sendAmount)
+      : await client.sendTokenFromAccount(account, recipient, asset, sendAmount);
+
+    const explorer = EXPLORERS[blockchain];
+    console.log(`Tx hash:         ${txHash}`);
+    console.log(`Explorer:        ${explorer}/tx/${txHash}`);
+    console.log('Waiting for 1 confirmation...');
+    const receipt = await client.provider.waitForTransaction(txHash, 1);
+    console.log(`Confirmed in block ${receipt.blockNumber}, status=${receipt.status === 1 ? 'OK' : 'FAILED'}`);
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(`\nERROR: ${e.message}`);
+  process.exit(1);
+});

--- a/src/scripts/__tests__/refund-deposit.util.spec.ts
+++ b/src/scripts/__tests__/refund-deposit.util.spec.ts
@@ -1,0 +1,170 @@
+import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
+import {
+  CHAIN_NAMES,
+  CHAIN_TO_BLOCKCHAIN,
+  computeNativeSweepAmount,
+  EXPLORERS,
+  parseArgs,
+  SWEEP_FEE_SAFETY_FACTOR,
+  validateArgs,
+} from '../refund-deposit.util';
+
+const baseArgv = (extra: string[]) => ['node', 'refund-deposit.js', ...extra];
+
+describe('refund-deposit.util', () => {
+  describe('parseArgs', () => {
+    it('parses key/value flags and the --execute switch', () => {
+      const args = parseArgs(
+        baseArgv([
+          '--chain',
+          'citrea',
+          '--account-index',
+          '4486',
+          '--asset',
+          'native',
+          '--amount',
+          'all',
+          '--to',
+          '0xB2CBBde7cfDb5ea1DB27aCcdd1abf7EE3BcC87C1',
+          '--execute',
+        ]),
+      );
+      expect(args).toEqual({
+        chain: 'citrea',
+        'account-index': '4486',
+        asset: 'native',
+        amount: 'all',
+        to: '0xB2CBBde7cfDb5ea1DB27aCcdd1abf7EE3BcC87C1',
+        execute: true,
+      });
+    });
+
+    it('recognises -h and --help', () => {
+      expect(parseArgs(baseArgv(['-h']))).toEqual({ help: true });
+      expect(parseArgs(baseArgv(['--help']))).toEqual({ help: true });
+    });
+
+    it('throws on unknown flags', () => {
+      expect(() => parseArgs(baseArgv(['--chian', 'ethereum']))).toThrow(/Unknown flag/);
+    });
+
+    it('throws on positional arguments', () => {
+      expect(() => parseArgs(baseArgv(['ethereum']))).toThrow(/Unexpected positional argument/);
+    });
+
+    it('throws when a value is missing', () => {
+      expect(() => parseArgs(baseArgv(['--chain']))).toThrow(/Missing value for --chain/);
+      expect(() => parseArgs(baseArgv(['--chain', '--asset', 'native']))).toThrow(/Missing value for --chain/);
+    });
+  });
+
+  describe('validateArgs', () => {
+    const validBase = {
+      chain: 'citrea',
+      'account-index': '4486',
+      asset: 'native',
+      amount: 'all',
+      to: '0xB2CBBde7cfDb5ea1DB27aCcdd1abf7EE3BcC87C1',
+    };
+
+    it('returns a fully resolved option set for the happy path', () => {
+      const opts = validateArgs(validBase);
+      expect(opts).toEqual({
+        chainName: 'citrea',
+        blockchain: Blockchain.CITREA,
+        accountIndex: 4486,
+        asset: 'native',
+        isNative: true,
+        amountArg: 'all',
+        sweepAll: true,
+        explicitTo: '0xB2CBBde7cfDb5ea1DB27aCcdd1abf7EE3BcC87C1',
+        toSenderOfTx: undefined,
+        execute: false,
+      });
+    });
+
+    it('lowercases the contract address before storage', () => {
+      const opts = validateArgs({
+        ...validBase,
+        asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // checksum form
+      });
+      expect(opts.isNative).toBe(false);
+      expect(opts.asset).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+    });
+
+    it('rejects unknown chains', () => {
+      expect(() => validateArgs({ ...validBase, chain: 'monad' })).toThrow(/Unknown --chain/);
+    });
+
+    it('rejects non-numeric account indexes', () => {
+      expect(() => validateArgs({ ...validBase, 'account-index': '4486x' })).toThrow(/account-index/);
+      expect(() => validateArgs({ ...validBase, 'account-index': '-1' })).toThrow(/account-index/);
+    });
+
+    it('rejects an asset that is neither "native" nor a valid address', () => {
+      expect(() => validateArgs({ ...validBase, asset: 'usdc' })).toThrow(/--asset must be/);
+      expect(() => validateArgs({ ...validBase, asset: '0xnotvalid' })).toThrow(/--asset must be/);
+    });
+
+    it('rejects an amount that is not "all" or a positive number', () => {
+      expect(() => validateArgs({ ...validBase, amount: 'half' })).toThrow(/--amount/);
+      expect(() => validateArgs({ ...validBase, amount: '-1' })).toThrow(/--amount/);
+    });
+
+    it('requires exactly one of --to or --to-sender-of', () => {
+      const { to: _to, ...withoutTo } = validBase;
+      expect(() => validateArgs(withoutTo)).toThrow(/--to <addr> OR --to-sender-of/);
+      expect(() =>
+        validateArgs({
+          ...validBase,
+          'to-sender-of': '0x' + '0'.repeat(64),
+        }),
+      ).toThrow(/mutually exclusive/);
+    });
+
+    it('rejects an invalid recipient address', () => {
+      expect(() => validateArgs({ ...validBase, to: '0xnotvalid' })).toThrow(/--to must be a valid/);
+    });
+
+    it('rejects a malformed tx hash for --to-sender-of', () => {
+      const { to: _to, ...rest } = validBase;
+      expect(() => validateArgs({ ...rest, 'to-sender-of': '0xabc' })).toThrow(/32-byte hex tx hash/);
+    });
+
+    it('passes an execute=true flag through', () => {
+      expect(validateArgs({ ...validBase, execute: true }).execute).toBe(true);
+    });
+  });
+
+  describe('computeNativeSweepAmount', () => {
+    it('subtracts the safety-buffered fee from the balance', () => {
+      const balance = 1.0;
+      const fee = 0.001;
+      const sendAmount = computeNativeSweepAmount(balance, fee, SWEEP_FEE_SAFETY_FACTOR);
+      expect(sendAmount).toBeCloseTo(balance - fee * SWEEP_FEE_SAFETY_FACTOR, 12);
+    });
+
+    it('throws when the fee exceeds the balance', () => {
+      expect(() => computeNativeSweepAmount(0.0001, 0.0002, SWEEP_FEE_SAFETY_FACTOR)).toThrow(/≤ reserved fee/);
+    });
+
+    it('honours a custom safety factor', () => {
+      const sendAmount = computeNativeSweepAmount(1.0, 0.01, 1.5);
+      expect(sendAmount).toBeCloseTo(1.0 - 0.015, 12);
+    });
+  });
+
+  describe('CHAIN_TO_BLOCKCHAIN / EXPLORERS', () => {
+    it('covers every CHAIN_NAME with a Blockchain mapping', () => {
+      for (const name of CHAIN_NAMES) {
+        expect(CHAIN_TO_BLOCKCHAIN[name]).toBeDefined();
+      }
+    });
+
+    it('covers every mapped Blockchain with an explorer URL', () => {
+      for (const blockchain of Object.values(CHAIN_TO_BLOCKCHAIN)) {
+        expect(EXPLORERS[blockchain]).toMatch(/^https:\/\//);
+      }
+    });
+  });
+});

--- a/src/scripts/refund-deposit.util.ts
+++ b/src/scripts/refund-deposit.util.ts
@@ -1,0 +1,176 @@
+import { ethers } from 'ethers';
+import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
+
+export const CHAIN_NAMES = ['ethereum', 'optimism', 'arbitrum', 'polygon', 'base', 'bsc', 'gnosis', 'citrea'] as const;
+
+export type ChainName = (typeof CHAIN_NAMES)[number];
+
+export const CHAIN_TO_BLOCKCHAIN: Record<ChainName, Blockchain> = {
+  ethereum: Blockchain.ETHEREUM,
+  optimism: Blockchain.OPTIMISM,
+  arbitrum: Blockchain.ARBITRUM,
+  polygon: Blockchain.POLYGON,
+  base: Blockchain.BASE,
+  bsc: Blockchain.BINANCE_SMART_CHAIN,
+  gnosis: Blockchain.GNOSIS,
+  citrea: Blockchain.CITREA,
+};
+
+export const EXPLORERS: Partial<Record<Blockchain, string>> = {
+  [Blockchain.ETHEREUM]: 'https://etherscan.io',
+  [Blockchain.OPTIMISM]: 'https://optimistic.etherscan.io',
+  [Blockchain.ARBITRUM]: 'https://arbiscan.io',
+  [Blockchain.POLYGON]: 'https://polygonscan.com',
+  [Blockchain.BASE]: 'https://basescan.org',
+  [Blockchain.BINANCE_SMART_CHAIN]: 'https://bscscan.com',
+  [Blockchain.GNOSIS]: 'https://gnosisscan.io',
+  [Blockchain.CITREA]: 'https://citreascan.com',
+};
+
+// Safety margin on the estimated tx fee for native sweeps. Covers small
+// gas-price drift between dry-run and execute, plus floating-point round-trips
+// when the API converts ether-units back to wei.
+export const SWEEP_FEE_SAFETY_FACTOR = 1.05;
+
+export interface RefundOptions {
+  chainName: ChainName;
+  blockchain: Blockchain;
+  accountIndex: number;
+  asset: string; // 'native' | normalized lowercase contract address
+  isNative: boolean;
+  amountArg: string;
+  sweepAll: boolean;
+  explicitTo?: string;
+  toSenderOfTx?: string;
+  execute: boolean;
+}
+
+export interface RawArgs {
+  [key: string]: string | boolean | undefined;
+}
+
+export function parseArgs(argv: string[]): RawArgs {
+  const args: RawArgs = {};
+  const knownFlags = new Set(['--execute', '-h', '--help']);
+  const knownKeys = new Set(['--chain', '--account-index', '--asset', '--amount', '--to', '--to-sender-of']);
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+
+    if (a === '--execute') {
+      args.execute = true;
+      continue;
+    }
+    if (a === '-h' || a === '--help') {
+      args.help = true;
+      continue;
+    }
+
+    if (!a.startsWith('--')) {
+      throw new Error(`Unexpected positional argument: ${a}`);
+    }
+    if (!knownKeys.has(a) && !knownFlags.has(a)) {
+      throw new Error(`Unknown flag: ${a}`);
+    }
+
+    const key = a.slice(2);
+    const val = argv[i + 1];
+    if (val === undefined || val.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    args[key] = val;
+    i++;
+  }
+  return args;
+}
+
+export function validateArgs(args: RawArgs): RefundOptions {
+  const chainName = args.chain;
+  if (typeof chainName !== 'string' || !(CHAIN_NAMES as readonly string[]).includes(chainName)) {
+    throw new Error(`Unknown --chain (have: ${CHAIN_NAMES.join(', ')})`);
+  }
+
+  const accountIndexRaw = args['account-index'];
+  if (typeof accountIndexRaw !== 'string' || !/^\d+$/.test(accountIndexRaw)) {
+    throw new Error('--account-index must be a non-negative integer');
+  }
+
+  const assetRaw = args.asset;
+  if (typeof assetRaw !== 'string') throw new Error('--asset is required (native|<contract>)');
+  const isNative = assetRaw === 'native';
+  if (!isNative && !ethers.utils.isAddress(assetRaw)) {
+    throw new Error('--asset must be "native" or a valid contract address');
+  }
+  // Normalize contract address to lowercase: asset.chainId is stored
+  // lowercase in the database, while operators typically paste a checksum
+  // address copied from a block-explorer.
+  const asset = isNative ? 'native' : assetRaw.toLowerCase();
+
+  const amountArg = args.amount;
+  if (typeof amountArg !== 'string') throw new Error('--amount is required (all|<float>)');
+  if (amountArg !== 'all' && !/^\d+(\.\d+)?$/.test(amountArg)) {
+    throw new Error('--amount must be "all" or a positive number');
+  }
+
+  const explicitToRaw = args.to;
+  const toSenderOfTxRaw = args['to-sender-of'];
+  const explicitTo = typeof explicitToRaw === 'string' ? explicitToRaw : undefined;
+  const toSenderOfTx = typeof toSenderOfTxRaw === 'string' ? toSenderOfTxRaw : undefined;
+
+  if (!explicitTo && !toSenderOfTx) {
+    throw new Error('Need --to <addr> OR --to-sender-of <txHash>');
+  }
+  if (explicitTo && toSenderOfTx) {
+    throw new Error('--to and --to-sender-of are mutually exclusive');
+  }
+  if (explicitTo && !ethers.utils.isAddress(explicitTo)) {
+    throw new Error('--to must be a valid address');
+  }
+  if (toSenderOfTx && !/^0x[0-9a-fA-F]{64}$/.test(toSenderOfTx)) {
+    throw new Error('--to-sender-of must be a 32-byte hex tx hash');
+  }
+
+  return {
+    chainName: chainName as ChainName,
+    blockchain: CHAIN_TO_BLOCKCHAIN[chainName as ChainName],
+    accountIndex: parseInt(accountIndexRaw, 10),
+    asset,
+    isNative,
+    amountArg,
+    sweepAll: amountArg === 'all',
+    explicitTo,
+    toSenderOfTx,
+    execute: args.execute === true,
+  };
+}
+
+export function helpText(): string {
+  return `Refund / forward funds from a DFX EVM deposit address.
+
+Required:
+  --chain <name>           ${CHAIN_NAMES.join(', ')}
+  --account-index <N>      Deposit address slot (BIP-44 m/44'/60'/0'/0/N)
+  --asset native|<addr>    'native' or ERC20 contract address
+  --amount all|<float>     'all' to sweep everything
+
+One of:
+  --to <address>           Explicit recipient
+  --to-sender-of <txHash>  Use the 'from' of that transaction as recipient
+
+Optional:
+  --execute                Broadcast (default: dry-run)
+  -h, --help               This help
+`;
+}
+
+// Compute the value to send when sweeping native balance.
+// Returns the amount that, when sent as `value`, leaves enough native balance
+// to cover the gas fee with the given safety margin.
+export function computeNativeSweepAmount(nativeBalance: number, estimatedFee: number, safetyFactor: number): number {
+  const reservedFee = estimatedFee * safetyFactor;
+  const sendAmount = nativeBalance - reservedFee;
+  if (sendAmount <= 0) {
+    throw new Error(`Native balance ${nativeBalance} ≤ reserved fee ${reservedFee}`);
+  }
+  return sendAmount;
+}

--- a/src/scripts/refund-deposit.util.ts
+++ b/src/scripts/refund-deposit.util.ts
@@ -145,7 +145,12 @@ export function validateArgs(args: RawArgs): RefundOptions {
 }
 
 export function helpText(): string {
-  return `Refund / forward funds from a DFX EVM deposit address.
+  return `Refund / forward funds from a DFX EVM deposit address — LAST-RESORT TOOL.
+
+Prefer PUT /support/crypto-input/:id/return for normal cases (it updates the
+crypto_input record, lets the cron pipeline send and tracks confirmations).
+Use this script only when the pipeline cannot process the record at all
+(asset null, not confirmed, or no record exists).
 
 Required:
   --chain <name>           ${CHAIN_NAMES.join(', ')}

--- a/src/subdomains/generic/support/dto/crypto-input-return.dto.ts
+++ b/src/subdomains/generic/support/dto/crypto-input-return.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsNumber, IsString, IsPositive } from 'class-validator';
+import { Util } from 'src/shared/utils/util';
+
+export class CryptoInputReturnDto {
+  @ApiProperty({ description: 'Recipient address for the return tx (typically the original sender)' })
+  @IsNotEmpty()
+  @IsString()
+  @Transform(Util.trimAll)
+  @Transform(Util.sanitize)
+  destinationAddress: string;
+
+  @ApiProperty({ description: 'Amount to return in asset units (not wei)' })
+  @IsNumber()
+  @IsPositive()
+  chargebackAmount: number;
+}

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -19,6 +19,7 @@ import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
 import { UserRole } from 'src/shared/auth/user-role.enum';
 import { RefundDataDto } from 'src/subdomains/core/history/dto/refund-data.dto';
 import { ChargebackRefundDto } from 'src/subdomains/core/history/dto/transaction-refund.dto';
+import { CryptoInputReturnDto } from './dto/crypto-input-return.dto';
 import { GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
 import { ReviewStatus } from '../kyc/enums/review-status.enum';
@@ -194,5 +195,13 @@ export class SupportController {
     @GetJwt() jwt: JwtPayload,
   ): Promise<void> {
     await this.supportService.processTransactionRefund(+id, dto, jwt.account);
+  }
+
+  @Put('crypto-input/:id/return')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async returnCryptoInput(@Param('id') id: string, @Body() dto: CryptoInputReturnDto): Promise<void> {
+    await this.supportService.processCryptoInputReturn(+id, dto);
   }
 }

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -69,6 +69,7 @@ import { PhoneCallStatus } from '../user/models/user-data/user-data.enum';
 import { UserDataService } from '../user/models/user-data/user-data.service';
 import { User } from '../user/models/user/user.entity';
 import { UserService } from '../user/models/user/user.service';
+import { CryptoInputReturnDto } from './dto/crypto-input-return.dto';
 import { ComplianceDecision, GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
 import {
@@ -1332,6 +1333,18 @@ export class SupportService {
       ),
       ...baseRefund,
     });
+  }
+
+  // Trigger an on-chain return for a CryptoInput that is not attached to the
+  // standard BuyCrypto/BuyFiat refund flow (e.g. an unassigned deposit that
+  // could not be routed). The cron-driven send pipeline picks the record up
+  // and submits the actual transaction.
+  async processCryptoInputReturn(cryptoInputId: number, dto: CryptoInputReturnDto): Promise<void> {
+    const payIn = await this.payInService.getCryptoInputForReturn(cryptoInputId);
+    if (!payIn) throw new NotFoundException('CryptoInput not found');
+    if (!payIn.asset) throw new BadRequestException('CryptoInput has no asset — pipeline cannot process it');
+    if (!payIn.isConfirmed) throw new BadRequestException('CryptoInput is not confirmed yet');
+    await this.payInService.returnPayIn(payIn, dto.destinationAddress, dto.chargebackAmount);
   }
 
   private async getChargebackRefundTarget(transaction: Transaction): Promise<string | undefined> {

--- a/src/subdomains/supporting/payin/services/payin.service.ts
+++ b/src/subdomains/supporting/payin/services/payin.service.ts
@@ -151,6 +151,13 @@ export class PayInService {
     return query.getOne();
   }
 
+  async getCryptoInputForReturn(id: number): Promise<CryptoInput> {
+    return this.payInRepository.findOne({
+      where: { id },
+      relations: { asset: true, route: { user: true }, transaction: true },
+    });
+  }
+
   private async fetchPayment(payIn: CryptoInput): Promise<void> {
     try {
       payIn.paymentQuote = await this.paymentLinkPaymentService.getPaymentQuoteByCryptoInput(payIn);


### PR DESCRIPTION
## Summary
- New `scripts/refund-deposit.js` lets an operator manually forward funds from a DFX EVM deposit address to any recipient (e.g. back to the original sender of a stuck deposit)
- Bootstraps the NestJS application context and uses the existing service layer:
  - `BlockchainRegistryService.getEvmClient(blockchain)` for the right client
  - `EvmClient.sendNativeCoinFromAccount` / `sendTokenFromAccount` for the actual send
  - `EvmUtil.createWallet` + `GetConfig().blockchain.evm.walletAccount` for wallet derivation
  - `AssetService.getNativeAsset` / `getAssetByChainId` for asset entities
- Single source of truth: chain config, gas handling, RPC URLs all come from the existing codebase — no duplication

## Behaviour
- Default is **dry-run**; `--execute` is required to broadcast
- Supports all configured EVM chains: ethereum, optimism, arbitrum, polygon, base, bsc, gnosis, citrea
- Native or ERC20 transfers, with `--amount all` to sweep (native: balance − fee; token: full balance)
- Recipient via `--to <addr>` or `--to-sender-of <txHash>` (looks up `tx.from`)
- Heavy NestJS / dist requires deferred until after arg validation, so `--help` and input errors stay sub-100ms

## Use case
Stuck deposits (unsupported asset, failed routing) sit on the deposit address with no automated path back. This gives operations a safe, auditable way to forward them without exporting the private key.

## Usage
```
node scripts/refund-deposit.js \
  --chain citrea \
  --account-index 4486 \
  --asset native \
  --amount all \
  --to-sender-of 0x8b3bbec3... \
  --execute
```

Run from inside the api container on prd (Azure App Service via `az webapp ssh`) — the seed env var lives there.

## Test plan
- [ ] `node scripts/refund-deposit.js --help` prints usage instantly (no NestJS bootstrap)
- [ ] Arg validation covers: unknown chain, missing seed, conflicting `--to`/`--to-sender-of`, invalid recipient address
- [ ] Dry-run on a known stuck deposit reports correct deposit address (matches `deposit.address` in DB), correct recipient (sender of referenced tx), correct balance and gas estimate
- [ ] After dry-run review, `--execute` broadcasts and the tx confirms on-chain