### PR TITLE
feat(gs): unmask bank_tx.iban in debug endpoint

### DIFF
--- a/src/subdomains/generic/gs/dto/gs.dto.ts
+++ b/src/subdomains/generic/gs/dto/gs.dto.ts
@@ -57,7 +57,6 @@ export const DebugBlockedCols: Record<string, string[]> = {
   bank_tx: [
     'name',
     'ultimateName',
-    'iban',
     'country',
     'senderAccount',
     'bic',


### PR DESCRIPTION
## Summary
- Removes `iban` from `DebugBlockedCols.bank_tx` so the debug endpoint (`POST /gs/debug`, used by `scripts/db-debug.sh`) returns the sender IBAN instead of `[RESTRICTED:SET]`.
- All other PII columns in `bank_tx` (`name`, `ultimateName`, `country`, `bic`, `addressLine*`, `txInfo`, `txRaw`, `virtualIban`, …) remain masked.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test`
- [ ] After deploy: verify `./scripts/db-debug.sh "SELECT TOP 1 iban FROM bank_tx"` returns the IBAN value