### PR TITLE
feat(gs): unmask bank_tx.iban in debug endpoint for Admin role

### DIFF
--- a/src/subdomains/generic/gs/__tests__/gs.service.spec.ts
+++ b/src/subdomains/generic/gs/__tests__/gs.service.spec.ts
@@ -23,6 +23,7 @@ import { LimitRequestService } from 'src/subdomains/supporting/support-issue/ser
 import { SupportIssueService } from 'src/subdomains/supporting/support-issue/services/support-issue.service';
 import { SwapService } from 'src/subdomains/core/buy-crypto/routes/swap/swap.service';
 import { VirtualIbanService } from 'src/subdomains/supporting/bank/virtual-iban/virtual-iban.service';
+import { UserRole } from 'src/shared/auth/user-role.enum';
 
 describe('GsService', () => {
   let service: GsService;
@@ -68,67 +69,93 @@ describe('GsService', () => {
         ['SELECT * FROM [user] FOR  XML AUTO', 'double-space bypass attempt'],
         ['SELECT * FROM [user] FOR -- comment\nXML AUTO', 'inline comment bypass attempt'],
       ])('should block: %s (%s)', async (sql) => {
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should NOT block FOR XML in string literals (no false positives)', async () => {
         jest.spyOn(dataSource, 'query').mockResolvedValue([{ label: 'FOR XML' }]);
 
-        const result = await service.executeDebugQuery("SELECT 'FOR XML' as label FROM [user]", 'test-user');
+        const result = await service.executeDebugQuery(
+          "SELECT 'FOR XML' as label FROM [user]",
+          'test-user',
+          UserRole.DEBUG,
+        );
 
         expect(result).toBeDefined();
       });
 
       it('should block FOR XML in subqueries (SELECT column)', async () => {
         const sql = "SELECT id, (SELECT name FROM items FOR XML PATH('')) as xml FROM [user]";
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in derived tables (FROM clause)', async () => {
         const sql = 'SELECT * FROM (SELECT id FROM [user] FOR XML AUTO) as t';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in HAVING clause', async () => {
         const sql =
           'SELECT COUNT(*) FROM [user] GROUP BY status HAVING (SELECT id FROM items FOR XML AUTO) IS NOT NULL';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in ORDER BY clause', async () => {
         const sql = 'SELECT * FROM [user] ORDER BY (SELECT id FROM items FOR XML AUTO)';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in JOIN ON condition', async () => {
         const sql = 'SELECT * FROM [user] u JOIN items i ON i.id = (SELECT id FOR XML AUTO)';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in CASE expression', async () => {
         const sql = 'SELECT CASE WHEN 1=1 THEN (SELECT id FOR XML AUTO) END FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in GROUP BY clause', async () => {
         const sql = 'SELECT COUNT(*) FROM [user] GROUP BY (SELECT id FOR XML AUTO)';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in WINDOW OVER ORDER BY clause', async () => {
         const sql = 'SELECT id, ROW_NUMBER() OVER (ORDER BY (SELECT id FOR XML AUTO)) FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in WINDOW OVER PARTITION BY clause', async () => {
         const sql = 'SELECT id, ROW_NUMBER() OVER (PARTITION BY (SELECT id FOR XML AUTO) ORDER BY id) FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
 
       it('should block FOR XML in COALESCE function', async () => {
         const sql = 'SELECT COALESCE((SELECT id FOR XML AUTO), 1) FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('FOR XML/JSON not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'FOR XML/JSON not allowed',
+        );
       });
     });
 
@@ -139,12 +166,14 @@ describe('GsService', () => {
         ['DELETE FROM [user]', 'DELETE'],
         ['DROP TABLE [user]', 'DROP'],
       ])('should block non-SELECT: %s (%s)', async (sql) => {
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block multiple statements', async () => {
         const sql = 'SELECT * FROM [user]; SELECT * FROM user_data';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('Only single statements allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'Only single statements allowed',
+        );
       });
     });
 
@@ -157,13 +186,15 @@ describe('GsService', () => {
         ['SELECT mail AS m FROM user_data', 'aliased mail'],
         ['SELECT firstname, surname FROM user_data', 'multiple PII columns'],
       ])('should block PII column access: %s (%s)', async (sql) => {
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(/Access to column .* is not allowed/);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          /Access to column .* is not allowed/,
+        );
       });
 
       it('should block PII in subqueries', async () => {
         const sql = 'SELECT id, (SELECT mail FROM user_data WHERE id = 1) FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
     });
 
@@ -173,49 +204,49 @@ describe('GsService', () => {
         ['SELECT * FROM INFORMATION_SCHEMA.TABLES', 'INFORMATION_SCHEMA'],
         ['SELECT * FROM master.dbo.sysdatabases', 'master database'],
       ])('should block system schema access: %s (%s)', async (sql) => {
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block sys schema in SELECT column subquery', async () => {
         const sql = 'SELECT (SELECT TOP 1 name FROM sys.sql_logins) FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block sys schema in HAVING subquery', async () => {
         const sql = 'SELECT COUNT(*) FROM [user] GROUP BY status HAVING (SELECT 1 FROM sys.sql_logins) = 1';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block sys schema in ORDER BY subquery', async () => {
         const sql = 'SELECT * FROM [user] ORDER BY (SELECT 1 FROM sys.sql_logins)';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block sys schema in GROUP BY subquery', async () => {
         const sql = 'SELECT COUNT(*) FROM [user] GROUP BY (SELECT 1 FROM sys.sql_logins)';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block sys schema in CTE', async () => {
         const sql = 'WITH cte AS (SELECT * FROM sys.sql_logins) SELECT * FROM cte';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block sys schema in JOIN ON subquery', async () => {
         const sql = 'SELECT * FROM [user] u JOIN [order] o ON o.id = (SELECT 1 FROM sys.sql_logins)';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block linked server access (4-part names)', async () => {
         const sql = 'SELECT * FROM [LinkedServer].[database].[schema].[table]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
           'Linked server access is not allowed',
         );
       });
 
       it('should block linked server access even with non-blocked database', async () => {
         const sql = 'SELECT * FROM [ExternalServer].[otherdb].[dbo].[users]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
           'Linked server access is not allowed',
         );
       });
@@ -227,34 +258,34 @@ describe('GsService', () => {
         ["SELECT * FROM OPENQUERY(LinkedServer, 'SELECT 1')", 'OPENQUERY'],
         ["SELECT * FROM OPENDATASOURCE('SQLNCLI', 'Data Source=x;').db.schema.table", 'OPENDATASOURCE'],
       ])('should block dangerous function: %s', async (sql) => {
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block OPENROWSET in HAVING subquery', async () => {
         const sql = "SELECT COUNT(*) FROM [user] GROUP BY status HAVING (SELECT 1 FROM OPENROWSET('a','b','c')) = 1";
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block OPENROWSET in ORDER BY subquery', async () => {
         const sql = "SELECT * FROM [user] ORDER BY (SELECT 1 FROM OPENROWSET('a','b','c'))";
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block OPENROWSET in CTE', async () => {
         const sql = "WITH cte AS (SELECT * FROM OPENROWSET('a','b','c')) SELECT * FROM cte";
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
 
       it('should block OPENROWSET in GROUP BY subquery', async () => {
         const sql = "SELECT COUNT(*) FROM [user] GROUP BY (SELECT 1 FROM OPENROWSET('a','b','c'))";
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(BadRequestException);
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(BadRequestException);
       });
     });
 
     describe('UNION/INTERSECT/EXCEPT', () => {
       it('should block UNION queries', async () => {
         const sql = 'SELECT id FROM [user] UNION SELECT id FROM user_data';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow(
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
           'UNION/INTERSECT/EXCEPT queries not allowed',
         );
       });
@@ -263,7 +294,9 @@ describe('GsService', () => {
     describe('SELECT INTO', () => {
       it('should block SELECT INTO', async () => {
         const sql = 'SELECT * INTO #temp FROM [user]';
-        await expect(service.executeDebugQuery(sql, 'test-user')).rejects.toThrow('SELECT INTO not allowed');
+        await expect(service.executeDebugQuery(sql, 'test-user', UserRole.DEBUG)).rejects.toThrow(
+          'SELECT INTO not allowed',
+        );
       });
     });
 
@@ -271,7 +304,7 @@ describe('GsService', () => {
       it('should allow SELECT on non-PII columns', async () => {
         jest.spyOn(dataSource, 'query').mockResolvedValue([{ id: 1, status: 'Active' }]);
 
-        const result = await service.executeDebugQuery('SELECT id, status FROM [user]', 'test-user');
+        const result = await service.executeDebugQuery('SELECT id, status FROM [user]', 'test-user', UserRole.DEBUG);
 
         expect(result).toEqual([{ id: 1, status: 'Active' }]);
         expect(dataSource.query).toHaveBeenCalled();
@@ -280,7 +313,7 @@ describe('GsService', () => {
       it('should allow SELECT with TOP clause', async () => {
         jest.spyOn(dataSource, 'query').mockResolvedValue([{ id: 1 }]);
 
-        const result = await service.executeDebugQuery('SELECT TOP 10 id FROM [user]', 'test-user');
+        const result = await service.executeDebugQuery('SELECT TOP 10 id FROM [user]', 'test-user', UserRole.DEBUG);
 
         expect(result).toBeDefined();
       });
@@ -288,9 +321,35 @@ describe('GsService', () => {
       it('should allow SELECT with WHERE clause', async () => {
         jest.spyOn(dataSource, 'query').mockResolvedValue([{ id: 1 }]);
 
-        const result = await service.executeDebugQuery("SELECT id FROM [user] WHERE status = 'Active'", 'test-user');
+        const result = await service.executeDebugQuery(
+          "SELECT id FROM [user] WHERE status = 'Active'",
+          'test-user',
+          UserRole.DEBUG,
+        );
 
         expect(result).toBeDefined();
+      });
+    });
+
+    describe('Admin PII unmask (bank_tx.iban)', () => {
+      it('should block bank_tx.iban for DEBUG role', async () => {
+        await expect(
+          service.executeDebugQuery('SELECT iban FROM bank_tx', 'test-user', UserRole.DEBUG),
+        ).rejects.toThrow(/Access to column .*iban.* is not allowed/);
+      });
+
+      it('should allow bank_tx.iban for ADMIN role', async () => {
+        jest.spyOn(dataSource, 'query').mockResolvedValue([{ iban: 'CH9300762011623852957' }]);
+
+        const result = await service.executeDebugQuery('SELECT iban FROM bank_tx', 'test-user', UserRole.ADMIN);
+
+        expect(result).toEqual([{ iban: 'CH9300762011623852957' }]);
+      });
+
+      it('should still block bank_tx.name for ADMIN role (only iban is unmasked)', async () => {
+        await expect(
+          service.executeDebugQuery('SELECT name FROM bank_tx', 'test-user', UserRole.ADMIN),
+        ).rejects.toThrow(/Access to column .*name.* is not allowed/);
       });
     });
   });

--- a/src/subdomains/generic/gs/dto/gs.dto.ts
+++ b/src/subdomains/generic/gs/dto/gs.dto.ts
@@ -126,6 +126,11 @@ export const DebugBlockedCols: Record<string, string[]> = {
   webhook: ['data'],
   notification: ['data'],
 };
+
+// Columns from DebugBlockedCols that are unmasked for Admin (and higher) roles in the debug endpoint
+export const DebugAdminUnmaskCols: Record<string, string[]> = {
+  bank_tx: ['iban'],
+};
 export const DebugLogQueryTemplates: Record<
   LogQueryTemplate,
   { kql: string; requiredParams: (keyof LogQueryDto)[]; defaultLimit: number }

--- a/src/subdomains/generic/gs/gs.controller.ts
+++ b/src/subdomains/generic/gs/gs.controller.ts
@@ -53,7 +53,7 @@ export class GsController {
   @ApiExcludeEndpoint()
   @UseGuards(AuthGuard(), RoleGuard(UserRole.DEBUG), UserActiveGuard())
   async executeDebugQuery(@GetJwt() jwt: JwtPayload, @Body() dto: DebugQueryDto): Promise<Record<string, unknown>[]> {
-    return this.gsService.executeDebugQuery(dto.sql, jwt.address ?? `account:${jwt.account}`);
+    return this.gsService.executeDebugQuery(dto.sql, jwt.address ?? `account:${jwt.account}`, jwt.role);
   }
 
   @Post('debug/logs')

--- a/src/subdomains/generic/gs/gs.service.ts
+++ b/src/subdomains/generic/gs/gs.service.ts
@@ -30,6 +30,7 @@ import { UserDataService } from '../user/models/user-data/user-data.service';
 import { UserService } from '../user/models/user/user.service';
 import { DbQueryBaseDto, DbQueryDto, DbReturnData } from './dto/db-query.dto';
 import {
+  DebugAdminUnmaskCols,
   DebugBlockedCols,
   DebugBlockedSchemas,
   DebugDangerousFunctions,
@@ -191,7 +192,9 @@ export class GsService {
     };
   }
 
-  async executeDebugQuery(sql: string, userIdentifier: string): Promise<Record<string, unknown>[]> {
+  async executeDebugQuery(sql: string, userIdentifier: string, role: UserRole): Promise<Record<string, unknown>[]> {
+    const blockedCols = this.getEffectiveDebugBlockedCols(role);
+
     // 1. Parse SQL to AST for robust validation
     let ast;
     try {
@@ -232,7 +235,7 @@ export class GsService {
 
     // 8. Check for blocked columns BEFORE execution (prevents alias bypass)
     const tables = this.getTablesFromQuery(sql);
-    const blockedColumn = this.findBlockedColumnInQuery(sql, stmt, tables);
+    const blockedColumn = this.findBlockedColumnInQuery(sql, stmt, tables, blockedCols);
     if (blockedColumn) {
       throw new BadRequestException(`Access to column '${blockedColumn}' is not allowed`);
     }
@@ -251,7 +254,7 @@ export class GsService {
       const result = await this.dataSource.query(limitedSql);
 
       // 12. Post-execution masking (defense in depth - also catches pre-execution failures)
-      this.maskDebugBlockedColumns(result, tables);
+      this.maskDebugBlockedColumns(result, tables, blockedCols);
 
       return result;
     } catch (e) {
@@ -600,13 +603,29 @@ export class GsService {
     }
   }
 
-  private maskDebugBlockedColumns(data: Record<string, unknown>[], tables: string[]): void {
+  private getEffectiveDebugBlockedCols(role: UserRole): Record<string, string[]> {
+    const isAdminOrHigher = role === UserRole.ADMIN || role === UserRole.SUPER_ADMIN;
+    if (!isAdminOrHigher) return DebugBlockedCols;
+
+    const effective: Record<string, string[]> = {};
+    for (const [table, cols] of Object.entries(DebugBlockedCols)) {
+      const unmask = DebugAdminUnmaskCols[table];
+      effective[table] = unmask?.length ? cols.filter((c) => !unmask.includes(c)) : cols;
+    }
+    return effective;
+  }
+
+  private maskDebugBlockedColumns(
+    data: Record<string, unknown>[],
+    tables: string[],
+    blockedColsMap: Record<string, string[]>,
+  ): void {
     if (!data?.length || !tables?.length) return;
 
     // Collect all blocked columns from all tables in the query
     const blockedColumns = new Set<string>();
     for (const table of tables) {
-      const tableCols = DebugBlockedCols[table];
+      const tableCols = blockedColsMap[table];
       if (tableCols) {
         for (const col of tableCols) {
           blockedColumns.add(col.toLowerCase());
@@ -655,23 +674,33 @@ export class GsService {
     return map;
   }
 
-  private isColumnBlockedInTable(columnName: string, table: string | null, allTables: string[]): boolean {
+  private isColumnBlockedInTable(
+    columnName: string,
+    table: string | null,
+    allTables: string[],
+    blockedColsMap: Record<string, string[]>,
+  ): boolean {
     const lower = columnName.toLowerCase();
 
     if (table) {
       // Explicit table known → check if this column is blocked in this table
-      const blockedCols = DebugBlockedCols[table];
+      const blockedCols = blockedColsMap[table];
       return blockedCols?.some((b) => b.toLowerCase() === lower) ?? false;
     } else {
       // No explicit table → if ANY of the query tables blocks this column, block it
       return allTables.some((t) => {
-        const blockedCols = DebugBlockedCols[t];
+        const blockedCols = blockedColsMap[t];
         return blockedCols?.some((b) => b.toLowerCase() === lower) ?? false;
       });
     }
   }
 
-  private findBlockedColumnInQuery(sql: string, ast: any, tables: string[]): string | null {
+  private findBlockedColumnInQuery(
+    sql: string,
+    ast: any,
+    tables: string[],
+    blockedColsMap: Record<string, string[]>,
+  ): string | null {
     try {
       // columnList returns: ['select::table::column', 'select::null::column', ...]
       const columns = this.sqlParser.columnList(sql, { database: 'TransactSQL' });
@@ -694,7 +723,7 @@ export class GsService {
             : aliasMap.get(tableOrAlias) || tableOrAlias;
 
         // Check if column is blocked in this table
-        if (this.isColumnBlockedInTable(columnName, resolvedTable, tables)) {
+        if (this.isColumnBlockedInTable(columnName, resolvedTable, tables, blockedColsMap)) {
           return `${resolvedTable || 'unknown'}.${columnName}`;
         }
       }


### PR DESCRIPTION
## Summary
- The debug endpoint (`POST /gs/debug`, used by `scripts/db-debug.sh`) hardcoded `bank_tx.iban` as a blocked PII column for every caller, blocking reconciliations that need the sender IBAN.
- Adds a `DebugAdminUnmaskCols` allow-list and threads `jwt.role` through `executeDebugQuery`. For `Admin` (and higher) only, the listed columns are removed from the effective block-list — pre-execution column check and post-execution masking both honor the bypass.
- Currently scoped to `bank_tx.iban` only. All other PII columns (`name`, `ultimateName`, `country`, `bic`, `addressLine*`, `txInfo`, `txRaw`, `virtualIban`, …) remain masked for every role.
- Default `Debug`-role behavior is unchanged.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test` — 934 tests pass (incl. 3 new tests under `Admin PII unmask (bank_tx.iban)`)
- [ ] After deploy: verify `./scripts/db-debug.sh "SELECT TOP 1 iban FROM bank_tx"` returns the IBAN value (Admin token) and is still rejected with `Access to column 'bank_tx.iban' is not allowed` for a pure Debug token