### PR TITLE
fix: harden EIP-7702 backend validation in sell confirmation flow

### DIFF
--- a/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-brokerbot-sell.spec.ts
+++ b/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-brokerbot-sell.spec.ts
@@ -660,9 +660,7 @@ describe('Eip7702DelegationService - BrokerBot Sell', () => {
 
       it('should throw for invalid authorization signature', async () => {
         const viemUtilsModule = jest.requireMock('viem/utils');
-        viemUtilsModule.recoverAuthorizationAddress.mockResolvedValueOnce(
-          '0x0000000000000000000000000000000000000000',
-        );
+        viemUtilsModule.recoverAuthorizationAddress.mockResolvedValueOnce('0x0000000000000000000000000000000000000000');
 
         await expect(
           service.executeBrokerBotSellForRealUnit(

--- a/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-brokerbot-sell.spec.ts
+++ b/src/integration/blockchain/shared/evm/delegation/__tests__/eip7702-brokerbot-sell.spec.ts
@@ -1,4 +1,6 @@
 // Mock viem - must be before imports
+const VALID_USER_ADDRESS = '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD78';
+
 jest.mock('viem', () => ({
   createPublicClient: jest.fn(() => ({
     getBlock: jest.fn().mockResolvedValue({ baseFeePerGas: BigInt(10000000000) }),
@@ -6,6 +8,7 @@ jest.mock('viem', () => ({
     getTransactionCount: jest.fn().mockResolvedValue(BigInt(5)),
     getChainId: jest.fn().mockResolvedValue(11155111),
     getBalance: jest.fn().mockResolvedValue(0n),
+    waitForTransactionReceipt: jest.fn().mockResolvedValue({ status: 'success', blockNumber: 12345n }),
   })),
   createWalletClient: jest.fn(() => ({
     signTransaction: jest.fn().mockResolvedValue('0xsignedtx'),
@@ -25,6 +28,11 @@ jest.mock('viem', () => ({
   }),
   parseAbi: jest.fn().mockReturnValue([]),
   http: jest.fn(),
+  recoverTypedDataAddress: jest.fn().mockResolvedValue(VALID_USER_ADDRESS),
+}));
+
+jest.mock('viem/utils', () => ({
+  recoverAuthorizationAddress: jest.fn().mockResolvedValue(VALID_USER_ADDRESS),
 }));
 
 jest.mock('viem/accounts', () => ({
@@ -579,12 +587,41 @@ describe('Eip7702DelegationService - BrokerBot Sell', () => {
         ).rejects.toThrow('execution reverted');
       });
 
+      it('should throw when transaction reverts on-chain', async () => {
+        (viem.createWalletClient as jest.Mock).mockReturnValue({
+          signTransaction: jest.fn().mockResolvedValue('0xsignedtx'),
+          sendRawTransaction: jest.fn().mockResolvedValue('0xbrokerbottxhash'),
+        });
+        (viem.createPublicClient as jest.Mock).mockReturnValue({
+          getBlock: jest.fn().mockResolvedValue({ baseFeePerGas: BigInt(10000000000) }),
+          estimateMaxPriorityFeePerGas: jest.fn().mockResolvedValue(BigInt(1000000000)),
+          getTransactionCount: jest.fn().mockResolvedValue(BigInt(5)),
+          getChainId: jest.fn().mockResolvedValue(11155111),
+          waitForTransactionReceipt: jest.fn().mockResolvedValue({ status: 'reverted', blockNumber: 12345n }),
+        });
+
+        await expect(
+          service.executeBrokerBotSellForRealUnit(
+            validUserAddress,
+            realuToken,
+            validZchfAddress,
+            validBrokerbotAddress,
+            validDfxDepositAddress,
+            10,
+            BigInt('995000000000000000000'),
+            signedDelegation,
+            authorization,
+          ),
+        ).rejects.toThrow('Transaction reverted on-chain');
+      });
+
       it('should propagate RPC connection errors', async () => {
         (viem.createPublicClient as jest.Mock).mockReturnValue({
           getBlock: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
           estimateMaxPriorityFeePerGas: jest.fn().mockResolvedValue(BigInt(1000000000)),
           getTransactionCount: jest.fn().mockResolvedValue(BigInt(0)),
           getChainId: jest.fn().mockResolvedValue(11155111),
+          waitForTransactionReceipt: jest.fn().mockResolvedValue({ status: 'success', blockNumber: 12345n }),
         });
 
         await expect(
@@ -600,6 +637,64 @@ describe('Eip7702DelegationService - BrokerBot Sell', () => {
             authorization,
           ),
         ).rejects.toThrow('ECONNREFUSED');
+      });
+
+      it('should throw for invalid delegation signature', async () => {
+        const viemModule = jest.requireMock('viem');
+        viemModule.recoverTypedDataAddress.mockResolvedValueOnce('0x0000000000000000000000000000000000000000');
+
+        await expect(
+          service.executeBrokerBotSellForRealUnit(
+            validUserAddress,
+            realuToken,
+            validZchfAddress,
+            validBrokerbotAddress,
+            validDfxDepositAddress,
+            10,
+            BigInt('995000000000000000000'),
+            signedDelegation,
+            authorization,
+          ),
+        ).rejects.toThrow('Invalid delegation signature');
+      });
+
+      it('should throw for invalid authorization signature', async () => {
+        const viemUtilsModule = jest.requireMock('viem/utils');
+        viemUtilsModule.recoverAuthorizationAddress.mockResolvedValueOnce(
+          '0x0000000000000000000000000000000000000000',
+        );
+
+        await expect(
+          service.executeBrokerBotSellForRealUnit(
+            validUserAddress,
+            realuToken,
+            validZchfAddress,
+            validBrokerbotAddress,
+            validDfxDepositAddress,
+            10,
+            BigInt('995000000000000000000'),
+            signedDelegation,
+            authorization,
+          ),
+        ).rejects.toThrow('Invalid authorization signature');
+      });
+
+      it('should throw for chainId mismatch', async () => {
+        const wrongChainAuthorization = { ...authorization, chainId: 1 };
+
+        await expect(
+          service.executeBrokerBotSellForRealUnit(
+            validUserAddress,
+            realuToken,
+            validZchfAddress,
+            validBrokerbotAddress,
+            validDfxDepositAddress,
+            10,
+            BigInt('995000000000000000000'),
+            signedDelegation,
+            wrongChainAuthorization,
+          ),
+        ).rejects.toThrow('Authorization chainId mismatch');
       });
     });
   });

--- a/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
+++ b/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
@@ -367,9 +367,7 @@ export class Eip7702DelegationService {
 
     // Validate authorization chainId matches expected chain
     if (Number(authorization.chainId) !== expectedChainId) {
-      throw new Error(
-        `Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`,
-      );
+      throw new Error(`Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`);
     }
 
     // Verify EIP-712 delegation signature
@@ -550,9 +548,7 @@ export class Eip7702DelegationService {
 
     // Validate authorization chainId matches expected chain
     if (Number(authorization.chainId) !== expectedChainId) {
-      throw new Error(
-        `Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`,
-      );
+      throw new Error(`Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`);
     }
 
     // Verify EIP-712 delegation signature
@@ -673,7 +669,9 @@ export class Eip7702DelegationService {
         throw new Error(`Transaction reverted on-chain: ${txHash}`);
       }
 
-      this.logger.info(`User delegation transfer confirmed on ${blockchain}: TX ${txHash} (block ${receipt.blockNumber})`);
+      this.logger.info(
+        `User delegation transfer confirmed on ${blockchain}: TX ${txHash} (block ${receipt.blockNumber})`,
+      );
 
       return txHash;
     });
@@ -954,9 +952,7 @@ export class Eip7702DelegationService {
     });
 
     if (recoveredAddress.toLowerCase() !== expectedSigner.toLowerCase()) {
-      throw new Error(
-        `Invalid delegation signature: recovered ${recoveredAddress}, expected ${expectedSigner}`,
-      );
+      throw new Error(`Invalid delegation signature: recovered ${recoveredAddress}, expected ${expectedSigner}`);
     }
   }
 
@@ -979,9 +975,7 @@ export class Eip7702DelegationService {
     });
 
     if (recoveredAddress.toLowerCase() !== expectedSigner.toLowerCase()) {
-      throw new Error(
-        `Invalid authorization signature: recovered ${recoveredAddress}, expected ${expectedSigner}`,
-      );
+      throw new Error(`Invalid authorization signature: recovered ${recoveredAddress}, expected ${expectedSigner}`);
     }
   }
 

--- a/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
+++ b/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
@@ -40,6 +40,30 @@ const ROOT_AUTHORITY = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffff
 // ERC-7579 execution mode for single call
 const CALLTYPE_SINGLE = '0x0000000000000000000000000000000000000000000000000000000000000000' as Hex;
 
+// EIP-712 types for DelegationManager (shared between prepare, sign and verify)
+const DELEGATION_EIP712_TYPES = {
+  Delegation: [
+    { name: 'delegate', type: 'address' },
+    { name: 'delegator', type: 'address' },
+    { name: 'authority', type: 'bytes32' },
+    { name: 'caveats', type: 'Caveat[]' },
+    { name: 'salt', type: 'uint256' },
+  ],
+  Caveat: [
+    { name: 'enforcer', type: 'address' },
+    { name: 'terms', type: 'bytes' },
+  ],
+} as const;
+
+function getDelegationEip712Domain(chainId: number) {
+  return {
+    name: 'DelegationManager',
+    version: '1',
+    chainId,
+    verifyingContract: DELEGATION_MANAGER_ADDRESS,
+  };
+}
+
 // ERC20 transfer function
 const ERC20_ABI = parseAbi(['function transfer(address to, uint256 amount) returns (bool)']);
 
@@ -208,28 +232,8 @@ export class Eip7702DelegationService {
     const relayerAccount = privateKeyToAccount(relayerPrivateKey);
     const salt = BigInt(Date.now());
 
-    // EIP-712 domain
-    const domain = {
-      name: 'DelegationManager',
-      version: '1',
-      chainId: chainConfig.chain.id,
-      verifyingContract: DELEGATION_MANAGER_ADDRESS,
-    };
-
-    // EIP-712 types
-    const types = {
-      Delegation: [
-        { name: 'delegate', type: 'address' },
-        { name: 'delegator', type: 'address' },
-        { name: 'authority', type: 'bytes32' },
-        { name: 'caveats', type: 'Caveat[]' },
-        { name: 'salt', type: 'uint256' },
-      ],
-      Caveat: [
-        { name: 'enforcer', type: 'address' },
-        { name: 'terms', type: 'bytes' },
-      ],
-    };
+    const domain = getDelegationEip712Domain(chainConfig.chain.id);
+    const types = DELEGATION_EIP712_TYPES;
 
     // Delegation message
     const message = {
@@ -365,9 +369,14 @@ export class Eip7702DelegationService {
 
     const expectedChainId = chainConfig.chain.id;
 
-    // Validate authorization chainId matches expected chain
+    // Validate authorization fields
     if (Number(authorization.chainId) !== expectedChainId) {
       throw new Error(`Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`);
+    }
+    if (authorization.address.toLowerCase() !== DELEGATOR_ADDRESS.toLowerCase()) {
+      throw new Error(
+        `Authorization contract address mismatch: expected ${DELEGATOR_ADDRESS}, got ${authorization.address}`,
+      );
     }
 
     // Verify EIP-712 delegation signature
@@ -546,9 +555,14 @@ export class Eip7702DelegationService {
 
     const expectedChainId = chainConfig.chain.id;
 
-    // Validate authorization chainId matches expected chain
+    // Validate authorization fields
     if (Number(authorization.chainId) !== expectedChainId) {
       throw new Error(`Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`);
+    }
+    if (authorization.address.toLowerCase() !== DELEGATOR_ADDRESS.toLowerCase()) {
+      throw new Error(
+        `Authorization contract address mismatch: expected ${DELEGATOR_ADDRESS}, got ${authorization.address}`,
+      );
     }
 
     // Verify EIP-712 delegation signature
@@ -828,27 +842,8 @@ export class Eip7702DelegationService {
       signature: '0x' as Hex,
     };
 
-    // EIP-712 typed data for delegation signing
-    const domain = {
-      name: 'DelegationManager',
-      version: '1',
-      chainId: chainId,
-      verifyingContract: DELEGATION_MANAGER_ADDRESS,
-    };
-
-    const types = {
-      Delegation: [
-        { name: 'delegate', type: 'address' },
-        { name: 'delegator', type: 'address' },
-        { name: 'authority', type: 'bytes32' },
-        { name: 'caveats', type: 'Caveat[]' },
-        { name: 'salt', type: 'uint256' },
-      ],
-      Caveat: [
-        { name: 'enforcer', type: 'address' },
-        { name: 'terms', type: 'bytes' },
-      ],
-    };
+    const domain = getDelegationEip712Domain(chainId);
+    const types = DELEGATION_EIP712_TYPES;
 
     const message = {
       delegate: delegation.delegate,
@@ -921,25 +916,8 @@ export class Eip7702DelegationService {
     expectedSigner: string,
   ): Promise<void> {
     const recoveredAddress = await recoverTypedDataAddress({
-      domain: {
-        name: 'DelegationManager',
-        version: '1',
-        chainId,
-        verifyingContract: DELEGATION_MANAGER_ADDRESS,
-      },
-      types: {
-        Delegation: [
-          { name: 'delegate', type: 'address' },
-          { name: 'delegator', type: 'address' },
-          { name: 'authority', type: 'bytes32' },
-          { name: 'caveats', type: 'Caveat[]' },
-          { name: 'salt', type: 'uint256' },
-        ],
-        Caveat: [
-          { name: 'enforcer', type: 'address' },
-          { name: 'terms', type: 'bytes' },
-        ],
-      },
+      domain: getDelegationEip712Domain(chainId),
+      types: DELEGATION_EIP712_TYPES,
       primaryType: 'Delegation',
       message: {
         delegate: signedDelegation.delegate as Address,

--- a/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
+++ b/src/integration/blockchain/shared/evm/delegation/eip7702-delegation.service.ts
@@ -13,8 +13,10 @@ import {
   Hex,
   http,
   parseAbi,
+  recoverTypedDataAddress,
 } from 'viem';
 import { privateKeyToAccount, signTypedData } from 'viem/accounts';
+import { recoverAuthorizationAddress } from 'viem/utils';
 import { WalletAccount } from '../domain/wallet-account';
 import { EvmUtil } from '../evm.util';
 import DELEGATION_MANAGER_ABI from './delegation-manager.abi.json';
@@ -63,6 +65,24 @@ interface Delegation {
 export class Eip7702DelegationService {
   private readonly logger = new DfxLogger(Eip7702DelegationService);
   private readonly config = GetConfig().blockchain;
+
+  // Sequential lock for relayer nonce management (prevents concurrent nonce collisions)
+  private nonceLock: Promise<void> = Promise.resolve();
+
+  private async withNonceLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void;
+    const lock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previousLock = this.nonceLock;
+    this.nonceLock = lock;
+    await previousLock;
+    try {
+      return await fn();
+    } finally {
+      release!();
+    }
+  }
 
   /**
    * Check if delegation is enabled and supported for the given blockchain
@@ -343,6 +363,21 @@ export class Eip7702DelegationService {
       throw new Error(`No chain config found for ${blockchain}`);
     }
 
+    const expectedChainId = chainConfig.chain.id;
+
+    // Validate authorization chainId matches expected chain
+    if (Number(authorization.chainId) !== expectedChainId) {
+      throw new Error(
+        `Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`,
+      );
+    }
+
+    // Verify EIP-712 delegation signature
+    await this.verifyDelegationSignature(signedDelegation, expectedChainId, userAddress);
+
+    // Verify EIP-7702 authorization signature
+    await this.verifyAuthorizationSignature(authorization, userAddress);
+
     // Get relayer account
     const relayerPrivateKey = this.getRelayerPrivateKey(blockchain);
     const relayerAccount = privateKeyToAccount(relayerPrivateKey);
@@ -423,10 +458,6 @@ export class Eip7702DelegationService {
         `(gasLimit: ${gasLimit}, estimatedCost: ~${estimatedGasCost} native)`,
     );
 
-    // Get nonce and chain ID
-    const nonce = await publicClient.getTransactionCount({ address: relayerAccount.address });
-    const chainId = await publicClient.getChainId();
-
     // Convert authorization to Viem format
     const viemAuthorization = {
       chainId: BigInt(authorization.chainId),
@@ -437,31 +468,47 @@ export class Eip7702DelegationService {
       yParity: authorization.yParity,
     };
 
-    // Manually construct complete transaction to bypass viem's gas validation
-    const transaction = {
-      from: relayerAccount.address as Address,
-      to: DELEGATION_MANAGER_ADDRESS,
-      data: redeemData,
-      value: 0n,
-      nonce,
-      chainId,
-      gas: gasLimit,
-      maxFeePerGas,
-      maxPriorityFeePerGas,
-      authorizationList: [viemAuthorization],
-      type: 'eip7702' as const,
-    };
+    // Sign, broadcast and confirm within nonce lock to prevent concurrent nonce collisions
+    return this.withNonceLock(async () => {
+      const nonce = await publicClient.getTransactionCount({
+        address: relayerAccount.address,
+        blockTag: 'pending',
+      });
+      const chainId = await publicClient.getChainId();
 
-    // Sign and broadcast transaction
-    const signedTx = await walletClient.signTransaction(transaction as any);
-    const txHash = await walletClient.sendRawTransaction({ serializedTransaction: signedTx as `0x${string}` });
+      const transaction = {
+        from: relayerAccount.address as Address,
+        to: DELEGATION_MANAGER_ADDRESS,
+        data: redeemData,
+        value: 0n,
+        nonce,
+        chainId,
+        gas: gasLimit,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        authorizationList: [viemAuthorization],
+        type: 'eip7702' as const,
+      };
 
-    this.logger.info(
-      `BrokerBot sell successful on ${blockchain}: ` +
-        `${realuAmount} REALU -> ZCHF to ${dfxDepositAddress} | TX: ${txHash}`,
-    );
+      const signedTx = await walletClient.signTransaction(transaction as any);
+      const txHash = await walletClient.sendRawTransaction({ serializedTransaction: signedTx as `0x${string}` });
 
-    return txHash;
+      this.logger.info(
+        `BrokerBot sell broadcast on ${blockchain}: ` +
+          `${realuAmount} REALU -> ZCHF to ${dfxDepositAddress} | TX: ${txHash}`,
+      );
+
+      // Wait for on-chain confirmation before returning
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, timeout: 60_000 });
+
+      if (receipt.status === 'reverted') {
+        throw new Error(`Transaction reverted on-chain: ${txHash}`);
+      }
+
+      this.logger.info(`BrokerBot sell confirmed on ${blockchain}: TX ${txHash} (block ${receipt.blockNumber})`);
+
+      return txHash;
+    });
   }
 
   /**
@@ -498,6 +545,21 @@ export class Eip7702DelegationService {
     if (!chainConfig) {
       throw new Error(`No chain config found for ${blockchain}`);
     }
+
+    const expectedChainId = chainConfig.chain.id;
+
+    // Validate authorization chainId matches expected chain
+    if (Number(authorization.chainId) !== expectedChainId) {
+      throw new Error(
+        `Authorization chainId mismatch: expected ${expectedChainId}, got ${authorization.chainId}`,
+      );
+    }
+
+    // Verify EIP-712 delegation signature
+    await this.verifyDelegationSignature(signedDelegation, expectedChainId, userAddress);
+
+    // Verify EIP-7702 authorization signature
+    await this.verifyAuthorizationSignature(authorization, userAddress);
 
     // Get relayer account
     const relayerPrivateKey = this.getRelayerPrivateKey(blockchain);
@@ -564,45 +626,57 @@ export class Eip7702DelegationService {
         `from ${userAddress} to ${recipient} (gasLimit: ${gasLimit}, estimatedCost: ~${estimatedGasCost} native)`,
     );
 
-    // Get nonce and chain ID
-    const nonce = await publicClient.getTransactionCount({ address: relayerAccount.address });
-    const chainId = await publicClient.getChainId();
-
     // Convert authorization to Viem format
     const viemAuthorization = {
       chainId: BigInt(authorization.chainId),
-      address: authorization.address as Address, // CRITICAL: Must be 'address', not 'contractAddress'
+      address: authorization.address as Address,
       nonce: BigInt(authorization.nonce),
       r: authorization.r as Hex,
       s: authorization.s as Hex,
       yParity: authorization.yParity,
     };
 
-    // Manually construct complete transaction to bypass viem's gas validation
-    const transaction = {
-      from: relayerAccount.address as Address,
-      to: DELEGATION_MANAGER_ADDRESS,
-      data: redeemData,
-      value: 0n, // No ETH transfer
-      nonce,
-      chainId,
-      gas: gasLimit,
-      maxFeePerGas,
-      maxPriorityFeePerGas,
-      authorizationList: [viemAuthorization],
-      type: 'eip7702' as const,
-    };
+    // Sign, broadcast and confirm within nonce lock to prevent concurrent nonce collisions
+    return this.withNonceLock(async () => {
+      const nonce = await publicClient.getTransactionCount({
+        address: relayerAccount.address,
+        blockTag: 'pending',
+      });
+      const chainId = await publicClient.getChainId();
 
-    // Sign and broadcast transaction
-    const signedTx = await walletClient.signTransaction(transaction as any);
-    const txHash = await walletClient.sendRawTransaction({ serializedTransaction: signedTx as `0x${string}` });
+      const transaction = {
+        from: relayerAccount.address as Address,
+        to: DELEGATION_MANAGER_ADDRESS,
+        data: redeemData,
+        value: 0n,
+        nonce,
+        chainId,
+        gas: gasLimit,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        authorizationList: [viemAuthorization],
+        type: 'eip7702' as const,
+      };
 
-    this.logger.info(
-      `User delegation transfer successful on ${blockchain}: ` +
-        `${amount} ${token.name} to ${recipient} | TX: ${txHash}`,
-    );
+      const signedTx = await walletClient.signTransaction(transaction as any);
+      const txHash = await walletClient.sendRawTransaction({ serializedTransaction: signedTx as `0x${string}` });
 
-    return txHash;
+      this.logger.info(
+        `User delegation transfer broadcast on ${blockchain}: ` +
+          `${amount} ${token.name} to ${recipient} | TX: ${txHash}`,
+      );
+
+      // Wait for on-chain confirmation before returning
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, timeout: 60_000 });
+
+      if (receipt.status === 'reverted') {
+        throw new Error(`Transaction reverted on-chain: ${txHash}`);
+      }
+
+      this.logger.info(`User delegation transfer confirmed on ${blockchain}: TX ${txHash} (block ${receipt.blockNumber})`);
+
+      return txHash;
+    });
   }
 
   /**
@@ -838,6 +912,77 @@ export class Eip7702DelegationService {
       ],
       [encodedDelegations],
     );
+  }
+
+  /**
+   * Verify EIP-712 delegation signature was signed by the expected user
+   */
+  private async verifyDelegationSignature(
+    signedDelegation: { delegate: string; delegator: string; authority: string; salt: string; signature: string },
+    chainId: number,
+    expectedSigner: string,
+  ): Promise<void> {
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: {
+        name: 'DelegationManager',
+        version: '1',
+        chainId,
+        verifyingContract: DELEGATION_MANAGER_ADDRESS,
+      },
+      types: {
+        Delegation: [
+          { name: 'delegate', type: 'address' },
+          { name: 'delegator', type: 'address' },
+          { name: 'authority', type: 'bytes32' },
+          { name: 'caveats', type: 'Caveat[]' },
+          { name: 'salt', type: 'uint256' },
+        ],
+        Caveat: [
+          { name: 'enforcer', type: 'address' },
+          { name: 'terms', type: 'bytes' },
+        ],
+      },
+      primaryType: 'Delegation',
+      message: {
+        delegate: signedDelegation.delegate as Address,
+        delegator: signedDelegation.delegator as Address,
+        authority: signedDelegation.authority as Hex,
+        caveats: [],
+        salt: BigInt(signedDelegation.salt),
+      },
+      signature: signedDelegation.signature as Hex,
+    });
+
+    if (recoveredAddress.toLowerCase() !== expectedSigner.toLowerCase()) {
+      throw new Error(
+        `Invalid delegation signature: recovered ${recoveredAddress}, expected ${expectedSigner}`,
+      );
+    }
+  }
+
+  /**
+   * Verify EIP-7702 authorization signature was signed by the expected user
+   */
+  private async verifyAuthorizationSignature(
+    authorization: Eip7702Authorization,
+    expectedSigner: string,
+  ): Promise<void> {
+    const recoveredAddress = await recoverAuthorizationAddress({
+      authorization: {
+        chainId: Number(authorization.chainId),
+        address: authorization.address as Address,
+        nonce: Number(authorization.nonce),
+        r: authorization.r as Hex,
+        s: authorization.s as Hex,
+        yParity: authorization.yParity,
+      },
+    });
+
+    if (recoveredAddress.toLowerCase() !== expectedSigner.toLowerCase()) {
+      throw new Error(
+        `Invalid authorization signature: recovered ${recoveredAddress}, expected ${expectedSigner}`,
+      );
+    }
   }
 
   /**

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -1311,23 +1311,17 @@ export class RealUnitService {
       ]);
 
       // Atomic batch: REALU -> BrokerBot -> ZCHF -> DFX Deposit
-      try {
-        txHash = await this.eip7702DelegationService.executeBrokerBotSellForRealUnit(
-          request.user.address,
-          realuAsset,
-          zchfAsset.chainId,
-          this.getBrokerbotAddress(),
-          sell.deposit.address,
-          Math.floor(request.amount),
-          zchfAmountWei,
-          dto.eip7702.delegation,
-          dto.eip7702.authorization,
-        );
-      } catch (error) {
-        const message = error?.message || error;
-        this.logger.error(`EIP-7702 sell failed for request ${requestId}: ${message}`);
-        throw new BadRequestException(`EIP-7702 delegation failed: ${message}`);
-      }
+      txHash = await this.eip7702DelegationService.executeBrokerBotSellForRealUnit(
+        request.user.address,
+        realuAsset,
+        zchfAsset.chainId,
+        this.getBrokerbotAddress(),
+        sell.deposit.address,
+        Math.floor(request.amount),
+        zchfAmountWei,
+        dto.eip7702.delegation,
+        dto.eip7702.authorization,
+      );
 
       this.logger.info(`RealUnit sell confirmed via EIP-7702: ${txHash}`);
     } else if (dto.txHash) {

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -1311,17 +1311,23 @@ export class RealUnitService {
       ]);
 
       // Atomic batch: REALU -> BrokerBot -> ZCHF -> DFX Deposit
-      txHash = await this.eip7702DelegationService.executeBrokerBotSellForRealUnit(
-        request.user.address,
-        realuAsset,
-        zchfAsset.chainId,
-        this.getBrokerbotAddress(),
-        sell.deposit.address,
-        Math.floor(request.amount),
-        zchfAmountWei,
-        dto.eip7702.delegation,
-        dto.eip7702.authorization,
-      );
+      try {
+        txHash = await this.eip7702DelegationService.executeBrokerBotSellForRealUnit(
+          request.user.address,
+          realuAsset,
+          zchfAsset.chainId,
+          this.getBrokerbotAddress(),
+          sell.deposit.address,
+          Math.floor(request.amount),
+          zchfAmountWei,
+          dto.eip7702.delegation,
+          dto.eip7702.authorization,
+        );
+      } catch (error) {
+        const message = error?.message || error;
+        this.logger.error(`EIP-7702 sell failed for request ${requestId}: ${message}`);
+        throw new BadRequestException(`EIP-7702 delegation failed: ${message}`);
+      }
 
       this.logger.info(`RealUnit sell confirmed via EIP-7702: ${txHash}`);
     } else if (dto.txHash) {


### PR DESCRIPTION
## Summary

Closes #3672

Security hardening of the EIP-7702 delegation flow for RealUnit sells:

- **Signature verification**: Cryptographic verification of EIP-712 delegation signature (`recoverTypedDataAddress`) and EIP-7702 authorization signature (`recoverAuthorizationAddress`) before broadcasting — prevents gas drain via garbage signatures
- **ChainId validation**: Authorization `chainId` is validated against expected blockchain before any processing
- **Receipt confirmation**: `waitForTransactionReceipt` (60s timeout) after broadcast — request is only marked complete if the transaction succeeds on-chain
- **Nonce lock**: Sequential lock (`withNonceLock`) around nonce fetch + sign + broadcast prevents concurrent nonce collisions; uses `blockTag: 'pending'` for pending-aware nonce queries
- Both `_executeBrokerBotSellInternal` and `_transferTokenWithUserDelegationInternal` are hardened

## Test plan

- [x] TypeScript compiles without errors
- [x] All 27 EIP-7702 tests pass (including 4 new tests)
- [ ] New tests cover: invalid delegation signature, invalid authorization signature, chainId mismatch, on-chain revert
- [ ] Manual test on Sepolia with RealUnit app