### PR TITLE
fix(support): compliance reviewer feedback (api side)

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -47,6 +47,21 @@ export class PendingOnboardingInfo {
   date: Date;
 }
 
+export class PendingTransactionInfo {
+  txId: number;
+  uid: string;
+  sourceType: 'BuyCrypto' | 'BuyFiat';
+  userDataId: number;
+  userName?: string;
+  accountType?: string;
+  kycLevel?: number;
+  inputAmount?: number;
+  inputAsset?: string;
+  amlCheck?: CheckStatus;
+  amlReason?: AmlReason;
+  date: Date;
+}
+
 export enum PendingReviewType {
   KYC_STEP = 'KycStep',
   BANK_DATA = 'BankData',
@@ -193,6 +208,15 @@ export class KycLogSupportInfo {
   created: Date;
 }
 
+export class BankDataAlternative {
+  id: number;
+  userDataId: number;
+  name?: string;
+  verifiedName?: string;
+  accountType?: string;
+  type?: string;
+}
+
 export class BankDataSupportInfo {
   id: number;
   iban: string;
@@ -204,6 +228,7 @@ export class BankDataSupportInfo {
   active: boolean;
   comment?: string;
   created: Date;
+  alternatives?: BankDataAlternative[];
 }
 
 export class BuySupportInfo {

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -29,6 +29,7 @@ import {
   KycFileListEntry,
   KycFileYearlyStats,
   PendingOnboardingInfo,
+  PendingTransactionInfo,
   PendingReviewItem,
   PendingReviewSummaryEntry,
   PendingReviewType,
@@ -90,6 +91,14 @@ export class SupportController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getPendingOnboardings(): Promise<PendingOnboardingInfo[]> {
     return this.supportService.getPendingOnboardings();
+  }
+
+  @Get('pending-transactions')
+  @ApiBearerAuth()
+  @ApiExcludeEndpoint()
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
+  async getPendingTransactions(): Promise<PendingTransactionInfo[]> {
+    return this.supportService.getPendingTransactions();
   }
 
   @Get('pending-reviews')

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -71,6 +71,7 @@ import { UserService } from '../user/models/user/user.service';
 import { ComplianceDecision, GenerateOnboardingPdfDto } from './dto/onboarding-pdf.dto';
 import { TransactionListQuery } from './dto/transaction-list-query.dto';
 import {
+  BankDataAlternative,
   BankDataSupportInfo,
   BankTxSupportInfo,
   BuySupportInfo,
@@ -87,6 +88,7 @@ import {
   NotificationSupportInfo,
   OnboardingStatus,
   PendingOnboardingInfo,
+  PendingTransactionInfo,
   PendingReviewItem,
   PendingReviewSummaryEntry,
   PendingReviewType,
@@ -327,7 +329,7 @@ export class SupportService {
       ipLogs: ipLogs?.map((l) => this.toIpLogSupportInfo(l)),
       supportIssues: supportIssues?.map((s) => this.toSupportIssueSupportInfo(s)),
       users: await this.toUserSupportInfos(users),
-      bankDatas: bankDatas.map((b) => this.toBankDataSupportInfo(b)),
+      bankDatas: await this.toBankDataSupportInfos(bankDatas),
       buyRoutes: buyRoutes.map((b) => this.toBuySupportInfo(b)),
       sellRoutes: sellRoutes.map((s) => this.toSellSupportInfo(s)),
       swapRoutes: swapRoutes.map((s) => this.toSwapSupportInfo(s)),
@@ -529,7 +531,26 @@ export class SupportService {
     });
   }
 
-  private toBankDataSupportInfo(bankData: BankData): BankDataSupportInfo {
+  private async toBankDataSupportInfos(bankDatas: BankData[]): Promise<BankDataSupportInfo[]> {
+    const alternatives = await this.bankDataService.getApprovedAlternatives(bankDatas);
+    const alternativesByIban = new Map<string, BankDataAlternative[]>();
+    for (const a of alternatives) {
+      const list = alternativesByIban.get(a.iban) ?? [];
+      list.push({
+        id: a.id,
+        userDataId: a.userData?.id,
+        name: a.name,
+        verifiedName: a.userData?.verifiedName,
+        accountType: a.userData?.accountType,
+        type: a.type,
+      });
+      alternativesByIban.set(a.iban, list);
+    }
+
+    return bankDatas.map((b) => this.toBankDataSupportInfo(b, alternativesByIban.get(b.iban)));
+  }
+
+  private toBankDataSupportInfo(bankData: BankData, alternatives?: BankDataAlternative[]): BankDataSupportInfo {
     return {
       id: bankData.id,
       iban: bankData.iban,
@@ -541,6 +562,7 @@ export class SupportService {
       active: bankData.active,
       comment: bankData.comment,
       created: bankData.created,
+      alternatives: alternatives && alternatives.length > 0 ? alternatives : undefined,
     };
   }
 
@@ -734,6 +756,41 @@ export class SupportService {
       type: searchResult.type,
       userDatas: uniqueUserDatas.map((u) => this.toUserDataDto(u, onboardingStatuses)),
       bankTx: bankTx.sort((a, b) => a.id - b.id).map((b) => this.toBankTxDto(b, recallByBankTxId.get(b.id))),
+    };
+  }
+
+  async getPendingTransactions(): Promise<PendingTransactionInfo[]> {
+    const [buyCryptos, buyFiats] = await Promise.all([
+      this.buyCryptoService.getByAmlReason(AmlReason.MANUAL_CHECK, CheckStatus.PENDING),
+      this.buyFiatService.getByAmlReason(AmlReason.MANUAL_CHECK, CheckStatus.PENDING),
+    ]);
+    const items: PendingTransactionInfo[] = [
+      ...buyCryptos.map((bc) => this.toPendingTransactionInfo(bc, 'BuyCrypto')),
+      ...buyFiats.map((bf) => this.toPendingTransactionInfo(bf, 'BuyFiat')),
+    ];
+    return items.sort((a, b) => a.date.getTime() - b.date.getTime());
+  }
+
+  private toPendingTransactionInfo(
+    tx: BuyCrypto | BuyFiat,
+    sourceType: 'BuyCrypto' | 'BuyFiat',
+  ): PendingTransactionInfo {
+    const ud = tx.userData;
+    const inputAsset =
+      sourceType === 'BuyCrypto' ? (tx as BuyCrypto).inputAsset : (tx as BuyFiat).cryptoInput?.asset?.name;
+    return {
+      txId: tx.transaction.id,
+      uid: tx.transaction.uid,
+      sourceType,
+      userDataId: ud.id,
+      userName: this.formatUserName(ud),
+      accountType: ud.accountType,
+      kycLevel: ud.kycLevel,
+      inputAmount: tx.inputAmount,
+      inputAsset,
+      amlCheck: tx.amlCheck,
+      amlReason: tx.amlReason,
+      date: tx.created,
     };
   }
 

--- a/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
+++ b/src/subdomains/generic/user/models/bank-data/bank-data.service.ts
@@ -20,7 +20,7 @@ import { BankAccountService } from 'src/subdomains/supporting/bank/bank-account/
 import { CreateBankAccountDto } from 'src/subdomains/supporting/bank/bank-account/dto/create-bank-account.dto';
 import { UpdateBankAccountDto } from 'src/subdomains/supporting/bank/bank-account/dto/update-bank-account.dto';
 import { SpecialExternalAccountService } from 'src/subdomains/supporting/payment/services/special-external-account.service';
-import { FindOptionsRelations, FindOptionsWhere, IsNull, Like, Not } from 'typeorm';
+import { FindOptionsRelations, FindOptionsWhere, In, IsNull, Like, Not } from 'typeorm';
 import { AccountMerge, MergeReason } from '../account-merge/account-merge.entity';
 import { AccountMergeService } from '../account-merge/account-merge.service';
 import { KycType, UserDataStatus } from '../user-data/user-data.enum';
@@ -300,6 +300,16 @@ export class BankDataService {
   async getBankDatasByUserData(userDataId: number): Promise<BankData[]> {
     return this.bankDataRepo.find({
       where: { userData: { id: userDataId } },
+    });
+  }
+
+  async getApprovedAlternatives(bankDatas: BankData[]): Promise<BankData[]> {
+    const ibans = [...new Set(bankDatas.map((b) => b.iban).filter(Boolean))];
+    if (ibans.length === 0) return [];
+    const ids = bankDatas.map((b) => b.id);
+    return this.bankDataRepo.find({
+      where: { iban: In(ibans), id: Not(In(ids)), approved: true },
+      relations: { userData: true },
     });
   }
 


### PR DESCRIPTION
## Summary
API-side changes that go with the services PR DFXswiss/services#1087.

### Changes
- **BankData support endpoint**: each BankData entry is now returned with `alternatives` — other approved BankData rows that share the same IBAN (different id). Compliance uses this in the BankData review to spot user collisions. Added `BankDataAlternative` DTO and `BankDataService.getApprovedAlternatives()` which fetches all alternatives in a single batched query (`In(ibans)` / `Not(In(ids))`).
- **Pending Transactions endpoint**: new `GET /support/pending-transactions` that returns BuyCrypto + BuyFiat with `amlReason=ManualCheck` and `amlCheck=Pending`. Used by the new Pending Transactions section on the compliance dashboard. Added `PendingTransactionInfo` DTO.

## Test plan
- [ ] `GET /v1/support/:id` returns each BankData with optional `alternatives` array; for entries with a same-IBAN approved counterpart at a different user, the array contains the other entry (id, userDataId, name, verifiedName, accountType, type).
- [ ] `GET /v1/support/pending-transactions` returns the expected list (matches what the AML Pending tab shows per user).
- [ ] `npm test`, `npm run lint`, `npx tsc --noEmit` remain green.