### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: Install packages
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/api-migration-check.yaml
+++ b/.github/workflows/api-migration-check.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/api-pr.yaml
+++ b/.github/workflows/api-pr.yaml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: Install packages
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: Install packages
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -12,12 +12,12 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check for unverified commits
         id: verify-commits
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const commits = await github.rest.pulls.listCommits({
@@ -86,7 +86,7 @@ jobs:
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           UNVERIFIED: ${{ steps.verify-commits.outputs.unverified }}
           UNVERIFIED_LIST: ${{ steps.verify-commits.outputs.unverified_list }}


### PR DESCRIPTION
## Context

Every workflow run currently emits this deprecation notice:

> `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, nick-fields/retry@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.`

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Changes

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/setup-node` | `@v4` | `@v5` |
| `actions/github-script` | `@v7` | `@v8` |
| `nick-fields/retry` | `@v3` | `@v4` |

Note: this is the minimal jump to Node.js 24. Each of these has further majors available (`checkout@v6`, `setup-node@v6`, `github-script@v9`) — bumping the rest can happen in a follow-up if desired. `github/codeql-action@v4` is already current; `azure/webapps-deploy@v3` was not flagged by the deprecation warning.

## Files touched

- `.github/workflows/api-dev.yaml`
- `.github/workflows/api-pr.yaml`
- `.github/workflows/api-prd.yaml`
- `.github/workflows/api-migration-check.yaml`
- `.github/workflows/auto-release-pr.yaml`
- `.github/workflows/codeql.yml`
- `.github/workflows/pr-review-bot.yml`

## Test plan

- [ ] PR CI run passes with no deprecation warning
- [ ] DEV deploy still succeeds on merge