### PR TITLE
fix(bitcoin): round send fee_rate to 3 decimals

### DIFF
--- a/src/integration/blockchain/bitcoin/services/__tests__/bitcoin-fee.service.spec.ts
+++ b/src/integration/blockchain/bitcoin/services/__tests__/bitcoin-fee.service.spec.ts
@@ -97,6 +97,35 @@ describe('BitcoinFeeService', () => {
     });
   });
 
+  // --- getSendFeeRate() Tests --- //
+
+  describe('getSendFeeRate()', () => {
+    const feeConfig = { allowUnconfirmedUtxos: true, cpfpFeeMultiplier: 2.0, defaultFeeMultiplier: 1.5 };
+
+    beforeEach(() => {
+      Object.defineProperty(service, 'feeConfig', { get: () => feeConfig });
+    });
+
+    it('should round fee rate to 3 decimal places (Bitcoin Core send RPC limit)', async () => {
+      // estimatesmartfee returning 1.935 sat/vB multiplied by cpfpFeeMultiplier=2.0
+      // produces 3.8699999999999997 in JS due to floating-point arithmetic; Bitcoin Core
+      // rejects fee_rate with more than 3 decimal places via "Invalid amount".
+      mockClient.estimateSmartFee.mockResolvedValueOnce(1.935);
+
+      const result = await service.getSendFeeRate();
+
+      expect(result).toBe(3.87);
+    });
+
+    it('should preserve integer fee rates without artifacts', async () => {
+      mockClient.estimateSmartFee.mockResolvedValueOnce(10);
+
+      const result = await service.getSendFeeRate();
+
+      expect(result).toBe(20); // 10 * cpfpFeeMultiplier (2.0)
+    });
+  });
+
   // --- getTxFeeRate() Tests --- //
 
   describe('getTxFeeRate()', () => {

--- a/src/integration/blockchain/bitcoin/services/bitcoin-based-fee.service.ts
+++ b/src/integration/blockchain/bitcoin/services/bitcoin-based-fee.service.ts
@@ -1,5 +1,6 @@
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { AsyncCache, CacheItemResetPeriod } from 'src/shared/utils/async-cache';
+import { Util } from 'src/shared/utils/util';
 import { NodeClient } from '../node/node-client';
 
 export type TxFeeRateStatus = 'unconfirmed' | 'confirmed' | 'not_found' | 'error';
@@ -89,6 +90,8 @@ export abstract class BitcoinBasedFeeService {
     const { allowUnconfirmedUtxos, cpfpFeeMultiplier, defaultFeeMultiplier } = this.feeConfig;
     const multiplier = allowUnconfirmedUtxos ? cpfpFeeMultiplier : defaultFeeMultiplier;
 
-    return baseRate * multiplier;
+    // Bitcoin Core's send RPC parses fee_rate with decimals=3; un-rounded floating-point
+    // products (e.g. 1.935 * 2 = 3.8699999999999997) are rejected with "Invalid amount".
+    return Util.round(baseRate * multiplier, 3);
   }
 }


### PR DESCRIPTION
## Summary

The BTC payout pipeline silently stalled today (2026-05-20) for ~80 minutes — every `sendmany`/`send` RPC was rejected by Bitcoin Core with `Invalid amount` (error code `-3`). A 120k EUR buy-crypto (and several smaller ones) sat in `Created` until the stuck batch was manually cleared.

## Root cause

Bitcoin Core's `send` / `sendmany` RPC parses the `fee_rate` argument with **decimals=3** ([source](https://github.com/bitcoin/bitcoin/blob/v30.0/src/wallet/rpc/spend.cpp#L223)):

```cpp
// Fee rates in sat/vB cannot represent more than 3 significant digits.
cc.m_feerate = CFeeRate{AmountFromValue(fee_rate, /*decimals=*/3)};
```

`ParseFixedPoint` returns `false` when the parsed value has more than 3 decimal places, which `AmountFromValue` re-throws as `"Invalid amount"`.

Our fee-rate computation chain produces values with floating-point artifacts:

```
estimatesmartfee(1) -> 0.00001935 BTC/kvB
                    * 100000 = 1.9349999999999998   (binary64 imprecision)
                    * 2.0    = 3.8699999999999997   (cpfpFeeMultiplier)
JSON.stringify       = "3.8699999999999997"          (16 decimals)
Bitcoin Core         -> "Invalid amount"
```

Reproduced against the live BTC output node:

```
$ bitcoin-cli -named send outputs='[...]' fee_rate=3.8699999999999997 ...
error code: -3
error message: Invalid amount

$ bitcoin-cli -named send outputs='[...]' fee_rate=3.87 ...
   (accepted; fails later with "Insufficient funds" — expected, wallet was drained)
```

This also explains:
- Only Bitcoin was affected (other chains don't go through `rpc.send` with a sat/vB `fee_rate`).
- Recovery was non-deterministic — the loop unstuck itself when `estimatesmartfee` happened to return a value that survived the multiplication without artifacts.

## Fix

Round the computed `sat/vB` fee rate to 3 decimal places in `BitcoinBasedFeeService.getSendFeeRate()`, which is the single source consumed by `PayoutBitcoinService.sendUtxoToMany` and the dex Bitcoin strategies.

## Test plan

- [x] Added unit test in `bitcoin-fee.service.spec.ts` covering the exact floating-point case (`1.935 * 2 -> 3.87`, not `3.8699999999999997`).
- [x] `npm run lint`, `npm run format:check`, `npm run build`, full Bitcoin fee test suite: all green locally.
- [ ] Verify on DEV that BTC payouts continue to broadcast normally after deploy.