### PR TITLE
fix(exchange-tx): add missing Scrypt USDT Withdrawal from 2026-04-13

### DIFF
--- a/migration/1778873963000-AddMissingScryptUsdtWithdrawal.js
+++ b/migration/1778873963000-AddMissingScryptUsdtWithdrawal.js
@@ -1,0 +1,98 @@
+/**
+ * @typedef {import('typeorm').MigrationInterface} MigrationInterface
+ * @typedef {import('typeorm').QueryRunner} QueryRunner
+ */
+
+/**
+ * Add missing Scrypt USDT Withdrawal that was not picked up by the
+ * exchange sync job. The on-chain Tron transfer is verified
+ * (Scrypt → Binance Hot Wallet → DFX), and the receiving Binance
+ * deposit is correctly recorded as exchange_tx with exchange='Binance'.
+ * Only the Scrypt-side Withdrawal record is missing.
+ *
+ * Withdrawal details:
+ *   Amount:           63'140.0826 USDT
+ *   externalCreated:  2026-04-13T09:47:48Z (Tron block 81802005 timestamp)
+ *   txId:             cd3191af012bc797f747f1083b96ba8651eb628176cb8d0a3951ed9462d31bad
+ *
+ * Verification:
+ *   Tron Block 81802005:
+ *     Scrypt-Wallet TExZbGuTh1XgAn47Wt573ZTqkfCmUuWTXY
+ *       → Binance Hot TDyfzdnNqrXEVqrUyZQSGSEGfSHTAYkFD3 (63'140.0826 USDT)
+ *   Tron Block 81802029 (+72 seconds):
+ *     Binance Hot   → DFX TGF6FQc9zdXK6sa4u9qkNCcjQDMApQr9Ru (63'140.0826 USDT)
+ *     = exchange_tx 133988 (exchange='Binance', type='Deposit', status='ok')
+ *
+ * Root cause (suspected): in-memory cache in ScryptService.balanceTransactions
+ * was incomplete when syncExchangeJob ran, and the 12-hour default
+ * since-window in getSyncSinceDate did not catch the entry on subsequent
+ * runs once it was outside the cache window.
+ *
+ * externalId uses a deterministic 'MANUAL_RECONCILE_*' prefix derived from
+ * the on-chain txId, so future runs of the sync job cannot create a duplicate
+ * via the (exchange, externalId, type) lookup. If Scrypt's API ever returns
+ * the original Scrypt-internal id for this Withdrawal in a backfill, that
+ * record will be added as a separate row and a follow-up reconciliation
+ * step should merge it.
+ *
+ * @class
+ * @implements {MigrationInterface}
+ */
+module.exports = class AddMissingScryptUsdtWithdrawal1778873963000 {
+  name = 'AddMissingScryptUsdtWithdrawal1778873963000';
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async up(queryRunner) {
+    const txId = 'cd3191af012bc797f747f1083b96ba8651eb628176cb8d0a3951ed9462d31bad';
+
+    const existing = await queryRunner.query(`
+      SELECT "id" FROM "dbo"."exchange_tx"
+      WHERE "exchange" = 'Scrypt' AND "type" = 'Withdrawal' AND "txId" = '${txId}'
+    `);
+
+    if (existing.length > 0) {
+      console.log(`Scrypt USDT Withdrawal with txId ${txId} already exists, skipping`);
+      return;
+    }
+
+    await queryRunner.query(`
+      INSERT INTO "dbo"."exchange_tx" (
+        "exchange",
+        "type",
+        "externalId",
+        "externalCreated",
+        "status",
+        "amount",
+        "currency",
+        "txId"
+      ) VALUES (
+        'Scrypt',
+        'Withdrawal',
+        'MANUAL_RECONCILE_cd3191af',
+        '2026-04-13T09:47:48.000Z',
+        'ok',
+        63140.0826,
+        'USDT',
+        '${txId}'
+      )
+    `);
+
+    console.log(`Inserted missing Scrypt USDT Withdrawal: 63'140.0826 USDT, txId ${txId}`);
+  }
+
+  /**
+   * @param {QueryRunner} queryRunner
+   */
+  async down(queryRunner) {
+    await queryRunner.query(`
+      DELETE FROM "dbo"."exchange_tx"
+      WHERE "exchange" = 'Scrypt'
+        AND "type" = 'Withdrawal'
+        AND "externalId" = 'MANUAL_RECONCILE_cd3191af'
+    `);
+
+    console.log("Deleted manual Scrypt USDT Withdrawal reconciliation entry");
+  }
+};


### PR DESCRIPTION
## Summary

Adds a migration to insert a missing `exchange_tx` row for a Scrypt USDT Withdrawal from `2026-04-13 09:47 UTC` (63'140.0826 USDT) that was not picked up by the exchange sync job. The corresponding Binance Deposit (`exchange_tx 133988`) is present, so the crypto did arrive at DFX via the standard Scrypt → Binance Hot Wallet → DFX 2-Hop routing.

## On-chain verification (Tron)

| Block | Timestamp | From | To | Amount |
|---|---|---|---|---:|
| 81802005 | 2026-04-13 09:47:48Z | Scrypt wallet `TExZbGu…` | Binance Hot `TDyfzdnN…` | 63'140.0826 USDT |
| 81802029 | 2026-04-13 09:49:00Z | Binance Hot `TDyfzdnN…` | DFX deposit `TGF6FQc9…` | 63'140.0826 USDT |

72-second gap between blocks matches Binance auto-sweep behavior. The receiving DFX deposit is recorded as `exchange_tx 133988` (`exchange='Binance'`, `type='Deposit'`, `status='ok'`).

TronScan links:
- https://tronscan.org/#/transaction/cd3191af012bc797f747f1083b96ba8651eb628176cb8d0a3951ed9462d31bad
- https://tronscan.org/#/transaction/e7f5d1aac45efd09f671d84f2f47e9352ba684c8b6b7d98105b01d12513b4854

## Suspected root cause

`ScryptService.balanceTransactions` is an in-memory `Map` populated via WebSocket. When the sync cron runs while the cache is incomplete (e.g., after a server restart or WebSocket reconnect), some transactions can be missed. The 12-hour default since-window in `getSyncSinceDate` does not catch the entry on subsequent runs once it falls outside the cache window.

A structural fix to prevent future occurrences (e.g., a periodic reconciliation phase that sum-compares Scrypt API vs DB per day) is out of scope for this PR.

## Idempotency

- Checks for an existing row by `txId` before inserting
- Uses a deterministic `externalId` (`MANUAL_RECONCILE_cd3191af`) so a future API backfill cannot create a colliding row via the `(exchange, externalId, type)` lookup

## Test plan

- [ ] Migration up: inserts the row, logs the insertion
- [ ] Re-running migration up: skips with "already exists" log
- [ ] Migration down: removes the row, logs the deletion
- [ ] After migration: `SELECT SUM(amount) FROM exchange_tx WHERE exchange='Scrypt' AND type='Withdrawal' AND currency='USDT'` matches Scrypt's CSV export sum (21'321'062.01 USDT)