### PR TITLE
feat(support): remove pending-onboardings endpoint (DEV-4574)

### DIFF
--- a/src/subdomains/generic/kyc/services/kyc.service.ts
+++ b/src/subdomains/generic/kyc/services/kyc.service.ts
@@ -1842,48 +1842,6 @@ export class KycService {
     }
   }
 
-  // --- Company Onboarding Queries ---
-
-  async getPendingCompanyOnboardings(): Promise<{ userDataId: number; date: Date }[]> {
-    const companyStepNames = [
-      KycStepName.LEGAL_ENTITY,
-      KycStepName.AUTHORITY,
-      KycStepName.OWNER_DIRECTORY,
-      KycStepName.SIGNATORY_POWER,
-      KycStepName.BENEFICIAL_OWNER,
-      KycStepName.OPERATIONAL_ACTIVITY,
-      KycStepName.DFX_APPROVAL,
-    ];
-
-    const results = await this.kycStepRepo
-      .createQueryBuilder('step')
-      .select('step.userDataId', 'userDataId')
-      .addSelect('MIN(step.updated)', 'date')
-      .innerJoin('step.userData', 'userData')
-      .where('step.name IN (:...names)', { names: companyStepNames })
-      .andWhere('step.status = :status', { status: ReviewStatus.MANUAL_REVIEW })
-      .andWhere('userData.accountType IN (:...accountTypes)', {
-        accountTypes: [AccountType.ORGANIZATION, AccountType.SOLE_PROPRIETORSHIP],
-      })
-      .andWhere('userData.kycLevel >= :minLevel', { minLevel: KycLevel.LEVEL_30 })
-      .andWhere('userData.status != :mergedStatus', { mergedStatus: UserDataStatus.MERGED })
-      .andWhere(
-        `step.userDataId NOT IN (
-          SELECT s2.userDataId FROM kyc_step s2
-          WHERE s2.name = :approvalName AND s2.status IN (:...doneStatuses)
-        )`,
-        {
-          approvalName: KycStepName.DFX_APPROVAL,
-          doneStatuses: [ReviewStatus.COMPLETED, ReviewStatus.FAILED],
-        },
-      )
-      .groupBy('step.userDataId')
-      .orderBy('date', 'ASC')
-      .getRawMany<{ userDataId: number; date: Date }>();
-
-    return results;
-  }
-
   async getDfxApprovalSteps(userDataIds: number[]): Promise<KycStep[]> {
     if (userDataIds.length === 0) return [];
 

--- a/src/subdomains/generic/support/dto/user-data-support.dto.ts
+++ b/src/subdomains/generic/support/dto/user-data-support.dto.ts
@@ -41,13 +41,6 @@ export class UserDataSupportInfo {
   onboardingStatus?: OnboardingStatus;
 }
 
-export class PendingOnboardingInfo {
-  id: number;
-  name?: string;
-  accountType?: string;
-  date: Date;
-}
-
 export class PendingTransactionInfo {
   txId: number;
   uid: string;

--- a/src/subdomains/generic/support/support.controller.ts
+++ b/src/subdomains/generic/support/support.controller.ts
@@ -36,7 +36,6 @@ import {
   CallQueueSummaryEntry,
   KycFileListEntry,
   KycFileYearlyStats,
-  PendingOnboardingInfo,
   PendingReviewItem,
   PendingReviewSummaryEntry,
   PendingReviewType,
@@ -95,14 +94,6 @@ export class SupportController {
   @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
   async getRecommendationGraph(@Param('id') id: string): Promise<RecommendationGraph> {
     return this.supportService.getRecommendationGraph(+id);
-  }
-
-  @Get('pending-onboardings')
-  @ApiBearerAuth()
-  @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.COMPLIANCE), UserActiveGuard())
-  async getPendingOnboardings(): Promise<PendingOnboardingInfo[]> {
-    return this.supportService.getPendingOnboardings();
   }
 
   @Get('pending-transactions')

--- a/src/subdomains/generic/support/support.service.ts
+++ b/src/subdomains/generic/support/support.service.ts
@@ -87,7 +87,6 @@ import {
   KycStepSupportInfo,
   NotificationSupportInfo,
   OnboardingStatus,
-  PendingOnboardingInfo,
   PendingTransactionInfo,
   PendingReviewItem,
   PendingReviewSummaryEntry,
@@ -805,25 +804,6 @@ export class SupportService {
       amlReason: tx.amlReason,
       date: tx.created,
     };
-  }
-
-  async getPendingOnboardings(): Promise<PendingOnboardingInfo[]> {
-    const pendingEntries = await this.kycService.getPendingCompanyOnboardings();
-    if (pendingEntries.length === 0) return [];
-
-    const userDataIds = pendingEntries.map((e) => e.userDataId);
-    const userDatas = await Promise.all(userDataIds.map((id) => this.userDataService.getUserData(id)));
-
-    const dateMap = new Map(pendingEntries.map((e) => [e.userDataId, e.date]));
-
-    return userDatas
-      .filter((ud): ud is UserData => !!ud)
-      .map((ud) => ({
-        id: ud.id,
-        name: this.formatUserName(ud),
-        accountType: ud.accountType,
-        date: dateMap.get(ud.id) ?? ud.created,
-      }));
   }
 
   async getPendingReviewsSummary(): Promise<PendingReviewSummaryEntry[]> {


### PR DESCRIPTION
## Summary
- Removes the `GET /support/pending-onboardings` endpoint — no longer consumed by the compliance dashboard (replaced by the unified pending-reviews overview)
- Removes `PendingOnboardingInfo` DTO
- Removes `KycService.getPendingCompanyOnboardings()` helper (only caller was the removed endpoint)

## Test plan
- [ ] Existing pending-reviews summary endpoint still returns expected data (KYC steps + bank data)
- [ ] No remaining references to `pending-onboardings` / `PendingOnboardingInfo` / `getPendingCompanyOnboardings`
- [ ] Compliance dashboard in services repo (paired PR) no longer requests the removed endpoint