### PR TITLE
feat(auth): add Monitoring role with read access to financial dashboard

### DIFF
--- a/src/shared/auth/role.guard.ts
+++ b/src/shared/auth/role.guard.ts
@@ -39,14 +39,16 @@ class RoleGuardClass implements CanActivate {
     [UserRole.CLIENT_COMPANY]: [UserRole.KYC_CLIENT_COMPANY],
   };
 
-  constructor(private readonly entryRole: UserRole) {}
+  constructor(private readonly entryRoles: UserRole[]) {}
 
   canActivate(context: ExecutionContext): boolean {
     const userRole = context.switchToHttp().getRequest().user?.role;
-    return this.entryRole === userRole || this.additionalRoles[this.entryRole]?.includes(userRole);
+    return this.entryRoles.some(
+      (entryRole) => entryRole === userRole || this.additionalRoles[entryRole]?.includes(userRole),
+    );
   }
 }
 
-export function RoleGuard(entryRole: UserRole): RoleGuardClass {
-  return new RoleGuardClass(entryRole);
+export function RoleGuard(...entryRoles: UserRole[]): RoleGuardClass {
+  return new RoleGuardClass(entryRoles);
 }

--- a/src/shared/auth/user-role.enum.ts
+++ b/src/shared/auth/user-role.enum.ts
@@ -11,6 +11,7 @@ export enum UserRole {
   CUSTODY = 'Custody',
   REALUNIT = 'RealUnit',
   MARKETING = 'Marketing',
+  MONITORING = 'Monitoring',
   DEBUG = 'Debug',
 
   // service roles

--- a/src/subdomains/supporting/dashboard/dashboard-financial.controller.ts
+++ b/src/subdomains/supporting/dashboard/dashboard-financial.controller.ts
@@ -21,7 +21,7 @@ export class DashboardFinancialController {
   @Get('log')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.MONITORING), UserActiveGuard())
   async getFinancialLog(
     @Query('from') from?: string,
     @Query('dailySample') dailySample?: string,
@@ -35,7 +35,7 @@ export class DashboardFinancialController {
   @Get('latest')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.MONITORING), UserActiveGuard())
   async getLatestBalance(): Promise<LatestBalanceResponseDto> {
     const result = await this.dashboardFinancialService.getLatestBalance();
     if (!result) throw new NotFoundException('No financial data available');
@@ -45,7 +45,7 @@ export class DashboardFinancialController {
   @Get('changes/latest')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.MONITORING), UserActiveGuard())
   async getLatestChanges(): Promise<FinancialChangesEntryDto> {
     const result = await this.dashboardFinancialService.getLatestFinancialChanges();
     if (!result) throw new NotFoundException('No financial changes available');
@@ -55,7 +55,7 @@ export class DashboardFinancialController {
   @Get('ref-recipients')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.MONITORING), UserActiveGuard())
   async getRefRewardRecipients(@Query('from') from?: string): Promise<RefRewardRecipientDto[]> {
     return this.dashboardFinancialService.getRefRewardRecipients(this.parseDate(from));
   }
@@ -63,7 +63,7 @@ export class DashboardFinancialController {
   @Get('changes')
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
-  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN), UserActiveGuard())
+  @UseGuards(AuthGuard(), RoleGuard(UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.MONITORING), UserActiveGuard())
   async getFinancialChanges(
     @Query('from') from?: string,
     @Query('dailySample') dailySample?: string,


### PR DESCRIPTION
## Summary

- Adds a new `MONITORING` user role with read-only access to the financial dashboard endpoints.
- Hierarchy: `ADMIN` ⊃ `COMPLIANCE` ⊃ `MONITORING` — all three roles are explicitly listed on the affected guards so each can hit the endpoints without changing the existing `additionalRoles` hierarchy map.
- Extends `RoleGuard` to accept multiple entry roles (variadic, backward-compatible — existing single-arg call sites are unaffected).

## Changes

- `src/shared/auth/user-role.enum.ts`: add `MONITORING = 'Monitoring'` (positioned after `MARKETING`, before service / external roles).
- `src/shared/auth/role.guard.ts`: make `RoleGuard(...entryRoles)` variadic; `canActivate` returns true if the request role matches (or is in the `additionalRoles` of) any of the supplied entry roles.
- `src/subdomains/supporting/dashboard/dashboard-financial.controller.ts`: widen guards on all four endpoints (`GET /dashboard/financial/log`, `/latest`, `/changes/latest`, `/ref-recipients`, `/changes`) from `RoleGuard(ADMIN)` to `RoleGuard(ADMIN, COMPLIANCE, MONITORING)`.

## Test plan

- [x] `npm run lint`
- [x] `npm run format` (no diff)
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm test` (938 passed, 106 skipped — unchanged baseline)
- [ ] Manual: assign a user the `Monitoring` role and verify they can hit the five financial dashboard endpoints; verify they cannot hit other admin-only endpoints.

## Migration notes

None — additive enum value + guard widening only. No DB / schema changes.

## Coordination

Touches a different file than the in-flight PR #3725 (`perf/dashboard-financial-log-optimization` modifies the service, this PR modifies the controller + auth) — no merge conflicts expected.