### PR TITLE
fix(payout): recover EVM payouts from out-of-gas reverts

### DIFF
--- a/src/integration/blockchain/shared/evm/evm-client.ts
+++ b/src/integration/blockchain/shared/evm/evm-client.ts
@@ -194,18 +194,14 @@ export abstract class EvmClient extends BlockchainClient {
 
     try {
       const gasEstimate = await contract.estimateGas.transfer(to, estimateAmount);
-      // 50% buffer + 80k floor: covers EIP-2200 SSTORE swing (~15k gas) when recipient
-      // balance slot changes between estimate-time and execution-time (cold zero→nonzero
-      // costs 22.1k vs warm nonzero→nonzero 7.1k)
-      const buffered = gasEstimate.mul(15).div(10);
-      const floor = ethers.BigNumber.from(80_000);
-      return buffered.gt(floor) ? buffered : floor;
+      return gasEstimate.mul(12).div(10);
     } catch (error) {
       // If gas estimation fails (e.g., from EIP-7702 delegated address), use a safe default
+      // Standard ERC20 transfer is ~65k gas, using 100k as safe upper bound with buffer
       this.logger.verbose(
-        `Gas estimation failed for token transfer to ${to}: ${error.message}. Using default gas limit of 150000`,
+        `Gas estimation failed for token transfer to ${to}: ${error.message}. Using default gas limit of 100000`,
       );
-      return ethers.BigNumber.from(150_000);
+      return ethers.BigNumber.from(100000);
     }
   }
 

--- a/src/integration/blockchain/shared/evm/evm-client.ts
+++ b/src/integration/blockchain/shared/evm/evm-client.ts
@@ -194,14 +194,18 @@ export abstract class EvmClient extends BlockchainClient {
 
     try {
       const gasEstimate = await contract.estimateGas.transfer(to, estimateAmount);
-      return gasEstimate.mul(12).div(10);
+      // 50% buffer + 80k floor: covers EIP-2200 SSTORE swing (~15k gas) when recipient
+      // balance slot changes between estimate-time and execution-time (cold zero→nonzero
+      // costs 22.1k vs warm nonzero→nonzero 7.1k)
+      const buffered = gasEstimate.mul(15).div(10);
+      const floor = ethers.BigNumber.from(80_000);
+      return buffered.gt(floor) ? buffered : floor;
     } catch (error) {
       // If gas estimation fails (e.g., from EIP-7702 delegated address), use a safe default
-      // Standard ERC20 transfer is ~65k gas, using 100k as safe upper bound with buffer
       this.logger.verbose(
-        `Gas estimation failed for token transfer to ${to}: ${error.message}. Using default gas limit of 100000`,
+        `Gas estimation failed for token transfer to ${to}: ${error.message}. Using default gas limit of 150000`,
       );
-      return ethers.BigNumber.from(100000);
+      return ethers.BigNumber.from(150_000);
     }
   }
 
@@ -867,13 +871,13 @@ export abstract class EvmClient extends BlockchainClient {
     amount: number,
     nonce?: number,
   ): Promise<string> {
-    const gasLimit = +(await this.getTokenGasLimitForContact(contract, toAddress));
+    const token = await this.getTokenByContract(contract);
+    const targetAmount = EvmUtil.toWeiAmount(amount, token.decimals);
+
+    const gasLimit = +(await this.getTokenGasLimitForContact(contract, toAddress, targetAmount));
     const gasPrice = +(await this.getRecommendedGasPrice());
     const currentNonce = await this.getNonce(fromAddress);
     const txNonce = nonce ?? currentNonce;
-
-    const token = await this.getTokenByContract(contract);
-    const targetAmount = EvmUtil.toWeiAmount(amount, token.decimals);
 
     const tx = await contract.transfer(toAddress, targetAmount, { gasPrice, gasLimit, nonce: txNonce });
 

--- a/src/subdomains/supporting/payout/entities/__tests__/payout-order.entity.spec.ts
+++ b/src/subdomains/supporting/payout/entities/__tests__/payout-order.entity.spec.ts
@@ -110,6 +110,23 @@ describe('PayoutOrder', () => {
     });
   });
 
+  describe('#rollbackPayout(...)', () => {
+    it('clears payoutTxId and resets status to PayoutOrderStatus.PREPARATION_CONFIRMED for retry', () => {
+      const entity = createCustomPayoutOrder({
+        payoutTxId: 'PID_01',
+        status: PayoutOrderStatus.PAYOUT_PENDING,
+      });
+
+      expect(entity.payoutTxId).toBe('PID_01');
+      expect(entity.status).toBe(PayoutOrderStatus.PAYOUT_PENDING);
+
+      entity.rollbackPayout();
+
+      expect(entity.payoutTxId).toBeNull();
+      expect(entity.status).toBe(PayoutOrderStatus.PREPARATION_CONFIRMED);
+    });
+  });
+
   describe('#complete(...)', () => {
     it('sets status to PayoutOrderStatus.COMPLETE', () => {
       const entity = createCustomPayoutOrder({

--- a/src/subdomains/supporting/payout/entities/payout-order.entity.ts
+++ b/src/subdomains/supporting/payout/entities/payout-order.entity.ts
@@ -122,6 +122,13 @@ export class PayoutOrder extends IEntity {
     return this;
   }
 
+  rollbackPayout(): this {
+    this.payoutTxId = null;
+    this.status = PayoutOrderStatus.PREPARATION_CONFIRMED;
+
+    return this;
+  }
+
   recordPayoutFee(payoutFeeAsset: Asset, payoutFeeAmount: number, payoutFeeAmountChf: number): this {
     this.payoutFeeAsset = payoutFeeAsset;
     this.payoutFeeAmount = payoutFeeAmount;

--- a/src/subdomains/supporting/payout/interfaces/index.ts
+++ b/src/subdomains/supporting/payout/interfaces/index.ts
@@ -13,3 +13,8 @@ export interface FeeResult {
   asset: Asset;
   amount: number;
 }
+
+export type PayoutTxStatus =
+  | { state: 'pending' }
+  | { state: 'complete'; fee: number }
+  | { state: 'failed'; isOutOfGas: boolean };

--- a/src/subdomains/supporting/payout/services/payout-evm.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-evm.service.ts
@@ -1,11 +1,7 @@
 import { EvmClient } from 'src/integration/blockchain/shared/evm/evm-client';
 import { EvmService } from 'src/integration/blockchain/shared/evm/evm.service';
 import { Asset } from 'src/shared/models/asset/asset.entity';
-
-export type PayoutTxStatus =
-  | { state: 'pending' }
-  | { state: 'complete'; fee: number }
-  | { state: 'failed'; isOutOfGas: boolean };
+import { PayoutTxStatus } from '../interfaces';
 
 export abstract class PayoutEvmService {
   private readonly client: EvmClient;

--- a/src/subdomains/supporting/payout/services/payout-evm.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-evm.service.ts
@@ -2,6 +2,11 @@ import { EvmClient } from 'src/integration/blockchain/shared/evm/evm-client';
 import { EvmService } from 'src/integration/blockchain/shared/evm/evm.service';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 
+export type PayoutTxStatus =
+  | { state: 'pending' }
+  | { state: 'complete'; fee: number }
+  | { state: 'failed'; isOutOfGas: boolean };
+
 export abstract class PayoutEvmService {
   private readonly client: EvmClient;
 
@@ -17,11 +22,18 @@ export abstract class PayoutEvmService {
     return this.client.sendTokenFromDex(address, tokenName, amount, nonce);
   }
 
-  async getPayoutCompletionData(txHash: string): Promise<[boolean, number]> {
-    const isComplete = await this.client.isTxComplete(txHash);
-    const payoutFee = isComplete ? await this.client.getTxActualFee(txHash) : 0;
+  async getPayoutCompletionData(txHash: string): Promise<PayoutTxStatus> {
+    const receipt = await this.client.getTxReceipt(txHash);
+    if (!receipt || receipt.confirmations <= 0) return { state: 'pending' };
 
-    return [isComplete, payoutFee];
+    if (receipt.status === 1) {
+      const fee = await this.client.getTxActualFee(txHash);
+      return { state: 'complete', fee };
+    }
+
+    const tx = await this.client.getTx(txHash);
+    const isOutOfGas = tx ? receipt.gasUsed.eq(tx.gasLimit) : false;
+    return { state: 'failed', isOutOfGas };
   }
 
   async getCurrentGasForCoinTransaction(): Promise<number> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
@@ -38,8 +38,4 @@ export class BaseCoinStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getBaseCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.baseService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
@@ -38,8 +38,4 @@ export class BaseTokenStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getBaseCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.baseService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -69,7 +69,7 @@ export abstract class EvmStrategy extends PayoutStrategy {
           order.designatePayout();
           await this.payoutOrderRepo.save(order);
         } else if (await this.canRetryFailedPayout(order, status)) {
-          if (status.state === 'failed') {
+          if (status.state === 'failed' && status.isOutOfGas) {
             // OOG: free the spent nonce so the retry gets a fresh one
             this.logger.warn(
               `Payout order ${order.id} failed with out-of-gas (tx ${order.payoutTxId}), retrying with fresh nonce`,

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -4,11 +4,11 @@ import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { DisabledProcess, Process } from 'src/shared/services/process.service';
 import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
 import { Util } from 'src/shared/utils/util';
-import { FeeResult } from 'src/subdomains/supporting/payout/interfaces';
+import { FeeResult, PayoutTxStatus } from 'src/subdomains/supporting/payout/interfaces';
 import { PriceCurrency, PriceValidity } from 'src/subdomains/supporting/pricing/services/pricing.service';
 import { PayoutOrder } from '../../../../entities/payout-order.entity';
 import { PayoutOrderRepository } from '../../../../repositories/payout-order.repository';
-import { PayoutEvmService, PayoutTxStatus } from '../../../../services/payout-evm.service';
+import { PayoutEvmService } from '../../../../services/payout-evm.service';
 import { PayoutStrategy } from './payout.strategy';
 
 export abstract class EvmStrategy extends PayoutStrategy {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -62,26 +62,24 @@ export abstract class EvmStrategy extends PayoutStrategy {
           order.recordPayoutFee(feeAsset, status.fee, price.convert(status.fee, Config.defaultVolumeDecimal));
 
           await this.payoutOrderRepo.save(order);
-        } else if (status.state === 'failed') {
-          if (status.isOutOfGas) {
-            // Recoverable: TX consumed full gas limit, likely due to EIP-2200 SSTORE swing
-            // between estimate-time and execution-time. Rollback to PreparationConfirmed so
-            // the next cron pass retries with a fresh nonce and a re-estimated gas limit.
+        } else if (status.state === 'failed' && !status.isOutOfGas) {
+          // Non-recoverable on-chain revert (paused contract, balance mismatch, etc.).
+          // Designate for investigation - processFailedOrders will mail and move to PayoutUncertain.
+          this.logger.error(`Payout order ${order.id} reverted on-chain (tx ${order.payoutTxId}, not OOG)`);
+          order.designatePayout();
+          await this.payoutOrderRepo.save(order);
+        } else if (await this.canRetryFailedPayout(order, status)) {
+          if (status.state === 'failed') {
+            // OOG: free the spent nonce so the retry gets a fresh one
             this.logger.warn(
-              `Payout order ${order.id} failed with out-of-gas (tx ${order.payoutTxId}), rolling back for retry`,
+              `Payout order ${order.id} failed with out-of-gas (tx ${order.payoutTxId}), retrying with fresh nonce`,
             );
             order.rollbackPayout();
             await this.payoutOrderRepo.save(order);
           } else {
-            // Non-recoverable on-chain revert (paused contract, balance mismatch, etc.).
-            // Designate for investigation - processFailedOrders will mail and move to PayoutUncertain.
-            this.logger.error(`Payout order ${order.id} reverted on-chain (tx ${order.payoutTxId}, not OOG)`);
-            order.designatePayout();
-            await this.payoutOrderRepo.save(order);
+            // TX expired (not on-chain, not in mempool) - retry immediately, no gas costs incurred
+            this.logger.info(`Payout order ${order.id} has expired TX (${order.payoutTxId}), retrying immediately`);
           }
-        } else if (await this.canRetryFailedPayout(order)) {
-          // TX expired (not on-chain, not in mempool) - retry immediately, no gas costs incurred
-          this.logger.info(`Payout order ${order.id} has expired TX (${order.payoutTxId}), retrying immediately`);
           await this.doPayout([order]);
         }
       } catch (e) {
@@ -100,11 +98,14 @@ export abstract class EvmStrategy extends PayoutStrategy {
     }
   }
 
-  override async canRetryFailedPayout(order: PayoutOrder): Promise<boolean> {
+  override async canRetryFailedPayout(order: PayoutOrder, status?: PayoutTxStatus): Promise<boolean> {
     if (!order.payoutTxId) return false;
 
-    if (Util.hoursDiff(order.updated) < 1) return false;
+    // OOG-mined: retry immediately, re-estimation should resolve the state divergence
+    if (status?.state === 'failed' && status.isOutOfGas) return true;
 
+    // Expired in mempool: retry after 1h cooldown
+    if (Util.hoursDiff(order.updated) < 1) return false;
     return this.payoutEvmService.isTxExpired(order.payoutTxId);
   }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -70,8 +70,7 @@ export abstract class EvmStrategy extends PayoutStrategy {
             this.logger.warn(
               `Payout order ${order.id} failed with out-of-gas (tx ${order.payoutTxId}), rolling back for retry`,
             );
-            order.rollbackPayoutDesignation();
-            order.payoutTxId = null;
+            order.rollbackPayout();
             await this.payoutOrderRepo.save(order);
           } else {
             // Non-recoverable on-chain revert (paused contract, balance mismatch, etc.).

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -8,7 +8,7 @@ import { FeeResult } from 'src/subdomains/supporting/payout/interfaces';
 import { PriceCurrency, PriceValidity } from 'src/subdomains/supporting/pricing/services/pricing.service';
 import { PayoutOrder } from '../../../../entities/payout-order.entity';
 import { PayoutOrderRepository } from '../../../../repositories/payout-order.repository';
-import { PayoutEvmService } from '../../../../services/payout-evm.service';
+import { PayoutEvmService, PayoutTxStatus } from '../../../../services/payout-evm.service';
 import { PayoutStrategy } from './payout.strategy';
 
 export abstract class EvmStrategy extends PayoutStrategy {
@@ -52,16 +52,34 @@ export abstract class EvmStrategy extends PayoutStrategy {
   async checkPayoutCompletionData(orders: PayoutOrder[]): Promise<void> {
     for (const order of orders) {
       try {
-        const [isComplete, payoutFee] = await this.getPayoutCompletionData(order.payoutTxId);
+        const status = await this.getPayoutCompletionData(order.payoutTxId);
 
-        if (isComplete) {
+        if (status.state === 'complete') {
           order.complete();
 
           const feeAsset = await this.feeAsset();
           const price = await this.pricingService.getPrice(feeAsset, PriceCurrency.CHF, PriceValidity.ANY);
-          order.recordPayoutFee(feeAsset, payoutFee, price.convert(payoutFee, Config.defaultVolumeDecimal));
+          order.recordPayoutFee(feeAsset, status.fee, price.convert(status.fee, Config.defaultVolumeDecimal));
 
           await this.payoutOrderRepo.save(order);
+        } else if (status.state === 'failed') {
+          if (status.isOutOfGas) {
+            // Recoverable: TX consumed full gas limit, likely due to EIP-2200 SSTORE swing
+            // between estimate-time and execution-time. Rollback to PreparationConfirmed so
+            // the next cron pass retries with a fresh nonce and a re-estimated gas limit.
+            this.logger.warn(
+              `Payout order ${order.id} failed with out-of-gas (tx ${order.payoutTxId}), rolling back for retry`,
+            );
+            order.rollbackPayoutDesignation();
+            order.payoutTxId = null;
+            await this.payoutOrderRepo.save(order);
+          } else {
+            // Non-recoverable on-chain revert (paused contract, balance mismatch, etc.).
+            // Designate for investigation - processFailedOrders will mail and move to PayoutUncertain.
+            this.logger.error(`Payout order ${order.id} reverted on-chain (tx ${order.payoutTxId}, not OOG)`);
+            order.designatePayout();
+            await this.payoutOrderRepo.save(order);
+          }
         } else if (await this.canRetryFailedPayout(order)) {
           // TX expired (not on-chain, not in mempool) - retry immediately, no gas costs incurred
           this.logger.info(`Payout order ${order.id} has expired TX (${order.payoutTxId}), retrying immediately`);
@@ -73,7 +91,7 @@ export abstract class EvmStrategy extends PayoutStrategy {
     }
   }
 
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
+  protected async getPayoutCompletionData(payoutTxId: string): Promise<PayoutTxStatus> {
     return this.payoutEvmService.getPayoutCompletionData(payoutTxId);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
@@ -38,8 +38,4 @@ export class GnosisCoinStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getGnosisCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.gnosisService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
@@ -38,8 +38,4 @@ export class GnosisTokenStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getGnosisCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.gnosisService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
@@ -38,8 +38,4 @@ export class OptimismCoinStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getOptimismCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.optimismService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
@@ -38,8 +38,4 @@ export class OptimismTokenStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getOptimismCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.optimismService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
@@ -38,8 +38,4 @@ export class PolygonCoinStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getPolygonCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.polygonService.getPayoutCompletionData(payoutTxId);
-  }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
@@ -38,8 +38,4 @@ export class PolygonTokenStrategy extends EvmStrategy {
   protected getFeeAsset(): Promise<Asset> {
     return this.assetService.getPolygonCoin();
   }
-
-  protected async getPayoutCompletionData(payoutTxId: string): Promise<[boolean, number]> {
-    return this.polygonService.getPayoutCompletionData(payoutTxId);
-  }
 }


### PR DESCRIPTION
## Summary
Closes the failure mode where an EVM payout TX runs out of gas on-chain and the order stays in `PayoutPending` indefinitely.

## Root cause

Two defects had to coincide:

1. **Failure swallowed.** `isTxComplete` threw on reverted receipts. The outer `try/catch` in `PayoutService.checkPayoutCompletion` logged the error every 30 s but left the order in `PayoutPending`.
2. **No retry path for mined reverts.** `canRetryFailedPayout` only handles mempool-expired TXs (`isTxExpired`); a mined receipt with `status=0` is not expired and thus not retryable.

The underlying race itself — gas estimate vs execution diverging because of an EIP-2200 SSTORE swing on the recipient's balance slot — is rare in practice; the failure mode that needs fixing is the stuck order, not the rare gas estimate miss.

## Fix

- **`getPayoutCompletionData`** — returns a tri-state `PayoutTxStatus` (`pending` / `complete` / `failed` with `isOutOfGas`) read directly from the receipt instead of relying on the throwing `isTxComplete`.
- **`EvmStrategy.checkPayoutCompletionData`** — handles `failed` explicitly:
  - `isOutOfGas` → `rollbackPayout()` → next cron pass retries with a fresh nonce and a re-estimated gas limit.
  - non-OOG revert → `designatePayout()` → `processFailedOrders` already mails and moves the order to `PayoutUncertain`.
- **`PayoutOrder.rollbackPayout()`** — new entity method symmetric to `pendingPayout(txId)`: clears `payoutTxId` and resets status to `PreparationConfirmed`. Unit test added.
- **`sendToken`** now passes the real transfer amount through to `getTokenGasLimitForContact` (consistent with `prepareTxData`).
- Redundant `getPayoutCompletionData` overrides in `base-{coin,token}`, `gnosis-{coin,token}`, `optimism-{coin,token}`, `polygon-{coin,token}` strategies removed — all 18 EVM strategies now consistently use the parent implementation.
- `PayoutTxStatus` collocated with `PayoutRequest` / `FeeResult` in `payout/interfaces/index.ts`.

No DB migration, no new status, no new entity columns, no change to gas estimation values — everything routes through existing entity methods (`rollbackPayout`, `designatePayout`, `pendingInvestigation`) and the existing `processFailedOrders` mail+investigation path.

## Test plan
- [ ] CI green (format / type-check / lint / jest)
- [ ] Manual: trigger an EVM payout that previously failed, verify auto-rollback + retry produces a successful TX with a new nonce
- [ ] Manual: simulate a non-OOG revert (e.g. paused token), verify order ends in `PayoutUncertain` with mail