### PR TITLE
fix: upgrade sanitize-html to 2.17.4 (critical XSS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "reflect-metadata": "^0.1.14",
         "rimraf": "^4.4.1",
         "rxjs": "^7.8.2",
-        "sanitize-html": "^2.17.0",
+        "sanitize-html": "^2.17.4",
         "secp256k1": "^5.0.1",
         "swagger-ui-express": "^4.6.3",
         "swissqrbill": "^4.2.0",
@@ -20773,6 +20773,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/leac": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
@@ -25963,17 +25972,49 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
-      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "reflect-metadata": "^0.1.14",
     "rimraf": "^4.4.1",
     "rxjs": "^7.8.2",
-    "sanitize-html": "^2.17.0",
+    "sanitize-html": "^2.17.4",
     "secp256k1": "^5.0.1",
     "swagger-ui-express": "^4.6.3",
     "swissqrbill": "^4.2.0",


### PR DESCRIPTION
## Summary

Patch-bump `sanitize-html` from `^2.17.0` to `^2.17.4` to clear [GHSA-rpr9-rxv7-x643](https://github.com/advisories/GHSA-rpr9-rxv7-x643) (critical: default XSS via `xmp` raw-text passthrough). The advisory dropped this morning and now fails the `Security audit` step in the `Build and test` job, blocking every PR.

## Problem

`npm audit --audit-level=critical` (run as part of `Build and test`) exits 1:

```
sanitize-html  <=2.17.3
Severity: critical
Apostrophe has default XSS via `xmp` raw-text passthrough in `sanitize-html` - https://github.com/advisories/GHSA-rpr9-rxv7-x643
```

The vulnerable line of code in our codebase is `Util.sanitize()` (`src/shared/utils/util.ts:703`), used as a `class-transformer` `@Transform` hook on request DTOs — exactly the surface the advisory describes. Upstream fix is available in `2.17.4`; the API is unchanged.

## Verification

- `npm run lint` — clean
- `npm run type-check` — clean
- `npx jest src/shared/utils/__tests__/util.spec.ts` — 5/5 pass (the only spec touching `Util` → `sanitize-html`)
- `npm audit --audit-level=critical` — now exits 0 (188 vulns remain, 0 critical)

## Lockfile

Scoped under `node_modules/sanitize-html/*` only — `sanitize-html` itself + its private nested `entities`/`htmlparser2` plus a new transitive `launder`. No top-level dependency cascade.

## Unblocks

`Security audit` failure currently blocks #3707, #3708, #3709. Merging this clears all three.
