### PR TITLE
feat(support): expose bankDataId on transactions (DEV-4573)

### DIFF
--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -155,6 +155,7 @@ export class TransactionSupportInfo {
   uid: string;
   buyCryptoId?: number;
   buyFiatId?: number;
+  bankDataId?: number;
   type?: string;
   sourceType: string;
   inputAmount?: number;

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -482,6 +482,7 @@ export class SupportService {
       uid: tx.uid,
       buyCryptoId: tx.buyCrypto?.id,
       buyFiatId: tx.buyFiat?.id,
+      bankDataId: tx.buyCrypto?.bankData?.id ?? tx.buyFiat?.bankData?.id,
       type: tx.type,
       sourceType: tx.sourceType,
       inputAmount: tx.buyCrypto?.inputAmount ?? tx.buyFiat?.inputAmount,

--- a/src/subdomains/supporting/payment/services/transaction.service.ts
+++ b/src/subdomains/supporting/payment/services/transaction.service.ts
@@ -147,8 +147,8 @@ export class TransactionService {
     return this.repo.find({
       where: { userData: { id: userDataId } },
       relations: {
-        buyCrypto: { cryptoInput: true, outputAsset: true },
-        buyFiat: { cryptoInput: true, outputAsset: true },
+        buyCrypto: { cryptoInput: true, outputAsset: true, bankData: true },
+        buyFiat: { cryptoInput: true, outputAsset: true, bankData: true },
         bankTxReturn: true,
         bankTxRepeat: true,
       },


### PR DESCRIPTION
## Summary
- Load the `bankData` relation on `buyCrypto` / `buyFiat` in `TransactionService.getTransactionsByUserDataId`
- Add `bankDataId` to `TransactionSupportInfo`
- Map `bankDataId` from `tx.buyCrypto?.bankData?.id ?? tx.buyFiat?.bankData?.id` in `SupportService.toTransactionSupportInfo`

Consumed by the matching services change (DFXswiss/services: `feature/DEV-4573-notifications-and-bankdata`).

Ticket: DEV-4573

## Test plan
- [ ] Open compliance user detail and verify `bankDataId` is included on transactions that have a BuyCrypto/BuyFiat with `bankData`
- [ ] Verify the value is `null/undefined` when no `bankData` is linked