### PR TITLE
fix(realunit): make register/wallet idempotent on signature match

### DIFF
--- a/src/subdomains/supporting/realunit/__tests__/realunit.service.spec.ts
+++ b/src/subdomains/supporting/realunit/__tests__/realunit.service.spec.ts
@@ -443,6 +443,19 @@ describe('RealUnitService', () => {
       expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
     });
 
+    it('matches signatures case-insensitively (stored upper-case, incoming lower-case)', async () => {
+      const existingStep = buildExistingStep({ signature: matchingSignature.toUpperCase(), isCompleted: true });
+      mockUserWithSteps([existingStep]);
+
+      const status = await service.completeRegistrationForWalletAddress(userDataId, {
+        ...dto,
+        signature: matchingSignature.toLowerCase(),
+      });
+
+      expect(status).toBe(RealUnitRegistrationStatus.COMPLETED);
+      expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
+    });
+
     it('throws BadRequestException when an existing registration for the same wallet has a different signature', async () => {
       const existingStep = buildExistingStep({ signature: '0xDIFFERENT_SIGNATURE', isCompleted: true });
       mockUserWithSteps([existingStep]);

--- a/src/subdomains/supporting/realunit/__tests__/realunit.service.spec.ts
+++ b/src/subdomains/supporting/realunit/__tests__/realunit.service.spec.ts
@@ -26,6 +26,7 @@ import { TransactionRequestService } from 'src/subdomains/supporting/payment/ser
 import { TransactionService } from 'src/subdomains/supporting/payment/services/transaction.service';
 import { AssetPricesService } from '../../pricing/services/asset-prices.service';
 import { PricingService } from '../../pricing/services/pricing.service';
+import { RealUnitRegistrationStatus } from '../dto/realunit-registration.dto';
 import { RealUnitDevService } from '../realunit-dev.service';
 import { RealUnitService } from '../realunit.service';
 
@@ -87,6 +88,7 @@ jest.mock('src/shared/services/dfx-logger', () => ({
 jest.mock('src/shared/utils/util', () => ({
   Util: {
     createUid: jest.fn().mockReturnValue('MOCK-UID'),
+    equalsIgnoreCase: (a?: string, b?: string) => a?.toLowerCase() === b?.toLowerCase(),
   },
 }));
 
@@ -97,6 +99,8 @@ describe('RealUnitService', () => {
   let eip7702DelegationService: jest.Mocked<Eip7702DelegationService>;
   let transactionRequestService: jest.Mocked<TransactionRequestService>;
   let sellService: jest.Mocked<SellService>;
+  let userService: jest.Mocked<UserService>;
+  let kycService: jest.Mocked<KycService>;
 
   const realuAsset = createCustomAsset({
     id: 1,
@@ -136,8 +140,18 @@ describe('RealUnitService', () => {
           },
         },
         { provide: UserDataService, useValue: {} },
-        { provide: UserService, useValue: {} },
-        { provide: KycService, useValue: {} },
+        {
+          provide: UserService,
+          useValue: {
+            getUserByAddress: jest.fn(),
+          },
+        },
+        {
+          provide: KycService,
+          useValue: {
+            createCustomKycStep: jest.fn(),
+          },
+        },
         { provide: CountryService, useValue: {} },
         { provide: LanguageService, useValue: {} },
         { provide: HttpService, useValue: {} },
@@ -179,6 +193,8 @@ describe('RealUnitService', () => {
     eip7702DelegationService = module.get(Eip7702DelegationService);
     transactionRequestService = module.get(TransactionRequestService);
     sellService = module.get(SellService);
+    userService = module.get(UserService);
+    kycService = module.get(KycService);
   });
 
   afterEach(() => {
@@ -370,6 +386,69 @@ describe('RealUnitService', () => {
       assetService.getAssetByQuery.mockResolvedValue(realuAsset);
 
       await expect(service.confirmSell(42, 1, {})).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('completeRegistrationForWalletAddress (idempotency)', () => {
+    const walletAddress = '0x1111111111111111111111111111111111111111';
+    const userDataId = 42;
+    const matchingSignature = '0xSIGNATURE_MATCHING';
+    const registrationDate = '2026-05-21';
+
+    function buildExistingStep(opts: { signature: string; isCompleted: boolean }): any {
+      return {
+        getResult: () => ({
+          signature: opts.signature,
+          walletAddress,
+          registrationDate,
+        }),
+        isCompleted: opts.isCompleted,
+        isFailed: false,
+        isCanceled: false,
+        result: 'non-empty',
+      };
+    }
+
+    function mockUserWithSteps(steps: any[]): void {
+      const userData = {
+        id: userDataId,
+        getStepsWith: jest.fn().mockReturnValue(steps),
+      };
+      userService.getUserByAddress.mockResolvedValue({ userData } as any);
+    }
+
+    const dto = {
+      walletAddress,
+      signature: matchingSignature,
+      registrationDate,
+    };
+
+    it('returns COMPLETED without creating a new KycStep when signature matches a completed registration', async () => {
+      const existingStep = buildExistingStep({ signature: matchingSignature, isCompleted: true });
+      mockUserWithSteps([existingStep]);
+
+      const status = await service.completeRegistrationForWalletAddress(userDataId, dto);
+
+      expect(status).toBe(RealUnitRegistrationStatus.COMPLETED);
+      expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
+    });
+
+    it('returns FORWARDING_FAILED when signature matches but the existing registration is not completed', async () => {
+      const existingStep = buildExistingStep({ signature: matchingSignature, isCompleted: false });
+      mockUserWithSteps([existingStep]);
+
+      const status = await service.completeRegistrationForWalletAddress(userDataId, dto);
+
+      expect(status).toBe(RealUnitRegistrationStatus.FORWARDING_FAILED);
+      expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when an existing registration for the same wallet has a different signature', async () => {
+      const existingStep = buildExistingStep({ signature: '0xDIFFERENT_SIGNATURE', isCompleted: true });
+      mockUserWithSteps([existingStep]);
+
+      await expect(service.completeRegistrationForWalletAddress(userDataId, dto)).rejects.toThrow(BadRequestException);
+      expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -604,9 +604,9 @@ export class RealUnitService {
       throw new BadRequestException('Email does not match registered email');
     }
 
-    const existingForWallet = this.findRegistrationStep(userData, dto.walletAddress);
-    if (existingForWallet.isForCurrentWallet) {
-      return this.idempotentRegistrationResult(existingForWallet.step!, dto.signature);
+    const { step: existingStep, isForCurrentWallet } = this.findRegistrationStep(userData, dto.walletAddress);
+    if (isForCurrentWallet) {
+      return this.idempotentRegistrationResult(userData, existingStep!, dto.signature);
     }
 
     // validate personal data
@@ -668,7 +668,7 @@ export class RealUnitService {
     const { step: registrationStep, isForCurrentWallet } = this.findRegistrationStep(userData, dto.walletAddress);
 
     if (isForCurrentWallet) {
-      return this.idempotentRegistrationResult(registrationStep!, dto.signature);
+      return this.idempotentRegistrationResult(userData, registrationStep!, dto.signature);
     }
 
     if (!registrationStep) {
@@ -897,12 +897,30 @@ export class RealUnitService {
    * status without creating a new KycStep or re-forwarding. Different signature for the same
    * wallet stays a hard error: it means a fresh sign was produced over conflicting data.
    */
-  private idempotentRegistrationResult(step: KycStep, incomingSignature: string): RealUnitRegistrationStatus {
+  private idempotentRegistrationResult(
+    userData: UserData,
+    step: KycStep,
+    incomingSignature: string,
+  ): RealUnitRegistrationStatus {
     const existingData = step.getResult<RealUnitRegistrationDto>();
     if (existingData?.signature !== incomingSignature) {
       throw new BadRequestException('RealUnit registration already exists for this wallet with a different signature');
     }
-    return step.isCompleted ? RealUnitRegistrationStatus.COMPLETED : RealUnitRegistrationStatus.FORWARDING_FAILED;
+
+    // findRegistrationStep filters out FAILED and CANCELED, so the step is in one of the three
+    // states this service produces for REALUNIT_REGISTRATION: INTERNAL_REVIEW (created, forward
+    // not run yet), MANUAL_REVIEW (forward failed, awaiting admin retry), or COMPLETED (forward
+    // succeeded). Only COMPLETED is a terminal success; the other two map to FORWARDING_FAILED
+    // so the client surfaces the same retry path it would have seen on the original call.
+    const status = step.isCompleted
+      ? RealUnitRegistrationStatus.COMPLETED
+      : RealUnitRegistrationStatus.FORWARDING_FAILED;
+
+    this.logger.info(
+      `RealUnit registration idempotent retry for userData ${userData.id}, kycStep ${step.id} → ${status}`,
+    );
+
+    return status;
   }
 
   private toUserDataDto(step: KycStep | undefined): RealUnitUserDataDto | undefined {

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -903,7 +903,7 @@ export class RealUnitService {
     incomingSignature: string,
   ): RealUnitRegistrationStatus {
     const existingData = step.getResult<RealUnitRegistrationDto>();
-    if (existingData?.signature !== incomingSignature) {
+    if (!Util.equalsIgnoreCase(existingData?.signature, incomingSignature)) {
       throw new BadRequestException('RealUnit registration already exists for this wallet with a different signature');
     }
 

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -604,8 +604,9 @@ export class RealUnitService {
       throw new BadRequestException('Email does not match registered email');
     }
 
-    if (this.hasRegistrationForWallet(userData, dto.walletAddress)) {
-      throw new BadRequestException('RealUnit registration already exists for this wallet');
+    const existingForWallet = this.findRegistrationStep(userData, dto.walletAddress);
+    if (existingForWallet.isForCurrentWallet) {
+      return this.idempotentRegistrationResult(existingForWallet.step!, dto.signature);
     }
 
     // validate personal data
@@ -667,7 +668,7 @@ export class RealUnitService {
     const { step: registrationStep, isForCurrentWallet } = this.findRegistrationStep(userData, dto.walletAddress);
 
     if (isForCurrentWallet) {
-      throw new BadRequestException('RealUnit registration already exists for this wallet');
+      return this.idempotentRegistrationResult(registrationStep!, dto.signature);
     }
 
     if (!registrationStep) {
@@ -888,6 +889,20 @@ export class RealUnitService {
       });
 
     return { step: otherWalletStep, isForCurrentWallet: false };
+  }
+
+  /**
+   * Idempotent fallback for repeated register/wallet calls (e.g. client retry after a lost
+   * response). Same wallet + same EIP-712 signature → return the existing registration's
+   * status without creating a new KycStep or re-forwarding. Different signature for the same
+   * wallet stays a hard error: it means a fresh sign was produced over conflicting data.
+   */
+  private idempotentRegistrationResult(step: KycStep, incomingSignature: string): RealUnitRegistrationStatus {
+    const existingData = step.getResult<RealUnitRegistrationDto>();
+    if (existingData?.signature !== incomingSignature) {
+      throw new BadRequestException('RealUnit registration already exists for this wallet with a different signature');
+    }
+    return step.isCompleted ? RealUnitRegistrationStatus.COMPLETED : RealUnitRegistrationStatus.FORWARDING_FAILED;
   }
 
   private toUserDataDto(step: KycStep | undefined): RealUnitUserDataDto | undefined {

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -907,11 +907,13 @@ export class RealUnitService {
       throw new BadRequestException('RealUnit registration already exists for this wallet with a different signature');
     }
 
-    // findRegistrationStep filters out FAILED and CANCELED, so the step is in one of the three
-    // states this service produces for REALUNIT_REGISTRATION: INTERNAL_REVIEW (created, forward
-    // not run yet), MANUAL_REVIEW (forward failed, awaiting admin retry), or COMPLETED (forward
-    // succeeded). Only COMPLETED is a terminal success; the other two map to FORWARDING_FAILED
-    // so the client surfaces the same retry path it would have seen on the original call.
+    // Under the normal REALUNIT_REGISTRATION flow the step is in INTERNAL_REVIEW (created,
+    // forward not run yet), MANUAL_REVIEW (forward failed, awaiting admin retry), or COMPLETED
+    // (forward succeeded). findRegistrationStep filters out FAILED and CANCELED, but admin
+    // overrides via kyc-admin.updateKycStep can leave other non-failed/non-canceled statuses
+    // (e.g. ON_HOLD, OUTDATED) reachable here. Only COMPLETED is a terminal success; every
+    // other reachable status falls through to FORWARDING_FAILED, which surfaces the same retry
+    // path the client would have seen on the original call.
     const status = step.isCompleted
       ? RealUnitRegistrationStatus.COMPLETED
       : RealUnitRegistrationStatus.FORWARDING_FAILED;


### PR DESCRIPTION
## Summary

Surface a real client retry-stuck bug spotted while reviewing [DFXswiss/realunit-app#466](https://github.com/DFXswiss/realunit-app/pull/466) (KYC merge flow). \`POST /v1/realunit/register/wallet\` (and the same-wallet branch of \`POST /v1/realunit/register/complete\`) was non-idempotent: if the first call succeeded server-side but the response was lost (mobile network drop is the realistic case), the client's automatic retry with the same EIP-712 signature got a hard \`400 Bad Request\` — "RealUnit registration already exists for this wallet" — with no recovery path. The user ends up stuck on a failure snackbar even though the registration is in fact complete.

## Fix

Replace the hard throw with a signature-aware idempotency check in \`RealUnitService\` (new private helper \`idempotentRegistrationResult\`):

- **Same wallet + same signature** → return the existing registration's status. \`COMPLETED\` if the existing \`KycStep\` is completed (forward to Aktionariat succeeded on the first attempt), \`FORWARDING_FAILED\` otherwise. **No new \`KycStep\`, no re-forward.**
- **Same wallet + different signature** → keep the 400, but with a more precise message: \`"RealUnit registration already exists for this wallet with a different signature"\`. A fresh sign over the same wallet means the client produced a new payload — that is a real conflict, not a retry.

Signature comparison is **case-insensitive** (\`Util.equalsIgnoreCase\`): EIP-712 signatures are 0x-prefixed hex strings and lower/upper case representations are semantically identical. Matches the convention already used for wallet-address comparisons in \`findRegistrationStep\`.

Both endpoints share the helper; \`completeRegistration\` is refactored to call \`findRegistrationStep\` directly instead of the boolean-only \`hasRegistrationForWallet\`, so it has access to the \`KycStep\` for the idempotency check. \`hasRegistrationForWallet\` itself is preserved (still used by \`realunit.controller.ts\` and two other call-sites).

The helper takes \`userData\` as an explicit parameter rather than reading \`step.userData\` so the call does not depend on TypeORM back-populating the inverse relation on steps loaded via \`userData.kycSteps\`. Each idempotent hit is logged at \`info\` level (\`userData.id\`, \`kycStep.id\`, resulting status) so production retry frequency is observable and stuck-user reports can be correlated to a specific step.

## Tests

\`describe('completeRegistrationForWalletAddress (idempotency)', ...)\` block in \`realunit.service.spec.ts\` covers all branches:

1. Same signature + completed step → returns \`COMPLETED\`, no \`createCustomKycStep\` call
2. Same signature + non-completed step → returns \`FORWARDING_FAILED\`, no \`createCustomKycStep\` call
3. Same signature, different case (stored upper, incoming lower) → returns \`COMPLETED\`, no \`createCustomKycStep\` call
4. Different signature → throws \`BadRequestException\`, no \`createCustomKycStep\` call

Test setup expands the \`UserService\` and \`KycService\` mock providers (previously empty objects) with the methods needed by these tests. The \`Util.equalsIgnoreCase\` jest mock was missing from the existing setup — added here too, since both \`findRegistrationStep\` and the new signature comparison rely on it.

## Local verification

- \`npm install\` ✅
- \`npm run format\` — no changes to touched files
- \`npm run lint\` ✅
- \`npm run type-check\` ✅
- \`npm test\` — 14/14 in \`realunit.service.spec.ts\` ✅

## Test plan

- [ ] **Manual reproduction of the original stuck state** (against DEV): trigger \`/v1/realunit/register/wallet\` twice with identical body — second call should now return \`201 { "status": "completed" }\` instead of \`400\`.
- [ ] **Signature-mismatch protection**: second call with same wallet but altered signature → still \`400\`, new message ("…with a different signature").
- [ ] **Unrelated flows unchanged**: new-customer registration (no existing step) still creates a \`KycStep\` and forwards as before.

## Known limitations

- **UTC midnight retry**: the realunit-app client signs over \`registrationDate = today\` (in UTC). A retry that crosses the UTC date boundary therefore re-signs against a different message and lands in the "different signature" branch (400). In the real-world failure mode (snackbar fires, user taps "retry" seconds later) this never triggers, but if a retry happens minutes after the rollover the client will still need to surface a sensible error. A future iteration could relax the match to wallet+userData once the forward has reached \`COMPLETED\`, but that loosens the conflict semantics deliberately defined here.

## Out of scope / follow-ups

- The realunit-app KYC merge flow already surfaces these failures correctly after [DFXswiss/realunit-app#466](https://github.com/DFXswiss/realunit-app/pull/466) — this PR closes the backend loop so legitimate retries succeed instead of looping in the failure path.
- \`completeRegistrationForWalletAddress\` still does not call \`validateRegistrationDto\` (only the signature is verified). Out of scope here, but worth a separate look — \`registrationDate\` and birthday/age validation are skipped on this path.