### PR TITLE
feat(pricing): public CoinGecko coins/list proxy endpoint

### DIFF
--- a/src/subdomains/supporting/pricing/dto/coins-list-request.ts
+++ b/src/subdomains/supporting/pricing/dto/coins-list-request.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class CoinsListRequest {
+  @ApiPropertyOptional({
+    description: 'Include platform contract addresses per chain',
+    default: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  include_platform?: boolean = false;
+}

--- a/src/subdomains/supporting/pricing/pricing.controller.ts
+++ b/src/subdomains/supporting/pricing/pricing.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, NotFoundException, Put, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CoinListResponseItem } from 'coingecko-api-v3';
 import { RoleGuard } from 'src/shared/auth/role.guard';
 import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
@@ -31,6 +31,29 @@ export class PricingController {
     description:
       'Public, cached pass-through to CoinGecko /coins/list using the central CoinGecko Pro key. ' +
       'Response is cached server-side for 24 h.',
+  })
+  @ApiOkResponse({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          symbol: { type: 'string' },
+          name: { type: 'string' },
+          platforms: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+      },
+      example: [
+        { id: 'bitcoin', symbol: 'btc', name: 'Bitcoin', platforms: {} },
+        {
+          id: 'tether',
+          symbol: 'usdt',
+          name: 'Tether',
+          platforms: { ethereum: '0xdac17f958d2ee523a2206206994597c13d831ec7' },
+        },
+      ],
+    },
   })
   async getCoinsList(@Query() dto: CoinsListRequest): Promise<CoinListResponseItem[]> {
     return this.coinGeckoService.getCoinsList(dto.include_platform ?? false);

--- a/src/subdomains/supporting/pricing/pricing.controller.ts
+++ b/src/subdomains/supporting/pricing/pricing.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, NotFoundException, Put, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CoinListResponseItem } from 'coingecko-api-v3';
 import { RoleGuard } from 'src/shared/auth/role.guard';
 import { UserActiveGuard } from 'src/shared/auth/user-active.guard';
 import { UserRole } from 'src/shared/auth/user-role.enum';
@@ -8,8 +9,10 @@ import { Active } from 'src/shared/models/active';
 import { AssetService } from 'src/shared/models/asset/asset.service';
 import { FiatService } from 'src/shared/models/fiat/fiat.service';
 import { Price } from './domain/entities/price';
+import { CoinsListRequest } from './dto/coins-list-request';
 import { CurrencyType, PriceRequest } from './dto/price-request';
 import { PriceRequestRaw } from './dto/price-request-raw';
+import { CoinGeckoService } from './services/integration/coin-gecko.service';
 import { PricingService } from './services/pricing.service';
 
 @ApiTags('pricing')
@@ -19,7 +22,19 @@ export class PricingController {
     private readonly pricingService: PricingService,
     private readonly assetService: AssetService,
     private readonly fiatService: FiatService,
+    private readonly coinGeckoService: CoinGeckoService,
   ) {}
+
+  @Get('coins-list')
+  @ApiOperation({
+    summary: 'CoinGecko coins/list proxy',
+    description:
+      'Public, cached pass-through to CoinGecko /coins/list using the central CoinGecko Pro key. ' +
+      'Response is cached server-side for 24 h.',
+  })
+  async getCoinsList(@Query() dto: CoinsListRequest): Promise<CoinListResponseItem[]> {
+    return this.coinGeckoService.getCoinsList(dto.include_platform ?? false);
+  }
 
   @Get('price')
   @ApiBearerAuth()

--- a/src/subdomains/supporting/pricing/services/integration/coin-gecko.service.ts
+++ b/src/subdomains/supporting/pricing/services/integration/coin-gecko.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
-import { CoinGeckoClient } from 'coingecko-api-v3';
+import { CoinGeckoClient, CoinListResponseItem } from 'coingecko-api-v3';
 import { Environment, GetConfig } from 'src/config/config';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { Asset, AssetType } from 'src/shared/models/asset/asset.entity';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
+import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
 import { Price } from '../../domain/entities/price';
 import { PricingProvider } from './pricing-provider';
 
@@ -34,6 +35,7 @@ export class CoinGeckoService extends PricingProvider implements OnModuleInit {
   private readonly logger = new DfxLogger(CoinGeckoService);
 
   private readonly client: CoinGeckoClient;
+  private readonly coinsListCache = new AsyncCache<CoinListResponseItem[]>(CacheItemResetPeriod.EVERY_24_HOURS);
   private currencies: string[];
 
   constructor() {
@@ -55,6 +57,17 @@ export class CoinGeckoService extends PricingProvider implements OnModuleInit {
     if (param === 'contract') return this.getPriceFromContract(from, to);
 
     return this.getPriceFromToken(from, to);
+  }
+
+  async getCoinsList(includePlatform: boolean): Promise<CoinListResponseItem[]> {
+    return this.coinsListCache.get(`include_platform=${includePlatform}`, async () => {
+      try {
+        return await this.client.coinList({ include_platform: includePlatform });
+      } catch (e) {
+        this.logger.error(`Failed to get coins list (include_platform=${includePlatform}):`, e);
+        throw new ServiceUnavailableException('Failed to get coins list');
+      }
+    });
   }
 
   private async getPriceFromContract(contractAddress: string, to: string): Promise<Price> {


### PR DESCRIPTION
## Summary

Adds a public, unauthenticated `GET /pricing/coins-list` endpoint that proxies CoinGecko's `/coins/list` through `api.dfx.swiss`, using the central CoinGecko Pro key and a 24 h in-memory cache. Closes #3713.

- New `CoinsListRequest` DTO (optional `include_platform` boolean, defaults to `false`).
- New `CoinGeckoService.getCoinsList()`; responses cached via `AsyncCache` with separate entries per `include_platform` value (24 h TTL — matches the wallet's local cache and CoinGecko's update cadence).
- Controller returns CoinGecko's raw shape unchanged so the wallet only needs to swap the base URL.
- Swagger schema documented via `@ApiOkResponse` with an example payload.

## Test plan

- [ ] DEV: `curl https://dev.api.dfx.swiss/v1/pricing/coins-list?include_platform=true` returns the full CoinGecko coin list (~2.6 MB)
- [ ] `include_platform=false` (and omitted) returns the slim shape without `platforms` field
- [ ] Second identical request within 24 h does not hit CoinGecko (cache verified via logs)
- [ ] Wallet (`dfx-wallet`) swap of `COINGECKO_LIST_URL` to the new endpoint works end-to-end

## Out of scope / follow-up

- Filtering the payload (e.g. only chains the wallet uses) — keeping upstream shape minimizes wallet diff and keeps the endpoint reusable.
- Server-side gzip: the upstream payload is ~2.6 MB but the API has no global compression middleware. Adding `compression` to `main.ts` would benefit this and other endpoints — separate PR.