### PR TITLE
feat(payment-link): enable ADA payments on Cardano

### DIFF
--- a/migration/1777989917652-EnableCardanoPayment.js
+++ b/migration/1777989917652-EnableCardanoPayment.js
@@ -1,0 +1,11 @@
+module.exports = class EnableCardanoPayment1777989917652 {
+  name = 'EnableCardanoPayment1777989917652';
+
+  async up(queryRunner) {
+    await queryRunner.query(`UPDATE "dbo"."asset" SET "paymentEnabled" = 1 WHERE "uniqueName" = 'Cardano/ADA'`);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`UPDATE "dbo"."asset" SET "paymentEnabled" = 0 WHERE "uniqueName" = 'Cardano/ADA'`);
+  }
+};


### PR DESCRIPTION
## Summary
- Sets `paymentEnabled = 1` on `Cardano/ADA` asset so it surfaces in payment-link `transferAmounts`
- Required for urble (and other Cardano-supporting wallets) to accept ADA at merchant payment pages like SPAR

## Test plan
- [ ] Migration runs without error
- [ ] `GET /v1/paymentLink/payment?route=SPAR&...` returns Cardano in `transferAmounts`
- [ ] urble wallet detail on /pl shows ADA as payment option