### PR TITLE
feat(pricing): public CoinGecko simple/price proxy endpoint

### DIFF
--- a/src/subdomains/supporting/pricing/dto/simple-price-request.ts
+++ b/src/subdomains/supporting/pricing/dto/simple-price-request.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsString } from 'class-validator';
+
+export class SimplePriceRequest {
+  @ApiProperty({
+    description: 'Comma-separated list of CoinGecko coin ids (max 100)',
+    example: 'bitcoin,ethereum',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.split(',') : value))
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  ids: string[];
+
+  @ApiProperty({
+    description: 'Comma-separated list of target currencies',
+    example: 'usd,eur',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.split(',') : value))
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  vs_currencies: string[];
+}

--- a/src/subdomains/supporting/pricing/pricing.controller.ts
+++ b/src/subdomains/supporting/pricing/pricing.controller.ts
@@ -1,6 +1,6 @@
-import { BadRequestException, Controller, Get, NotFoundException, Put, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Put, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SimplePriceResponse } from 'coingecko-api-v3';
 import { RoleGuard } from 'src/shared/auth/role.guard';
 import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
@@ -28,15 +28,18 @@ export class PricingController {
   @Get('simple-price')
   @ApiOperation({
     summary: 'CoinGecko simple/price proxy',
-    description: 'Public, cached pass-through to CoinGecko /simple/price using the central CoinGecko Pro key.',
+    description:
+      'Public, cached pass-through to CoinGecko /simple/price using the central CoinGecko Pro key. ' +
+      'Response is cached server-side for 60 s.',
+  })
+  @ApiOkResponse({
+    schema: {
+      type: 'object',
+      additionalProperties: { type: 'object', additionalProperties: { type: 'number' } },
+      example: { bitcoin: { usd: 67000, eur: 62000 }, ethereum: { usd: 3500, eur: 3240 } },
+    },
   })
   async getSimplePrice(@Query() dto: SimplePriceRequest): Promise<SimplePriceResponse> {
-    const supported = this.coinGeckoService.getSupportedCurrencies();
-    if (supported.length) {
-      const invalid = dto.vs_currencies.map((c) => c.toLowerCase()).filter((c) => !supported.includes(c));
-      if (invalid.length) throw new BadRequestException(`Unsupported vs_currencies: ${invalid.join(',')}`);
-    }
-
     return this.coinGeckoService.getSimplePrice(dto.ids, dto.vs_currencies);
   }
 

--- a/src/subdomains/supporting/pricing/pricing.controller.ts
+++ b/src/subdomains/supporting/pricing/pricing.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, NotFoundException, Put, Query, UseGuards } from '@nestjs/common';
+import { BadRequestException, Controller, Get, NotFoundException, Put, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SimplePriceResponse } from 'coingecko-api-v3';
 import { RoleGuard } from 'src/shared/auth/role.guard';
 import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
 import { UserRole } from 'src/shared/auth/user-role.enum';
@@ -10,6 +11,8 @@ import { FiatService } from 'src/shared/models/fiat/fiat.service';
 import { Price } from './domain/entities/price';
 import { CurrencyType, PriceRequest } from './dto/price-request';
 import { PriceRequestRaw } from './dto/price-request-raw';
+import { SimplePriceRequest } from './dto/simple-price-request';
+import { CoinGeckoService } from './services/integration/coin-gecko.service';
 import { PricingService } from './services/pricing.service';
 
 @ApiTags('pricing')
@@ -19,7 +22,23 @@ export class PricingController {
     private readonly pricingService: PricingService,
     private readonly assetService: AssetService,
     private readonly fiatService: FiatService,
+    private readonly coinGeckoService: CoinGeckoService,
   ) {}
+
+  @Get('simple-price')
+  @ApiOperation({
+    summary: 'CoinGecko simple/price proxy',
+    description: 'Public, cached pass-through to CoinGecko /simple/price using the central CoinGecko Pro key.',
+  })
+  async getSimplePrice(@Query() dto: SimplePriceRequest): Promise<SimplePriceResponse> {
+    const supported = this.coinGeckoService.getSupportedCurrencies();
+    if (supported.length) {
+      const invalid = dto.vs_currencies.map((c) => c.toLowerCase()).filter((c) => !supported.includes(c));
+      if (invalid.length) throw new BadRequestException(`Unsupported vs_currencies: ${invalid.join(',')}`);
+    }
+
+    return this.coinGeckoService.getSimplePrice(dto.ids, dto.vs_currencies);
+  }
 
   @Get('price')
   @ApiBearerAuth()

--- a/src/subdomains/supporting/pricing/services/integration/coin-gecko.service.ts
+++ b/src/subdomains/supporting/pricing/services/integration/coin-gecko.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
-import { CoinGeckoClient } from 'coingecko-api-v3';
+import { CoinGeckoClient, SimplePriceResponse } from 'coingecko-api-v3';
+import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
 import { Environment, GetConfig } from 'src/config/config';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { Asset, AssetType } from 'src/shared/models/asset/asset.entity';
@@ -34,6 +35,7 @@ export class CoinGeckoService extends PricingProvider implements OnModuleInit {
   private readonly logger = new DfxLogger(CoinGeckoService);
 
   private readonly client: CoinGeckoClient;
+  private readonly simplePriceCache = new AsyncCache<SimplePriceResponse>(CacheItemResetPeriod.EVERY_1_MINUTE);
   private currencies: string[];
 
   constructor() {
@@ -55,6 +57,28 @@ export class CoinGeckoService extends PricingProvider implements OnModuleInit {
     if (param === 'contract') return this.getPriceFromContract(from, to);
 
     return this.getPriceFromToken(from, to);
+  }
+
+  getSupportedCurrencies(): string[] {
+    return this.currencies ?? [];
+  }
+
+  async getSimplePrice(ids: string[], vsCurrencies: string[]): Promise<SimplePriceResponse> {
+    const normalizedIds = [...new Set(ids.map((i) => i.toLowerCase()))].sort();
+    const normalizedCurrencies = [...new Set(vsCurrencies.map((c) => c.toLowerCase()))].sort();
+    const cacheKey = `${normalizedIds.join(',')}|${normalizedCurrencies.join(',')}`;
+
+    return this.simplePriceCache.get(cacheKey, async () => {
+      try {
+        return await this.client.simplePrice({
+          ids: normalizedIds.join(','),
+          vs_currencies: normalizedCurrencies.join(','),
+        });
+      } catch (e) {
+        this.logger.error(`Failed to get simple price for ${normalizedIds} -> ${normalizedCurrencies}:`, e);
+        throw new ServiceUnavailableException('Failed to get simple price');
+      }
+    });
   }
 
   private async getPriceFromContract(contractAddress: string, to: string): Promise<Price> {

--- a/src/subdomains/supporting/pricing/services/integration/coin-gecko.service.ts
+++ b/src/subdomains/supporting/pricing/services/integration/coin-gecko.service.ts
@@ -1,10 +1,10 @@
-import { Injectable, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
+import { BadRequestException, Injectable, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
 import { CoinGeckoClient, SimplePriceResponse } from 'coingecko-api-v3';
-import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
 import { Environment, GetConfig } from 'src/config/config';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { Asset, AssetType } from 'src/shared/models/asset/asset.entity';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
+import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
 import { Price } from '../../domain/entities/price';
 import { PricingProvider } from './pricing-provider';
 
@@ -59,13 +59,15 @@ export class CoinGeckoService extends PricingProvider implements OnModuleInit {
     return this.getPriceFromToken(from, to);
   }
 
-  getSupportedCurrencies(): string[] {
-    return this.currencies ?? [];
-  }
-
   async getSimplePrice(ids: string[], vsCurrencies: string[]): Promise<SimplePriceResponse> {
     const normalizedIds = [...new Set(ids.map((i) => i.toLowerCase()))].sort();
     const normalizedCurrencies = [...new Set(vsCurrencies.map((c) => c.toLowerCase()))].sort();
+
+    if (this.currencies) {
+      const invalid = normalizedCurrencies.filter((c) => !this.currencies.includes(c));
+      if (invalid.length) throw new BadRequestException(`Unsupported vs_currencies: ${invalid.join(',')}`);
+    }
+
     const cacheKey = `${normalizedIds.join(',')}|${normalizedCurrencies.join(',')}`;
 
     return this.simplePriceCache.get(cacheKey, async () => {


### PR DESCRIPTION
## Summary

Adds a public, unauthenticated `GET /pricing/simple-price` endpoint that proxies CoinGecko's `/simple/price` through `api.dfx.swiss`, using the central CoinGecko Pro key and a 60 s in-memory cache. Closes #3712.

- New `SimplePriceRequest` DTO (comma-list `ids` & `vs_currencies`, `ids` capped at 100).
- New `CoinGeckoService.getSimplePrice()` + `getSupportedCurrencies()`; responses cached via `AsyncCache` (60 s TTL).
- Controller validates `vs_currencies` against the supported list and returns CoinGecko's raw shape unchanged so the wallet only needs to swap the base URL.

## Test plan

- [ ] DEV: `curl https://dev.api.dfx.swiss/v1/pricing/simple-price?ids=bitcoin,ethereum&vs_currencies=usd,eur` returns CoinGecko's standard shape
- [ ] Invalid currency → `400 Bad Request`
- [ ] `>100` ids → `400 Bad Request`
- [ ] Second identical request within 60 s does not hit CoinGecko (cache verified via logs)
- [ ] Wallet (`dfx-wallet`) swap of `COINGECKO_SIMPLE_PRICE` to the new endpoint works end-to-end

## Out of scope

- `/coins/list` endpoint (separate issue)
- Contract-based lookups (internal `getRawPrice` covers backend consumers)