### PR TITLE
fix: stop buy-crypto transactions for blocked/deleted users to unblock batch completion

### DIFF
--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -520,7 +520,6 @@ export class BuyCrypto extends IEntity {
   stop(): UpdateResult<BuyCrypto> {
     const update: Partial<BuyCrypto> = {
       status: BuyCryptoStatus.STOPPED,
-      isComplete: true,
     };
 
     Object.assign(this, update);

--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -517,6 +517,17 @@ export class BuyCrypto extends IEntity {
     return [this.id, update];
   }
 
+  stop(): UpdateResult<BuyCrypto> {
+    const update: Partial<BuyCrypto> = {
+      status: BuyCryptoStatus.STOPPED,
+      isComplete: true,
+    };
+
+    Object.assign(this, update);
+
+    return [this.id, update];
+  }
+
   complete(payoutFee: number): UpdateResult<BuyCrypto> {
     const update: Partial<BuyCrypto> = {
       outputDate: new Date(),

--- a/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
+++ b/src/subdomains/core/buy-crypto/process/entities/buy-crypto.entity.ts
@@ -517,9 +517,10 @@ export class BuyCrypto extends IEntity {
     return [this.id, update];
   }
 
-  stop(): UpdateResult<BuyCrypto> {
+  stop(amlReason?: AmlReason): UpdateResult<BuyCrypto> {
     const update: Partial<BuyCrypto> = {
       status: BuyCryptoStatus.STOPPED,
+      ...(amlReason && { amlCheck: CheckStatus.FAIL, amlReason }),
     };
 
     Object.assign(this, update);

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
@@ -17,6 +17,7 @@ import { PayoutService } from 'src/subdomains/supporting/payout/services/payout.
 import { PriceValidity, PricingService } from 'src/subdomains/supporting/pricing/services/pricing.service';
 import { In } from 'typeorm';
 import { AmlReason } from '../../../aml/enums/aml-reason.enum';
+import { UserStatus } from '../../../../generic/user/models/user/user.enum';
 import { BuyCryptoBatch, BuyCryptoBatchStatus } from '../entities/buy-crypto-batch.entity';
 import { BuyCrypto, BuyCryptoStatus } from '../entities/buy-crypto.entity';
 import { BuyCryptoBatchRepository } from '../repositories/buy-crypto-batch.repository';
@@ -266,7 +267,7 @@ export class BuyCryptoOutService {
 
   private getBlockedAmlReason(tx: BuyCrypto): AmlReason {
     if (tx.user.isBlockedOrDeleted)
-      return tx.user.status === 'Deleted' ? AmlReason.USER_DELETED : AmlReason.USER_BLOCKED;
+      return tx.user.status === UserStatus.DELETED ? AmlReason.USER_DELETED : AmlReason.USER_BLOCKED;
     if (tx.userData.isBlocked) return AmlReason.USER_DATA_BLOCKED;
 
     return AmlReason.USER_BLOCKED;

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
@@ -250,7 +250,7 @@ export class BuyCryptoOutService {
       }
     }
 
-    const isBatchComplete = batch.transactions.every((tx) => tx.isComplete);
+    const isBatchComplete = batch.transactions.every((tx) => tx.isComplete || tx.status === BuyCryptoStatus.STOPPED);
 
     if (isBatchComplete) {
       this.logger.verbose(`Buy-crypto payout complete (batch ID: ${batch.id})`);

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
@@ -16,6 +16,7 @@ import { PayoutRequest } from 'src/subdomains/supporting/payout/interfaces';
 import { PayoutService } from 'src/subdomains/supporting/payout/services/payout.service';
 import { PriceValidity, PricingService } from 'src/subdomains/supporting/pricing/services/pricing.service';
 import { In } from 'typeorm';
+import { AmlReason } from '../../../aml/enums/aml-reason.enum';
 import { BuyCryptoBatch, BuyCryptoBatchStatus } from '../entities/buy-crypto-batch.entity';
 import { BuyCrypto, BuyCryptoStatus } from '../entities/buy-crypto.entity';
 import { BuyCryptoBatchRepository } from '../repositories/buy-crypto-batch.repository';
@@ -82,9 +83,10 @@ export class BuyCryptoOutService {
             transaction.userData.isRiskBlocked ||
             transaction.userData.isRiskBuyCryptoBlocked
           ) {
-            this.logger.warn(`Stopping payout for transaction ${transaction.id}: user is blocked or deleted`);
+            const reason = this.getBlockedAmlReason(transaction);
+            this.logger.warn(`Stopping payout for transaction ${transaction.id}: ${reason}`);
 
-            transaction.stop();
+            transaction.stop(reason);
             await this.buyCryptoRepo.save(transaction);
             continue;
           }
@@ -182,9 +184,10 @@ export class BuyCryptoOutService {
         tx.userData.isRiskBlocked ||
         tx.userData.isRiskBuyCryptoBlocked
       ) {
-        this.logger.warn(`Stopping transaction ${tx.id} in batch ${batch.id}: user is blocked or deleted`);
+        const reason = this.getBlockedAmlReason(tx);
+        this.logger.warn(`Stopping transaction ${tx.id} in batch ${batch.id}: ${reason}`);
 
-        tx.stop();
+        tx.stop(reason);
         await this.buyCryptoRepo.save(tx);
         continue;
       }
@@ -259,6 +262,14 @@ export class BuyCryptoOutService {
       await this.buyCryptoBatchRepo.save(batch);
       await this.dexService.completeOrders(LiquidityOrderContext.BUY_CRYPTO, batch.id.toString());
     }
+  }
+
+  private getBlockedAmlReason(tx: BuyCrypto): AmlReason {
+    if (tx.user.isBlockedOrDeleted)
+      return tx.user.status === 'Deleted' ? AmlReason.USER_DELETED : AmlReason.USER_BLOCKED;
+    if (tx.userData.isBlocked) return AmlReason.USER_DATA_BLOCKED;
+
+    return AmlReason.USER_BLOCKED;
   }
 
   //*** LOGS ***//

--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto-out.service.ts
@@ -81,8 +81,13 @@ export class BuyCryptoOutService {
             transaction.userData.isBlocked ||
             transaction.userData.isRiskBlocked ||
             transaction.userData.isRiskBuyCryptoBlocked
-          )
-            throw new Error('Payout stopped for blocked user');
+          ) {
+            this.logger.warn(`Stopping payout for transaction ${transaction.id}: user is blocked or deleted`);
+
+            transaction.stop();
+            await this.buyCryptoRepo.save(transaction);
+            continue;
+          }
 
           await this.doPayout(transaction);
           successfulRequests.push(transaction);
@@ -167,6 +172,20 @@ export class BuyCryptoOutService {
   private async checkCompletion(batch: BuyCryptoBatch) {
     for (const tx of batch.transactions) {
       if (tx.isComplete) {
+        continue;
+      }
+
+      // stop transactions for blocked/deleted users to unblock batch completion
+      if (
+        tx.user.isBlockedOrDeleted ||
+        tx.userData.isBlocked ||
+        tx.userData.isRiskBlocked ||
+        tx.userData.isRiskBuyCryptoBlocked
+      ) {
+        this.logger.warn(`Stopping transaction ${tx.id} in batch ${batch.id}: user is blocked or deleted`);
+
+        tx.stop();
+        await this.buyCryptoRepo.save(tx);
         continue;
       }
 

--- a/src/subdomains/supporting/fiat-output/__tests__/fiat-output-job.service.spec.ts
+++ b/src/subdomains/supporting/fiat-output/__tests__/fiat-output-job.service.spec.ts
@@ -13,6 +13,7 @@ import { TestSharedModule } from 'src/shared/utils/test.shared.module';
 import { TestUtil } from 'src/shared/utils/test.util';
 import { createCustomBuyCrypto } from 'src/subdomains/core/buy-crypto/process/entities/__mocks__/buy-crypto.entity.mock';
 import { createCustomLiquidityBalance } from 'src/subdomains/core/liquidity-management/__mocks__/liquidity-balance.entity.mock';
+import { BuyFiatRepository } from 'src/subdomains/core/sell-crypto/process/buy-fiat.repository';
 import { createCustomBuyFiat } from 'src/subdomains/core/sell-crypto/process/__mocks__/buy-fiat.entity.mock';
 import { createCustomSell } from 'src/subdomains/core/sell-crypto/route/__mocks__/sell.entity.mock';
 import { BankTxService } from 'src/subdomains/supporting/bank-tx/bank-tx/services/bank-tx.service';
@@ -74,6 +75,7 @@ describe('FiatOutputJobService', () => {
       providers: [
         FiatOutputJobService,
         { provide: FiatOutputRepository, useValue: fiatOutputRepo },
+        { provide: BuyFiatRepository, useValue: createMock<BuyFiatRepository>() },
         { provide: BankTxService, useValue: bankTxService },
         { provide: Ep2ReportService, useValue: ep2ReportService },
         { provide: CountryService, useValue: countryService },

--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -28,6 +28,7 @@ import { VirtualIbanService } from '../bank/virtual-iban/virtual-iban.service';
 import { AmlReason } from 'src/subdomains/core/aml/enums/aml-reason.enum';
 import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
 import { BuyFiatRepository } from 'src/subdomains/core/sell-crypto/process/buy-fiat.repository';
+import { UserStatus } from 'src/subdomains/generic/user/models/user/user.enum';
 import { LogService } from '../log/log.service';
 import { Ep2ReportService } from './ep2-report.service';
 import { FiatOutput, FiatOutputType } from './fiat-output.entity';
@@ -245,7 +246,11 @@ export class FiatOutputJobService {
             (entity.user?.isBlockedOrDeleted || entity.userData?.isBlocked) &&
             entity.type === FiatOutputType.BUY_FIAT
           ) {
-            const reason = entity.user?.isBlockedOrDeleted ? AmlReason.USER_BLOCKED : AmlReason.USER_DATA_BLOCKED;
+            const reason = entity.user?.isBlockedOrDeleted
+              ? entity.user.status === UserStatus.DELETED
+                ? AmlReason.USER_DELETED
+                : AmlReason.USER_BLOCKED
+              : AmlReason.USER_DATA_BLOCKED;
 
             for (const buyFiat of entity.buyFiats ?? []) {
               await this.buyFiatRepo.update(buyFiat.id, { amlCheck: CheckStatus.FAIL, amlReason: reason });

--- a/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
+++ b/src/subdomains/supporting/fiat-output/fiat-output-job.service.ts
@@ -25,6 +25,9 @@ import { Bank } from '../bank/bank/bank.entity';
 import { BankService } from '../bank/bank/bank.service';
 import { IbanBankName } from '../bank/bank/dto/bank.dto';
 import { VirtualIbanService } from '../bank/virtual-iban/virtual-iban.service';
+import { AmlReason } from 'src/subdomains/core/aml/enums/aml-reason.enum';
+import { CheckStatus } from 'src/subdomains/core/aml/enums/check-status.enum';
+import { BuyFiatRepository } from 'src/subdomains/core/sell-crypto/process/buy-fiat.repository';
 import { LogService } from '../log/log.service';
 import { Ep2ReportService } from './ep2-report.service';
 import { FiatOutput, FiatOutputType } from './fiat-output.entity';
@@ -36,6 +39,7 @@ export class FiatOutputJobService {
 
   constructor(
     private readonly fiatOutputRepo: FiatOutputRepository,
+    private readonly buyFiatRepo: BuyFiatRepository,
     @Inject(forwardRef(() => BankTxService))
     private readonly bankTxService: BankTxService,
     private readonly ep2ReportService: Ep2ReportService,
@@ -240,8 +244,16 @@ export class FiatOutputJobService {
           if (
             (entity.user?.isBlockedOrDeleted || entity.userData?.isBlocked) &&
             entity.type === FiatOutputType.BUY_FIAT
-          )
-            throw new Error('Payout stopped for blocked user');
+          ) {
+            const reason = entity.user?.isBlockedOrDeleted ? AmlReason.USER_BLOCKED : AmlReason.USER_DATA_BLOCKED;
+
+            for (const buyFiat of entity.buyFiats ?? []) {
+              await this.buyFiatRepo.update(buyFiat.id, { amlCheck: CheckStatus.FAIL, amlReason: reason });
+            }
+
+            this.logger.warn(`Stopping fiat output ${entity.id}: user is blocked or deleted (${reason})`);
+            continue;
+          }
           if (entity.originEntity && (!entity.originEntity.amountInChf || !entity.originEntity.amountInEur)) continue;
 
           const asset = assets.find((a) => a.bank.iban === entity.sourceIban);

--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -96,7 +96,7 @@ export class TransactionService {
     if (entity.buyCrypto.status === BuyCryptoStatus.STOPPED)
       throw new BadRequestException('Transaction is already stopped');
 
-    entity.buyCrypto.status = BuyCryptoStatus.STOPPED;
+    entity.buyCrypto.stop();
     await this.buyCryptoRepo.save(entity.buyCrypto);
   }
 


### PR DESCRIPTION
## Problem

A race condition in the buy-crypto payout pipeline causes **permanent deadlocks** when a user is deleted or blocked after their transaction has been added to a payout batch. The same issue affects the fiat-output pipeline (sell-crypto).

### Incident: Monero pipeline blocked for 18+ hours

On 2026-05-06, a single deleted user blocked the entire XMR payout pipeline:

| Time | Event |
|------|-------|
| 17:26:36 | BuyCrypto `121819` created (67 EUR → 0.1769 XMR, user `399153`, userData `392122`) |
| **17:41:00** | **User `399153` deleted** (between transaction creation and payout) |
| 17:44:15 | Batch `61024` created, both TX `121817` and `121819` set to `ReadyForPayout` |
| 17:44:17 | Payout loop: TX `121817` (user active) → PayoutOrder created ✅ |
| 17:44:17 | Payout loop: TX `121819` → `user.isBlockedOrDeleted = true` → `throw Error` → caught → **skipped** ❌ |
| 17:48:20 | TX `121817` completes normally |
| **18+ hours** | **TX `121819` stuck in ReadyForPayout, no PayoutOrder ever created** |

**Result:** 33 XMR transactions (~2,730 EUR) from different users were blocked and could not be processed.

### Root cause (buy-crypto)

```
1. payoutTransactions() detects blocked user → throws error → caught → continues
   → No PayoutOrder created, transaction stays in ReadyForPayout

2. checkCompletion() calls checkOrderCompletion() for TX without PayoutOrder → throws
   → tx.isComplete stays false

3. Batch completion requires: batch.transactions.every(tx => tx.isComplete)
   → batch stays in PayingOut → per-asset lock blocks ALL new batches

4. All new XMR transactions stay in Created status indefinitely
```

### Root cause (fiat-output)

The same pattern exists in `setReadyDate()`: a blocked user causes a `throw` that is caught and logged every minute, without ever resolving the fiat output. The linked BuyFiat entities never get their `amlCheck` set to `Fail`, preventing the chargeback process from returning the crypto.

## Solution

### 1. `stop()` method on `BuyCrypto` entity with AML reason

Sets `status = STOPPED` and optionally `amlCheck = Fail` with the appropriate `AmlReason`:
- `USER_DELETED` — user account deleted
- `USER_BLOCKED` — user account blocked
- `USER_DATA_BLOCKED` — userData blocked or risk-blocked

Does **not** set `isComplete` — reserved exclusively for confirmed on-chain payouts.

### 2. Buy-crypto payout: stop and trigger chargeback (prevention + recovery)

- **Payout loop**: Stops blocked/deleted user transactions immediately with `amlCheck = Fail`
- **checkCompletion()**: Detects and stops stuck transactions in existing batches
- **Batch completion**: Accepts `STOPPED` transactions alongside `isComplete`

### 3. Fiat-output: set `amlCheck = Fail` on BuyFiat entities (sell-crypto chargeback)

Instead of throwing (and repeating every minute), the blocked user's linked BuyFiat entities get `amlCheck = Fail` with the appropriate reason. This triggers the existing sell-crypto chargeback flow to return the crypto.

### 4. Consistency: use entity method in transaction service

The existing `TransactionService.stop()` set status directly. Updated to use the entity `stop()` method.

## Files changed

| File | Change |
|------|--------|
| `buy-crypto.entity.ts` | `stop()` accepts optional `amlReason`, sets `amlCheck = Fail` |
| `buy-crypto-out.service.ts` | Blocked user handling with AML reason in payout loop + checkCompletion, batch completion accepts STOPPED |
| `fiat-output-job.service.ts` | Set `amlCheck = Fail` on BuyFiat for blocked users instead of throwing |
| `transaction.service.ts` | Use entity `stop()` method |

## Verified: no side effects

- **Notification service**: Queries filter on `status: COMPLETE` or `amlCheck: PENDING` — no false matches
- **Preparation service**: Already excludes `STOPPED` in `refreshFee()` and `fillPaymentLinkPayments()`; `amlCheck = Fail` prevents re-processing
- **History/DTO mapping**: Already maps `STOPPED` to `TransactionState.STOPPED`

## Test plan

- [ ] Deploy to DEV
- [ ] Verify batch `61024` completes automatically (TX `121819` gets stopped with `amlCheck = Fail`)
- [ ] Verify the 33 pending XMR transactions start flowing through the pipeline
- [ ] Verify stopped transactions have `amlCheck = Fail` with correct `amlReason`
- [ ] Verify normal (non-blocked user) payout flow is unaffected
- [ ] Verify fiat-output blocked users get `amlCheck = Fail` on linked BuyFiats
- [ ] Verify `isComplete` remains `false` for stopped transactions