### PR TITLE
refactor(evm): cleanup typo, L2 dedup, and gas-method naming

### DIFF
--- a/src/integration/blockchain/base/base-client.ts
+++ b/src/integration/blockchain/base/base-client.ts
@@ -1,21 +1,15 @@
-import { CrossChainMessenger, L2Provider, MessageStatus, asL2Provider, estimateTotalGasCost } from '@eth-optimism/sdk';
-import { BigNumber, ethers } from 'ethers';
+import { CrossChainMessenger, MessageStatus } from '@eth-optimism/sdk';
+import { ethers } from 'ethers';
 import { GetConfig } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { Util } from 'src/shared/utils/util';
-import { EvmClient, EvmClientParams } from '../shared/evm/evm-client';
+import { EvmClientParams } from '../shared/evm/evm-client';
 import { EvmUtil } from '../shared/evm/evm.util';
 import { L2BridgeEvmClient } from '../shared/evm/interfaces';
+import { OpStackEvmClient } from '../shared/evm/op-stack-evm-client';
 
-interface BaseTransactionReceipt extends ethers.providers.TransactionReceipt {
-  l1Fee: BigNumber;
-  l1GasPrice: BigNumber;
-  l1GasUsed: BigNumber;
-  l1FeeScalar: number;
-}
-
-export class BaseClient extends EvmClient implements L2BridgeEvmClient {
+export class BaseClient extends OpStackEvmClient implements L2BridgeEvmClient {
   protected override readonly logger = new DfxLogger(BaseClient);
 
   private readonly l1Provider: ethers.providers.JsonRpcProvider;
@@ -139,48 +133,5 @@ export class BaseClient extends EvmClient implements L2BridgeEvmClient {
     } catch {
       return false;
     }
-  }
-
-  /**
-   * @overwrite
-   */
-
-  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
-    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
-      from: this.walletAddress,
-      to: this.randomReceiverAddress,
-      value: EvmUtil.toWeiAmount(amount).toString(),
-      type: 2,
-    });
-
-    return EvmUtil.fromWeiAmount(totalGasCost);
-  }
-
-  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
-    const amountWei = EvmUtil.toWeiAmount(amount, token.decimals);
-    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
-      from: this.walletAddress,
-      to: token.chainId,
-      data: EvmUtil.encodeErc20Transfer(this.randomReceiverAddress, amountWei),
-      type: 2,
-    });
-
-    return EvmUtil.fromWeiAmount(totalGasCost);
-  }
-
-  async getTxActualFee(txHash: string): Promise<number> {
-    const receipt = await this.l2Provider.getTransactionReceipt(txHash);
-
-    const { gasUsed, effectiveGasPrice, l1Fee } = receipt as BaseTransactionReceipt;
-
-    const l2Fee = gasUsed.mul(effectiveGasPrice);
-
-    return EvmUtil.fromWeiAmount(l1Fee.add(l2Fee));
-  }
-
-  //*** HELPER METHODS ***//
-
-  private get l2Provider(): L2Provider<ethers.providers.JsonRpcProvider> {
-    return asL2Provider(this.provider);
   }
 }

--- a/src/integration/blockchain/optimism/optimism-client.ts
+++ b/src/integration/blockchain/optimism/optimism-client.ts
@@ -1,21 +1,15 @@
-import { CrossChainMessenger, L2Provider, MessageStatus, asL2Provider, estimateTotalGasCost } from '@eth-optimism/sdk';
-import { BigNumber, ethers } from 'ethers';
+import { CrossChainMessenger, MessageStatus } from '@eth-optimism/sdk';
+import { ethers } from 'ethers';
 import { GetConfig } from 'src/config/config';
 import { Asset } from 'src/shared/models/asset/asset.entity';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { Util } from 'src/shared/utils/util';
-import { EvmClient, EvmClientParams } from '../shared/evm/evm-client';
+import { EvmClientParams } from '../shared/evm/evm-client';
 import { EvmUtil } from '../shared/evm/evm.util';
 import { L2BridgeEvmClient } from '../shared/evm/interfaces';
+import { OpStackEvmClient } from '../shared/evm/op-stack-evm-client';
 
-interface OptimismTransactionReceipt extends ethers.providers.TransactionReceipt {
-  l1GasPrice: BigNumber;
-  l1GasUsed: BigNumber;
-  l1FeeScalar: number;
-  l1Fee: BigNumber;
-}
-
-export class OptimismClient extends EvmClient implements L2BridgeEvmClient {
+export class OptimismClient extends OpStackEvmClient implements L2BridgeEvmClient {
   protected override readonly logger = new DfxLogger(OptimismClient);
 
   private readonly l1Provider: ethers.providers.JsonRpcProvider;
@@ -139,48 +133,5 @@ export class OptimismClient extends EvmClient implements L2BridgeEvmClient {
     } catch {
       return false;
     }
-  }
-
-  /**
-   * @overwrite
-   */
-
-  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
-    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
-      from: this.walletAddress,
-      to: this.randomReceiverAddress,
-      value: EvmUtil.toWeiAmount(amount).toString(),
-      type: 2,
-    });
-
-    return EvmUtil.fromWeiAmount(totalGasCost);
-  }
-
-  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
-    const amountWei = EvmUtil.toWeiAmount(amount, token.decimals);
-    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
-      from: this.walletAddress,
-      to: token.chainId,
-      data: EvmUtil.encodeErc20Transfer(this.randomReceiverAddress, amountWei),
-      type: 2,
-    });
-
-    return EvmUtil.fromWeiAmount(totalGasCost);
-  }
-
-  async getTxActualFee(txHash: string): Promise<number> {
-    const receipt = await this.l2Provider.getTransactionReceipt(txHash);
-
-    const { gasUsed, effectiveGasPrice, l1Fee } = receipt as OptimismTransactionReceipt;
-
-    const l2Fee = gasUsed.mul(effectiveGasPrice);
-
-    return EvmUtil.fromWeiAmount(l1Fee.add(l2Fee));
-  }
-
-  //*** HELPER METHODS ***//
-
-  private get l2Provider(): L2Provider<ethers.providers.JsonRpcProvider> {
-    return asL2Provider(this.provider);
   }
 }

--- a/src/integration/blockchain/shared/evm/evm-client.ts
+++ b/src/integration/blockchain/shared/evm/evm-client.ts
@@ -184,10 +184,10 @@ export abstract class EvmClient extends BlockchainClient {
   protected async getTokenGasLimitForAsset(token: Asset, amount: EthersNumber): Promise<EthersNumber> {
     const contract = this.getERC20ContractForDex(token.chainId);
 
-    return this.getTokenGasLimitForContact(contract, this.randomReceiverAddress, amount);
+    return this.getTokenGasLimitForContract(contract, this.randomReceiverAddress, amount);
   }
 
-  async getTokenGasLimitForContact(contract: Contract, to: string, amount: EthersNumber): Promise<EthersNumber> {
+  async getTokenGasLimitForContract(contract: Contract, to: string, amount: EthersNumber): Promise<EthersNumber> {
     const gasEstimate = await contract.estimateGas.transfer(to, amount);
     return gasEstimate.mul(12).div(10);
   }
@@ -241,7 +241,7 @@ export abstract class EvmClient extends BlockchainClient {
         to: asset.chainId,
         data: EvmUtil.encodeErc20Transfer(toAddress, amountWei),
         value: '0',
-        gasLimit: await this.getTokenGasLimitForContact(contract, toAddress, amountWei),
+        gasLimit: await this.getTokenGasLimitForContract(contract, toAddress, amountWei),
       };
     }
   }
@@ -858,7 +858,7 @@ export abstract class EvmClient extends BlockchainClient {
     const token = await this.getTokenByContract(contract);
     const targetAmount = EvmUtil.toWeiAmount(amount, token.decimals);
 
-    const gasLimit = +(await this.getTokenGasLimitForContact(contract, toAddress, targetAmount));
+    const gasLimit = +(await this.getTokenGasLimitForContract(contract, toAddress, targetAmount));
     const gasPrice = +(await this.getRecommendedGasPrice());
     const currentNonce = await this.getNonce(fromAddress);
     const txNonce = nonce ?? currentNonce;

--- a/src/integration/blockchain/shared/evm/op-stack-evm-client.ts
+++ b/src/integration/blockchain/shared/evm/op-stack-evm-client.ts
@@ -1,0 +1,56 @@
+import { L2Provider, asL2Provider, estimateTotalGasCost } from '@eth-optimism/sdk';
+import { BigNumber, ethers } from 'ethers';
+import { Asset } from 'src/shared/models/asset/asset.entity';
+import { EvmClient } from './evm-client';
+import { EvmUtil } from './evm.util';
+
+interface OpStackTransactionReceipt extends ethers.providers.TransactionReceipt {
+  l1GasPrice: BigNumber;
+  l1GasUsed: BigNumber;
+  l1FeeScalar: number;
+  l1Fee: BigNumber;
+}
+
+/**
+ * Shared base for OP Stack L2 EVM clients (Optimism, Base, ...). Provides the L2-aware
+ * gas estimation and fee calculation that uses `@eth-optimism/sdk`. Concrete clients add
+ * their own bridge logic on top.
+ */
+export abstract class OpStackEvmClient extends EvmClient {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
+    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
+      from: this.walletAddress,
+      to: this.randomReceiverAddress,
+      value: EvmUtil.toWeiAmount(amount).toString(),
+      type: 2,
+    });
+
+    return EvmUtil.fromWeiAmount(totalGasCost);
+  }
+
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
+    const amountWei = EvmUtil.toWeiAmount(amount, token.decimals);
+    const totalGasCost = await estimateTotalGasCost(this.l2Provider, {
+      from: this.walletAddress,
+      to: token.chainId,
+      data: EvmUtil.encodeErc20Transfer(this.randomReceiverAddress, amountWei),
+      type: 2,
+    });
+
+    return EvmUtil.fromWeiAmount(totalGasCost);
+  }
+
+  async getTxActualFee(txHash: string): Promise<number> {
+    const receipt = await this.l2Provider.getTransactionReceipt(txHash);
+
+    const { gasUsed, effectiveGasPrice, l1Fee } = receipt as OpStackTransactionReceipt;
+
+    const l2Fee = gasUsed.mul(effectiveGasPrice);
+
+    return EvmUtil.fromWeiAmount(l1Fee.add(l2Fee));
+  }
+
+  protected get l2Provider(): L2Provider<ethers.providers.JsonRpcProvider> {
+    return asL2Provider(this.provider);
+  }
+}

--- a/src/subdomains/supporting/payin/services/base/payin-evm.service.ts
+++ b/src/subdomains/supporting/payin/services/base/payin-evm.service.ts
@@ -23,7 +23,7 @@ export abstract class PayInEvmService {
     return this.#client.sendTokenFromAccount(account, addressTo, tokenName, amount);
   }
 
-  async getGasCostForCoinTransaction(amount: number): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     return this.#client.getCurrentGasCostForCoinTransaction(amount);
   }
 

--- a/src/subdomains/supporting/payin/strategies/send/impl/base/evm-coin.strategy.ts
+++ b/src/subdomains/supporting/payin/strategies/send/impl/base/evm-coin.strategy.ts
@@ -46,7 +46,7 @@ export abstract class EvmCoinStrategy extends EvmStrategy {
 
     const groupAmount = this.getTotalGroupAmount(payInGroup, type);
     // use fresh gas cost (not cached estimate) to avoid value + gas > balance
-    const freshGasCost = await this.payInEvmService.getGasCostForCoinTransaction(groupAmount);
+    const freshGasCost = await this.payInEvmService.getCurrentGasCostForCoinTransaction(groupAmount);
     const gasCost = Math.max(freshGasCost, estimatedNativeFee);
     const amount = Util.round(groupAmount - gasCost * 1.05, 12);
 

--- a/src/subdomains/supporting/payout/services/payout-base.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-base.service.ts
@@ -13,11 +13,11 @@ export class PayoutBaseService extends PayoutEvmService {
     this.baseClient = baseService.getDefaultClient<BaseClient>();
   }
 
-  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     return this.baseClient.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
     return this.baseClient.getCurrentGasCostForTokenTransaction(token, amount);
   }
 }

--- a/src/subdomains/supporting/payout/services/payout-evm.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-evm.service.ts
@@ -32,11 +32,11 @@ export abstract class PayoutEvmService {
     return { state: 'failed', isOutOfGas };
   }
 
-  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     return this.client.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
     return this.client.getCurrentGasCostForTokenTransaction(token, amount);
   }
 

--- a/src/subdomains/supporting/payout/services/payout-gnosis.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-gnosis.service.ts
@@ -13,11 +13,11 @@ export class PayoutGnosisService extends PayoutEvmService {
     this.gnosisClient = gnosisService.getDefaultClient<GnosisClient>();
   }
 
-  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     return this.gnosisClient.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
     return this.gnosisClient.getCurrentGasCostForTokenTransaction(token, amount);
   }
 }

--- a/src/subdomains/supporting/payout/services/payout-optimism.service.ts
+++ b/src/subdomains/supporting/payout/services/payout-optimism.service.ts
@@ -13,11 +13,11 @@ export class PayoutOptimismService extends PayoutEvmService {
     this.optimismClient = optimismService.getDefaultClient<OptimismClient>();
   }
 
-  async getCurrentGasForCoinTransaction(amount: number): Promise<number> {
+  async getCurrentGasCostForCoinTransaction(amount: number): Promise<number> {
     return this.optimismClient.getCurrentGasCostForCoinTransaction(amount);
   }
 
-  async getCurrentGasForTokenTransaction(token: Asset, amount: number): Promise<number> {
+  async getCurrentGasCostForTokenTransaction(token: Asset, amount: number): Promise<number> {
     return this.optimismClient.getCurrentGasCostForTokenTransaction(token, amount);
   }
 }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-coin.strategy.ts
@@ -31,8 +31,8 @@ export class ArbitrumCoinStrategy extends EvmStrategy {
     return this.arbitrumService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.arbitrumService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.arbitrumService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/arbitrum-token.strategy.ts
@@ -31,8 +31,8 @@ export class ArbitrumTokenStrategy extends EvmStrategy {
     return this.arbitrumService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.arbitrumService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.arbitrumService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-coin.strategy.ts
@@ -31,8 +31,8 @@ export class BaseCoinStrategy extends EvmStrategy {
     return this.baseService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.baseService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.baseService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base-token.strategy.ts
@@ -31,8 +31,8 @@ export class BaseTokenStrategy extends EvmStrategy {
     return this.baseService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.baseService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.baseService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/base/evm.strategy.ts
@@ -22,10 +22,10 @@ export abstract class EvmStrategy extends PayoutStrategy {
   }
 
   protected abstract dispatchPayout(order: PayoutOrder): Promise<string>;
-  protected abstract getCurrentGasForTransaction(token: Asset, amount: number): Promise<number>;
+  protected abstract getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number>;
 
   async estimateFee(targetAsset: Asset, _address: string, amount: number, _asset: Asset): Promise<FeeResult> {
-    const gasPerTransaction = await this.getCurrentGasForTransaction(targetAsset, amount);
+    const gasPerTransaction = await this.getCurrentGasCostForTransaction(targetAsset, amount);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };
   }
@@ -35,7 +35,7 @@ export abstract class EvmStrategy extends PayoutStrategy {
     // the transferred amount. Use 1 wei (minimal non-zero amount) to avoid balance-related
     // estimateGas reverts on the dex wallet.
     const previewAmount = EvmUtil.fromWeiAmount(1, asset.decimals);
-    const gasPerTransaction = await this.getCurrentGasForTransaction(asset, previewAmount);
+    const gasPerTransaction = await this.getCurrentGasCostForTransaction(asset, previewAmount);
 
     return { asset: await this.feeAsset(), amount: gasPerTransaction };
   }

--- a/src/subdomains/supporting/payout/strategies/payout/impl/bsc-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/bsc-coin.strategy.ts
@@ -31,8 +31,8 @@ export class BscCoinStrategy extends EvmStrategy {
     return this.bscService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.bscService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.bscService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/bsc-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/bsc-token.strategy.ts
@@ -31,8 +31,8 @@ export class BscTokenStrategy extends EvmStrategy {
     return this.bscService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.bscService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.bscService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-coin.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaCoinStrategy extends EvmStrategy {
     return this.citreaService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.citreaService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.citreaService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-coin.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaTestnetCoinStrategy extends EvmStrategy {
     return this.citreaTestnetService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.citreaTestnetService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.citreaTestnetService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-testnet-token.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaTestnetTokenStrategy extends EvmStrategy {
     return this.citreaTestnetService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.citreaTestnetService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.citreaTestnetService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected async getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/citrea-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/citrea-token.strategy.ts
@@ -31,8 +31,8 @@ export class CitreaTokenStrategy extends EvmStrategy {
     return this.citreaService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.citreaService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.citreaService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected async getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-coin.strategy.ts
@@ -31,8 +31,8 @@ export class EthereumCoinStrategy extends EvmStrategy {
     return this.ethereumService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.ethereumService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.ethereumService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/ethereum-token.strategy.ts
@@ -31,8 +31,8 @@ export class EthereumTokenStrategy extends EvmStrategy {
     return this.ethereumService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.ethereumService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.ethereumService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-coin.strategy.ts
@@ -31,8 +31,8 @@ export class GnosisCoinStrategy extends EvmStrategy {
     return this.gnosisService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.gnosisService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.gnosisService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/gnosis-token.strategy.ts
@@ -31,8 +31,8 @@ export class GnosisTokenStrategy extends EvmStrategy {
     return this.gnosisService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.gnosisService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.gnosisService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-coin.strategy.ts
@@ -31,8 +31,8 @@ export class OptimismCoinStrategy extends EvmStrategy {
     return this.optimismService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.optimismService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.optimismService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/optimism-token.strategy.ts
@@ -31,8 +31,8 @@ export class OptimismTokenStrategy extends EvmStrategy {
     return this.optimismService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.optimismService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.optimismService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-coin.strategy.ts
@@ -31,8 +31,8 @@ export class PolygonCoinStrategy extends EvmStrategy {
     return this.polygonService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.polygonService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.polygonService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/polygon-token.strategy.ts
@@ -31,8 +31,8 @@ export class PolygonTokenStrategy extends EvmStrategy {
     return this.polygonService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.polygonService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.polygonService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-coin.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-coin.strategy.ts
@@ -31,8 +31,8 @@ export class SepoliaCoinStrategy extends EvmStrategy {
     return this.sepoliaService.sendNativeCoin(order.destinationAddress, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(_token: Asset, amount: number): Promise<number> {
-    return this.sepoliaService.getCurrentGasForCoinTransaction(amount);
+  protected getCurrentGasCostForTransaction(_token: Asset, amount: number): Promise<number> {
+    return this.sepoliaService.getCurrentGasCostForCoinTransaction(amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {

--- a/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-token.strategy.ts
+++ b/src/subdomains/supporting/payout/strategies/payout/impl/sepolia-token.strategy.ts
@@ -31,8 +31,8 @@ export class SepoliaTokenStrategy extends EvmStrategy {
     return this.sepoliaService.sendToken(order.destinationAddress, order.asset, order.amount, nonce);
   }
 
-  protected getCurrentGasForTransaction(token: Asset, amount: number): Promise<number> {
-    return this.sepoliaService.getCurrentGasForTokenTransaction(token, amount);
+  protected getCurrentGasCostForTransaction(token: Asset, amount: number): Promise<number> {
+    return this.sepoliaService.getCurrentGasCostForTokenTransaction(token, amount);
   }
 
   protected getFeeAsset(): Promise<Asset> {


### PR DESCRIPTION
## Summary
Three independent cleanups on top of #3717, each as its own commit:

1. **Typo fix**: `getTokenGasLimitForContact` → `getTokenGasLimitForContract`. The method takes an ERC-20 contract, not a contact.
2. **L2 code dedup**: Optimism and Base are both OP Stack chains and had **identical** implementations of `getCurrentGasCostForCoinTransaction`, `getCurrentGasCostForTokenTransaction`, `getTxActualFee` and the `l2Provider` getter (all using `@eth-optimism/sdk`). Extracted into a shared abstract `OpStackEvmClient`. Each chain client now only contains its bridge-specific logic (CrossChainMessenger). Two local `OptimismTransactionReceipt` / `BaseTransactionReceipt` interfaces with identical fields collapsed into one shared `OpStackTransactionReceipt`.
3. **Gas-method naming unified**: the wrapping service and strategy methods dropped the "Cost" suffix even though they return gas cost in coin units (delegating to client methods that do have "Cost" in the name). Now every layer that returns gas cost uses `getCurrentGasCostFor*`:
   - `PayoutEvmService` + Optimism / Base / Gnosis overrides
   - `EvmStrategy` + all 20 concrete EVM strategies (`getCurrentGasForTransaction` → `getCurrentGasCostForTransaction`)
   - `PayInEvmService.getGasCostForCoinTransaction` → `getCurrentGasCostForCoinTransaction` (adds "Current" for consistency)

   `EvmClient.getCurrentGasForCoinTransaction(from, to, amount)` is intentionally **not** renamed: it's an internal helper that returns raw gas units, not gas cost in coin.

## Why
Cleanup of three pre-existing inconsistencies that became visible during the strict gas-estimation refactor in #3717. No functional change.

## Stacking
This PR is stacked on top of #3717. Base branch is `refactor/evm-fee-estimation-amount-pipeline`. After #3717 merges, this PR rebases onto `develop`.

## Test plan
- [ ] CI green (format / type-check / lint / jest)
- [ ] Spot check on DEV that EVM payouts still work after the merge