### PR TITLE
feat(support): expose sell deposit address and blockchains (DEV-4570)

### DIFF
--- a/src/subdomains/core/sell-crypto/route/sell.service.ts
+++ b/src/subdomains/core/sell-crypto/route/sell.service.ts
@@ -135,7 +135,7 @@ export class SellService {
   async getSellsByUserDataId(userDataId: number): Promise<Sell[]> {
     return this.sellRepo.find({
       where: { user: { userData: { id: userDataId } } },
-      relations: { fiat: true, user: true },
+      relations: { fiat: true, user: true, deposit: true },
     });
   }
 

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -248,6 +248,9 @@ export class SellSupportInfo {
   id: number;
   iban: string;
   fiatName?: string;
+  depositAddress?: string;
+  depositBlockchains?: string[];
+  depositAddressExplorerUrl?: string;
   volume: number;
   active: boolean;
   created: Date;

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -592,7 +592,7 @@ export class SupportService {
       depositAddress: sell.deposit?.address,
       depositBlockchains,
       depositAddressExplorerUrl:
-        depositBlockchains?.[0] && sell.deposit?.address
+        depositBlockchains?.length === 1 && sell.deposit?.address
           ? addressExplorerUrl(depositBlockchains[0], sell.deposit.address)
           : undefined,
       volume: sell.annualVolume,
@@ -602,15 +602,15 @@ export class SupportService {
   }
 
   private toSwapSupportInfo(swap: Swap): SwapSupportInfo {
-    const depositBlockchain = swap.deposit?.blockchainList?.[0];
+    const depositBlockchains = swap.deposit?.blockchainList;
     return {
       id: swap.id,
       assetName: swap.asset?.name,
       blockchain: swap.asset?.blockchain,
       depositAddress: swap.deposit?.address,
       depositAddressExplorerUrl:
-        depositBlockchain && swap.deposit?.address
-          ? addressExplorerUrl(depositBlockchain, swap.deposit.address)
+        depositBlockchains?.length === 1 && swap.deposit?.address
+          ? addressExplorerUrl(depositBlockchains[0], swap.deposit.address)
           : undefined,
       volume: swap.volume,
       annualVolume: swap.annualVolume,

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -584,10 +584,17 @@ export class SupportService {
   }
 
   private toSellSupportInfo(sell: Sell): SellSupportInfo {
+    const depositBlockchains = sell.deposit?.blockchainList;
     return {
       id: sell.id,
       iban: sell.iban,
       fiatName: sell.fiat?.name,
+      depositAddress: sell.deposit?.address,
+      depositBlockchains,
+      depositAddressExplorerUrl:
+        depositBlockchains?.[0] && sell.deposit?.address
+          ? addressExplorerUrl(depositBlockchains[0], sell.deposit.address)
+          : undefined,
       volume: sell.annualVolume,
       active: sell.active,
       created: sell.created,


### PR DESCRIPTION
## Summary
- Add `depositAddress`, `depositBlockchains` and `depositAddressExplorerUrl` to `SellSupportInfo`
- Load the `deposit` relation in `SellService.getSellsByUserDataId`
- Map deposit fields in `SupportService.toSellSupportInfo`

Ticket: DEV-4570

## Test plan
- [ ] Open customer search and inspect a user with sell routes
- [ ] Verify deposit address, blockchains and explorer link are returned