### PR TITLE
refactor(evm): make EVM gas estimation strict end-to-end

### DIFF
--- a/src/integration/blockchain/base/base-client.ts
+++ b/src/integration/blockchain/base/base-client.ts
@@ -145,31 +145,27 @@ export class BaseClient extends EvmClient implements L2BridgeEvmClient {
    * @overwrite
    */
 
-  async getCurrentGasCostForCoinTransaction(): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
       from: this.walletAddress,
       to: this.randomReceiverAddress,
-      value: 1,
+      value: EvmUtil.toWeiAmount(amount).toString(),
       type: 2,
     });
 
     return EvmUtil.fromWeiAmount(totalGasCost);
   }
 
-  async getCurrentGasCostForTokenTransaction(token: Asset): Promise<number> {
-    try {
-      const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
-        from: this.walletAddress,
-        to: token.chainId,
-        data: this.dummyTokenPayload,
-        type: 2,
-      });
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    const amountWei = EvmUtil.toWeiAmount(amount, token.decimals);
+    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
+      from: this.walletAddress,
+      to: token.chainId,
+      data: EvmUtil.encodeErc20Transfer(this.randomReceiverAddress, amountWei),
+      type: 2,
+    });
 
-      return EvmUtil.fromWeiAmount(totalGasCost);
-    } catch (e) {
-      this.logger.verbose(`Gas estimation failed for token ${token.uniqueName}: ${e.message}. Using default.`);
-      return 0.00001;
-    }
+    return EvmUtil.fromWeiAmount(totalGasCost);
   }
 
   async getTxActualFee(txHash: string): Promise<number> {
@@ -186,13 +182,5 @@ export class BaseClient extends EvmClient implements L2BridgeEvmClient {
 
   private get l2Provider(): L2Provider<ethers.providers.JsonRpcProvider> {
     return asL2Provider(this.provider);
-  }
-
-  private get dummyTokenPayload(): string {
-    const method = 'a9059cbb000000000000000000000000';
-    const destination = this.randomReceiverAddress.slice(2);
-    const value = '0000000000000000000000000000000000000000000000000000000000000001';
-
-    return '0x' + method + destination + value;
   }
 }

--- a/src/integration/blockchain/optimism/optimism-client.ts
+++ b/src/integration/blockchain/optimism/optimism-client.ts
@@ -145,31 +145,27 @@ export class OptimismClient extends EvmClient implements L2BridgeEvmClient {
    * @overwrite
    */
 
-  async getCurrentGasCostForCoinTransaction(): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
       from: this.walletAddress,
       to: this.randomReceiverAddress,
-      value: 1,
+      value: EvmUtil.toWeiAmount(amount).toString(),
       type: 2,
     });
 
     return EvmUtil.fromWeiAmount(totalGasCost);
   }
 
-  async getCurrentGasCostForTokenTransaction(token: Asset): Promise<number> {
-    try {
-      const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
-        from: this.walletAddress,
-        to: token.chainId,
-        data: this.dummyTokenPayload,
-        type: 2,
-      });
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    const amountWei = EvmUtil.toWeiAmount(amount, token.decimals);
+    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
+      from: this.walletAddress,
+      to: token.chainId,
+      data: EvmUtil.encodeErc20Transfer(this.randomReceiverAddress, amountWei),
+      type: 2,
+    });
 
-      return EvmUtil.fromWeiAmount(totalGasCost);
-    } catch (e) {
-      this.logger.verbose(`Gas estimation failed for token ${token.uniqueName}: ${e.message}. Using default.`);
-      return 0.00001;
-    }
+    return EvmUtil.fromWeiAmount(totalGasCost);
   }
 
   async getTxActualFee(txHash: string): Promise<number> {
@@ -186,13 +182,5 @@ export class OptimismClient extends EvmClient implements L2BridgeEvmClient {
 
   private get l2Provider(): L2Provider<ethers.providers.JsonRpcProvider> {
     return asL2Provider(this.provider);
-  }
-
-  private get dummyTokenPayload(): string {
-    const method = 'a9059cbb000000000000000000000000';
-    const destination = this.randomReceiverAddress.slice(2);
-    const value = '0000000000000000000000000000000000000000000000000000000000000001';
-
-    return '0x' + method + destination + value;
   }
 }

--- a/src/integration/blockchain/polygon/polygon-client.ts
+++ b/src/integration/blockchain/polygon/polygon-client.ts
@@ -62,7 +62,8 @@ export class PolygonClient extends EvmClient implements L2BridgeEvmClient {
     }
 
     // Increase the gas limit by a factor of 5 to enable the smart contract to be executed without "out of gas" error
-    const gasLimit = (await this.getTokenGasLimitForAsset(l1Token)).mul(5);
+    const amountWei = EvmUtil.toWeiAmount(amount, l1Token.decimals);
+    const gasLimit = (await this.getTokenGasLimitForAsset(l1Token, amountWei)).mul(5);
 
     const l1Erc20Token = this.posClient.erc20(l1Token.chainId, true);
 

--- a/src/integration/blockchain/shared/evm/evm-client.ts
+++ b/src/integration/blockchain/shared/evm/evm-client.ts
@@ -181,11 +181,10 @@ export abstract class EvmClient extends BlockchainClient {
     return this.provider.getTransactionCount(address);
   }
 
-  protected async getTokenGasLimitForAsset(token: Asset): Promise<EthersNumber> {
+  protected async getTokenGasLimitForAsset(token: Asset, amount: EthersNumber): Promise<EthersNumber> {
     const contract = this.getERC20ContractForDex(token.chainId);
 
-    // Sample amount of 1 wei for fee estimation only (no concrete TX context here)
-    return this.getTokenGasLimitForContact(contract, this.randomReceiverAddress, ethers.BigNumber.from(1));
+    return this.getTokenGasLimitForContact(contract, this.randomReceiverAddress, amount);
   }
 
   async getTokenGasLimitForContact(contract: Contract, to: string, amount: EthersNumber): Promise<EthersNumber> {
@@ -799,15 +798,16 @@ export abstract class EvmClient extends BlockchainClient {
     );
   }
 
-  async getCurrentGasCostForCoinTransaction(): Promise<number> {
-    const totalGas = await this.getCurrentGasForCoinTransaction(this.walletAddress, this.randomReceiverAddress, 1e-18);
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
+    const totalGas = await this.getCurrentGasForCoinTransaction(this.walletAddress, this.randomReceiverAddress, amount);
     const gasPrice = await this.getRecommendedGasPrice();
 
     return EvmUtil.fromWeiAmount(totalGas.mul(gasPrice));
   }
 
-  async getCurrentGasCostForTokenTransaction(token: Asset): Promise<number> {
-    const totalGas = await this.getTokenGasLimitForAsset(token);
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    const amountWei = EvmUtil.toWeiAmount(amount, token.decimals);
+    const totalGas = await this.getTokenGasLimitForAsset(token, amountWei);
     const gasPrice = await this.getRecommendedGasPrice();
 
     return EvmUtil.fromWeiAmount(totalGas.mul(gasPrice));

--- a/src/subdomains/supporting/payin/services/base/payin-evm.service.ts
+++ b/src/subdomains/supporting/payin/services/base/payin-evm.service.ts
@@ -23,8 +23,8 @@ export abstract class PayInEvmService {
     return this.#client.sendTokenFromAccount(account, addressTo, tokenName, amount);
   }
 
-  async getGasCostForCoinTransaction(): Promise<number> {
-    return this.#client.getCurrentGasCostForCoinTransaction();
+  async getGasCostForCoinTransaction(amount: number): Promise<number> {
+    return this.#client.getCurrentGasCostForCoinTransaction(amount);
   }
 
   async checkTransactionCompletion(txHash: string, minConfirmations: number): Promise<boolean> {

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/evm-coin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/evm-coin.strategy.ts
@@ -46,7 +46,7 @@ export abstract class EvmCoinStrategy extends EvmStrategy {
 
     const groupAmount = this.getTotalGroupAmount(payInGroup, type);
     // use fresh gas cost (not cached estimate) to avoid value + gas > balance
-    const freshGasCost = await this.payInEvmService.getGasCostForCoinTransaction();
+    const freshGasCost = await this.payInEvmService.getGasCostForCoinTransaction(groupAmount);
     const gasCost = Math.max(freshGasCost, estimatedNativeFee);
     const amount = Util.round(groupAmount - gasCost * 1.05, 12);
 

--- a/src/subdomains/supporting/payout/services/payout-base.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-base.service.ts
@@ -13,11 +13,11 @@ export class PayoutBaseService extends PayoutEvmService {
     this.baseClient = baseService.getDefaultClient<BaseClient>();
   }
 
-  async getCurrentGasForCoinTransaction(): Promise<number> {
-    return this.baseClient.getCurrentGasCostForCoinTransaction();
+  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+    return this.baseClient.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset): Promise<number> {
-    return this.baseClient.getCurrentGasCostForTokenTransaction(token);
+  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    return this.baseClient.getCurrentGasCostForTokenTransaction(token, amount);
   }
 }

--- a/src/subdomains/supporting/payout/services/payout-evm.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-evm.service.ts
@@ -32,12 +32,12 @@ export abstract class PayoutEvmService {
     return { state: 'failed', isOutOfGas };
   }
 
-  async getCurrentGasForCoinTransaction(): Promise<number> {
-    return this.client.getCurrentGasCostForCoinTransaction();
+  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+    return this.client.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset): Promise<number> {
-    return this.client.getCurrentGasCostForTokenTransaction(token);
+  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    return this.client.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   async getTxNonce(txHash: string): Promise<number> {

--- a/src/subdomains/supporting/payout/services/payout-gnosis.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-gnosis.service.ts
@@ -13,11 +13,11 @@ export class PayoutGnosisService extends PayoutEvmService {
     this.gnosisClient = gnosisService.getDefaultClient<GnosisClient>();
   }
 
-  async getCurrentGasForCoinTransaction(): Promise<number> {
-    return this.gnosisClient.getCurrentGasCostForCoinTransaction();
+  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+    return this.gnosisClient.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset): Promise<number> {
-    return this.gnosisClient.getCurrentGasCostForTokenTransaction(token);
+  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    return this.gnosisClient.getCurrentGasCostForTokenTransaction(token, amount);
   }
 }

--- a/src/subdomains/supporting/payout/services/payout-optimism.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-optimism.service.ts
@@ -13,11 +13,11 @@ export class PayoutOptimismService extends PayoutEvmService {
     this.optimismClient = optimismService.getDefaultClient<OptimismClient>();
   }
 
-  async getCurrentGasForCoinTransaction(): Promise<number> {
-    return this.optimismClient.getCurrentGasCostForCoinTransaction();
+  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+    return this.optimismClient.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset): Promise<number> {
-    return this.optimismClient.getCurrentGasCostForTokenTransaction(token);
+  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    return this.optimismClient.getCurrentGasCostForTokenTransaction(token, amount);
   }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-coin.strategy.ts
@@ -31,7 +31,7 @@ export class ArbitrumCoinStrategy extends EvmStrategy {
     return this.arbitrumService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.arbitrumService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-coin.strategy.ts
@@ -31,8 +31,8 @@ export class ArbitrumCoinStrategy extends EvmStrategy {
     return this.arbitrumService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.arbitrumService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.arbitrumService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-token.strategy.ts
@@ -31,8 +31,8 @@ export class ArbitrumTokenStrategy extends EvmStrategy {
     return this.arbitrumService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.arbitrumService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.arbitrumService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-token.strategy.ts
@@ -31,7 +31,7 @@ export class ArbitrumTokenStrategy extends EvmStrategy {
     return this.arbitrumService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.arbitrumService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
@@ -31,8 +31,8 @@ export class BaseCoinStrategy extends EvmStrategy {
     return this.baseService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.baseService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.baseService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
@@ -31,7 +31,7 @@ export class BaseCoinStrategy extends EvmStrategy {
     return this.baseService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.baseService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
@@ -31,8 +31,8 @@ export class BaseTokenStrategy extends EvmStrategy {
     return this.baseService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.baseService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.baseService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
@@ -31,7 +31,7 @@ export class BaseTokenStrategy extends EvmStrategy {
     return this.baseService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.baseService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -2,7 +2,6 @@ import { Config } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { DisabledProcess, Process } from 'src/shared/services/process.service';
-import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
 import { Util } from 'src/shared/utils/util';
 import { FeeResult, PayoutTxStatus } from 'src/subdomains/supporting/payout/interfaces';
 import { PriceCurrency, PriceValidity } from 'src/subdomains/supporting/pricing/services/pricing.service';
@@ -14,8 +13,6 @@ import { PayoutStrategy } from './payout.strategy';
 export abstract class EvmStrategy extends PayoutStrategy {
   private readonly logger = new DfxLogger(EvmStrategy);
 
-  private readonly txFees = new AsyncCache<number>(CacheItemResetPeriod.EVERY_30_SECONDS);
-
   constructor(
     protected readonly payoutEvmService: PayoutEvmService,
     protected readonly payoutOrderRepo: PayoutOrderRepository,
@@ -24,16 +21,21 @@ export abstract class EvmStrategy extends PayoutStrategy {
   }
 
   protected abstract dispatchPayout(order: PayoutOrder): Promise<string>;
-  protected abstract getCurrentGasForTransaction(token?: Asset): Promise<number>;
+  protected abstract getCurrentGasForTransaction(amount: number, token: Asset): Promise<number>;
 
-  async estimateFee(asset: Asset): Promise<FeeResult> {
-    const gasPerTransaction = await this.txFees.get(asset.id.toString(), () => this.getCurrentGasForTransaction(asset));
+  async estimateFee(targetAsset: Asset, _address: string, amount: number, _asset: Asset): Promise<FeeResult> {
+    const gasPerTransaction = await this.getCurrentGasForTransaction(amount, targetAsset);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };
   }
 
   async estimateBlockchainFee(asset: Asset): Promise<FeeResult> {
-    return this.estimateFee(asset);
+    // Amount-independent preview: gas cost for plain ERC-20 / coin transfers does not depend on
+    // the transferred amount, so any positive sample produces the same fee estimate.
+    const previewAmount = 1;
+    const gasPerTransaction = await this.getCurrentGasForTransaction(previewAmount, asset);
+
+    return { asset: await this.feeAsset(), amount: gasPerTransaction };
   }
 
   async doPayout(orders: PayoutOrder[]): Promise<void> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -1,4 +1,5 @@
 import { Config } from 'src/config/config';
+import { EvmUtil } from 'src/integration/blockchain/shared/evm/evm.util';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { DisabledProcess, Process } from 'src/shared/services/process.service';
@@ -33,7 +34,7 @@ export abstract class EvmStrategy extends PayoutStrategy {
     // Amount-independent preview: gas cost for plain ERC-20 / coin transfers does not depend on
     // the transferred amount. Use 1 wei (minimal non-zero amount) to avoid balance-related
     // estimateGas reverts on the dex wallet.
-    const previewAmount = 1 / Math.pow(10, asset.decimals);
+    const previewAmount = EvmUtil.fromWeiAmount(1, asset.decimals);
     const gasPerTransaction = await this.getCurrentGasForTransaction(previewAmount, asset);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -31,8 +31,9 @@ export abstract class EvmStrategy extends PayoutStrategy {
 
   async estimateBlockchainFee(asset: Asset): Promise<FeeResult> {
     // Amount-independent preview: gas cost for plain ERC-20 / coin transfers does not depend on
-    // the transferred amount, so any positive sample produces the same fee estimate.
-    const previewAmount = 1;
+    // the transferred amount. Use 1 wei (minimal non-zero amount) to avoid balance-related
+    // estimateGas reverts on the dex wallet.
+    const previewAmount = 1 / Math.pow(10, asset.decimals);
     const gasPerTransaction = await this.getCurrentGasForTransaction(previewAmount, asset);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -22,10 +22,10 @@ export abstract class EvmStrategy extends PayoutStrategy {
   }
 
   protected abstract dispatchPayout(order: PayoutOrder): Promise<string>;
-  protected abstract getCurrentGasForTransaction(amount: number, token: Asset): Promise<number>;
+  protected abstract getCurrentGasForTransaction(token: Asset, amount: number): Promise<number>;
 
   async estimateFee(targetAsset: Asset, _address: string, amount: number, _asset: Asset): Promise<FeeResult> {
-    const gasPerTransaction = await this.getCurrentGasForTransaction(amount, targetAsset);
+    const gasPerTransaction = await this.getCurrentGasForTransaction(targetAsset, amount);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };
   }
@@ -35,7 +35,7 @@ export abstract class EvmStrategy extends PayoutStrategy {
     // the transferred amount. Use 1 wei (minimal non-zero amount) to avoid balance-related
     // estimateGas reverts on the dex wallet.
     const previewAmount = EvmUtil.fromWeiAmount(1, asset.decimals);
-    const gasPerTransaction = await this.getCurrentGasForTransaction(previewAmount, asset);
+    const gasPerTransaction = await this.getCurrentGasForTransaction(asset, previewAmount);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };
   }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/bsc-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/bsc-coin.strategy.ts
@@ -31,7 +31,7 @@ export class BscCoinStrategy extends EvmStrategy {
     return this.bscService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.bscService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/bsc-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/bsc-coin.strategy.ts
@@ -31,8 +31,8 @@ export class BscCoinStrategy extends EvmStrategy {
     return this.bscService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.bscService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.bscService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/bsc-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/bsc-token.strategy.ts
@@ -31,7 +31,7 @@ export class BscTokenStrategy extends EvmStrategy {
     return this.bscService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.bscService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/bsc-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/bsc-token.strategy.ts
@@ -31,8 +31,8 @@ export class BscTokenStrategy extends EvmStrategy {
     return this.bscService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.bscService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.bscService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-coin.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaCoinStrategy extends EvmStrategy {
     return this.citreaService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.citreaService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.citreaService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-coin.strategy.ts
@@ -31,7 +31,7 @@ export class CitreaCoinStrategy extends EvmStrategy {
     return this.citreaService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.citreaService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-coin.strategy.ts
@@ -31,7 +31,7 @@ export class CitreaTestnetCoinStrategy extends EvmStrategy {
     return this.citreaTestnetService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.citreaTestnetService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-coin.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaTestnetCoinStrategy extends EvmStrategy {
     return this.citreaTestnetService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.citreaTestnetService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.citreaTestnetService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-token.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaTestnetTokenStrategy extends EvmStrategy {
     return this.citreaTestnetService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.citreaTestnetService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.citreaTestnetService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected async getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-token.strategy.ts
@@ -31,7 +31,7 @@ export class CitreaTestnetTokenStrategy extends EvmStrategy {
     return this.citreaTestnetService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.citreaTestnetService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-token.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaTokenStrategy extends EvmStrategy {
     return this.citreaService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.citreaService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.citreaService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected async getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-token.strategy.ts
@@ -31,7 +31,7 @@ export class CitreaTokenStrategy extends EvmStrategy {
     return this.citreaService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.citreaService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-coin.strategy.ts
@@ -31,7 +31,7 @@ export class EthereumCoinStrategy extends EvmStrategy {
     return this.ethereumService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.ethereumService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-coin.strategy.ts
@@ -31,8 +31,8 @@ export class EthereumCoinStrategy extends EvmStrategy {
     return this.ethereumService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.ethereumService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.ethereumService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-token.strategy.ts
@@ -31,8 +31,8 @@ export class EthereumTokenStrategy extends EvmStrategy {
     return this.ethereumService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.ethereumService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.ethereumService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-token.strategy.ts
@@ -31,7 +31,7 @@ export class EthereumTokenStrategy extends EvmStrategy {
     return this.ethereumService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.ethereumService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
@@ -31,8 +31,8 @@ export class GnosisCoinStrategy extends EvmStrategy {
     return this.gnosisService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.gnosisService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.gnosisService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
@@ -31,7 +31,7 @@ export class GnosisCoinStrategy extends EvmStrategy {
     return this.gnosisService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.gnosisService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
@@ -31,7 +31,7 @@ export class GnosisTokenStrategy extends EvmStrategy {
     return this.gnosisService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.gnosisService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
@@ -31,8 +31,8 @@ export class GnosisTokenStrategy extends EvmStrategy {
     return this.gnosisService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.gnosisService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.gnosisService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
@@ -31,8 +31,8 @@ export class OptimismCoinStrategy extends EvmStrategy {
     return this.optimismService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.optimismService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.optimismService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
@@ -31,7 +31,7 @@ export class OptimismCoinStrategy extends EvmStrategy {
     return this.optimismService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.optimismService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
@@ -31,7 +31,7 @@ export class OptimismTokenStrategy extends EvmStrategy {
     return this.optimismService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.optimismService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
@@ -31,8 +31,8 @@ export class OptimismTokenStrategy extends EvmStrategy {
     return this.optimismService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.optimismService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.optimismService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
@@ -31,8 +31,8 @@ export class PolygonCoinStrategy extends EvmStrategy {
     return this.polygonService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.polygonService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.polygonService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
@@ -31,7 +31,7 @@ export class PolygonCoinStrategy extends EvmStrategy {
     return this.polygonService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.polygonService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
@@ -31,8 +31,8 @@ export class PolygonTokenStrategy extends EvmStrategy {
     return this.polygonService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.polygonService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.polygonService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
@@ -31,7 +31,7 @@ export class PolygonTokenStrategy extends EvmStrategy {
     return this.polygonService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.polygonService.getCurrentGasForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-coin.strategy.ts
@@ -31,7 +31,7 @@ export class SepoliaCoinStrategy extends EvmStrategy {
     return this.sepoliaService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
     return this.sepoliaService.getCurrentGasForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-coin.strategy.ts
@@ -31,8 +31,8 @@ export class SepoliaCoinStrategy extends EvmStrategy {
     return this.sepoliaService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(): Promise<number> {
-    return this.sepoliaService.getCurrentGasForCoinTransaction();
+  protected getCurrentGasForTransaction(amount: number, _token: Asset): Promise<number> {
+    return this.sepoliaService.getCurrentGasForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-token.strategy.ts
@@ -31,8 +31,8 @@ export class SepoliaTokenStrategy extends EvmStrategy {
     return this.sepoliaService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset): Promise<number> {
-    return this.sepoliaService.getCurrentGasForTokenTransaction(token);
+  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+    return this.sepoliaService.getCurrentGasForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-token.strategy.ts
@@ -31,7 +31,7 @@ export class SepoliaTokenStrategy extends EvmStrategy {
     return this.sepoliaService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(amount: number, token: Asset): Promise<number> {
+  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
     return this.sepoliaService.getCurrentGasForTokenTransaction(token, amount);
   }
 


### PR DESCRIPTION
## Summary
Removes every silent fallback in the EVM gas-estimation pipeline. The transferred amount is now propagated all the way from the caller down to `estimateGas.transfer(...)`, so every estimate is computed against the real transaction context.

## Why
Previously the EVM gas pipeline had three independent fallback layers that hid wrong estimates behind safe-looking numbers:

1. `getTokenGasLimitForContact(amount?)` defaulted to `amount ?? 1` when callers didn't pass anything.
2. The same method had a `try/catch` returning a hardcoded **100 000** gas on estimation failure.
3. `OptimismClient` / `BaseClient` had their own `try/catch` returning a hardcoded **0.00001** fallback fee.

This made it impossible to tell whether a fee figure was the result of a real estimate or a silent fallback.

## Changes (high level)

- **`EvmClient`**: `getCurrentGasCostForCoinTransaction(amount)`, `getCurrentGasCostForTokenTransaction(token, amount)`, `getTokenGasLimitForAsset(token, amount)` — amount required, no defaults.
- **`OptimismClient`, `BaseClient`**: same signatures; removed the `try/catch → 0.00001` fallback; the dummy token payload is now built from the real amount via `EvmUtil.encodeErc20Transfer`.
- **`PayoutEvmService`** and the Optimism / Base / Gnosis overrides take `amount`.
- **`PayinEvmService.getGasCostForCoinTransaction(amount)`**: amount required; the only caller (evm-coin send strategy) already has the group amount and passes it.
- **`PolygonClient.depositTokenOnDex`**: passes the bridge `amount` through to `getTokenGasLimitForAsset`.
- **`EvmStrategy.getCurrentGasForTransaction(amount, token)`** abstract: signature now requires both — updated in all 20 EVM coin/token strategies.
- **`EvmStrategy.estimateFee(targetAsset, address, amount, asset)`**: now Liskov-conforming to `PayoutStrategy.estimateFee`; the per-asset `AsyncCache` is gone because the result is amount-dependent.
- **`EvmStrategy.estimateBlockchainFee`**: uses an explicitly documented preview sample (gas cost for plain transfers is amount-independent, so any positive sample is a valid preview); this is the only call site where no concrete amount exists by API contract.

## What is intentionally NOT in this PR
- Non-EVM chains (Cardano, ICP, Solana, Tron, Bitcoin) keep their existing 1-argument `estimateFee(asset)` and their own fee estimation pipelines untouched.
- `PayoutStrategy.estimateBlockchainFee(asset)` keeps its amount-free signature because two external call sites (`fee.service.calculateBlockchainFeeInChf`, `custody dfx-order-step.adapter` chargeRoute) have no concrete amount; only the EVM implementation is adjusted with a documented preview sample.

## Test plan
- [ ] CI green (format / type-check / lint / jest)
- [ ] DEV smoke test: trigger an EVM token payout and an EVM coin payout, verify success
- [ ] DEV smoke test: estimate fee for a token payout via the API, verify the returned amount matches a manual gas estimate