### PR TITLE
refactor(evm): drop silent fallbacks in token gas estimation

### DIFF
--- a/src/integration/blockchain/shared/evm/evm-client.ts
+++ b/src/integration/blockchain/shared/evm/evm-client.ts
@@ -184,25 +184,13 @@ export abstract class EvmClient extends BlockchainClient {
   protected async getTokenGasLimitForAsset(token: Asset): Promise<EthersNumber> {
     const contract = this.getERC20ContractForDex(token.chainId);
 
-    return this.getTokenGasLimitForContact(contract, this.randomReceiverAddress);
+    // Sample amount of 1 wei for fee estimation only (no concrete TX context here)
+    return this.getTokenGasLimitForContact(contract, this.randomReceiverAddress, ethers.BigNumber.from(1));
   }
 
-  async getTokenGasLimitForContact(contract: Contract, to: string, amount?: EthersNumber): Promise<EthersNumber> {
-    // Use actual amount if provided, otherwise use 1 for gas estimation
-    // Some tokens may have minimum transfer amounts or balance checks that fail with 1 Wei
-    const estimateAmount = amount ?? 1;
-
-    try {
-      const gasEstimate = await contract.estimateGas.transfer(to, estimateAmount);
-      return gasEstimate.mul(12).div(10);
-    } catch (error) {
-      // If gas estimation fails (e.g., from EIP-7702 delegated address), use a safe default
-      // Standard ERC20 transfer is ~65k gas, using 100k as safe upper bound with buffer
-      this.logger.verbose(
-        `Gas estimation failed for token transfer to ${to}: ${error.message}. Using default gas limit of 100000`,
-      );
-      return ethers.BigNumber.from(100000);
-    }
+  async getTokenGasLimitForContact(contract: Contract, to: string, amount: EthersNumber): Promise<EthersNumber> {
+    const gasEstimate = await contract.estimateGas.transfer(to, amount);
+    return gasEstimate.mul(12).div(10);
   }
 
   async prepareTransaction(


### PR DESCRIPTION
## Summary
Remove two implicit defaults in `getTokenGasLimitForContact` so that callers always work with a real estimate or see the error explicitly.

## Changes

- `amount` parameter is now **required** — the previous `amount ?? 1` hid the intent at the call site. `getTokenGasLimitForAsset` now passes an explicit `BigNumber.from(1)` documented as fee-estimation sample only.
- The `try/catch` returning a hardcoded **100k gas** fallback on `estimateGas` failure is removed. Errors now propagate to the caller. Existing outer error handlers (in `EvmStrategy.doPayout`, the sell prepare flow, and the Polygon bridge adapter) already log and let the affected flow retry on the next cron pass.

## Why
A silent 100k fallback could send a transaction with a gas limit that doesn't reflect the real cost — either over-paying or under-paying. Failing loudly is preferable: the caller knows the estimate is unreliable and can decide what to do (retry, alert, etc.) instead of silently shipping a wrong number.

## Test plan
- [ ] CI green (format / type-check / lint / jest)
- [ ] Verify on DEV that a normal token payout still works