### PR TITLE
feat(payment-link): add urble wallet app

### DIFF
--- a/migration/1777985314136-AddUrbleWalletApp.js
+++ b/migration/1777985314136-AddUrbleWalletApp.js
@@ -5,9 +5,10 @@ module.exports = class AddUrbleWalletApp1777985314136 {
     await queryRunner.query(`
       IF NOT EXISTS (SELECT 1 FROM "dbo"."wallet_app" WHERE "name" = 'urble')
       INSERT INTO "dbo"."wallet_app" (
-        "name", "websiteUrl", "iconUrl", "deepLink", "blockchains", "active"
+        "name", "websiteUrl", "iconUrl", "deepLink", "blockchains", "assets", "active"
       ) VALUES (
-        'urble', 'https://urble.io', 'https://dfx.swiss/images/app/urble.webp', 'urble:', 'Bitcoin;Cardano', 1
+        'urble', 'https://urble.io', 'https://dfx.swiss/images/app/urble.webp', 'urble:',
+        'Bitcoin;Cardano;Ethereum', '113;406;123;145;337', 1
       )
     `);
   }

--- a/migration/1777985314136-AddUrbleWalletApp.js
+++ b/migration/1777985314136-AddUrbleWalletApp.js
@@ -1,0 +1,18 @@
+module.exports = class AddUrbleWalletApp1777985314136 {
+  name = 'AddUrbleWalletApp1777985314136';
+
+  async up(queryRunner) {
+    await queryRunner.query(`
+      IF NOT EXISTS (SELECT 1 FROM "dbo"."wallet_app" WHERE "name" = 'urble')
+      INSERT INTO "dbo"."wallet_app" (
+        "name", "websiteUrl", "iconUrl", "deepLink", "blockchains", "active"
+      ) VALUES (
+        'urble', 'https://urble.io', 'https://dfx.swiss/images/app/urble.webp', 'urble:', 'Bitcoin;Cardano', 1
+      )
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`DELETE FROM "dbo"."wallet_app" WHERE "name" = 'urble'`);
+  }
+};


### PR DESCRIPTION
## Summary
- Adds new wallet app **urble** to the payment link wallet list
- Supports Bitcoin and Cardano, deep link `urble:`
- Logo expected at `https://dfx.swiss/images/app/urble.webp` (separate landing-page change)

## Test plan
- [ ] Migration runs without error against develop DB
- [ ] `GET /v1/paymentLink/walletApp` returns urble entry
- [ ] urble appears in "Other apps" section on /pl pages
- [ ] Logo loads correctly once landing-page asset is deployed