### PR TITLE
feat(user/realunit): expose user capabilities + structured ALREADY_REGISTERED status

### DIFF
--- a/src/subdomains/generic/user/models/user/dto/__tests__/user-dto.mapper.spec.ts
+++ b/src/subdomains/generic/user/models/user/dto/__tests__/user-dto.mapper.spec.ts
@@ -150,9 +150,7 @@ describe('UserDtoMapper', () => {
 
     it('canEditName is false once PersonalData is completed', () => {
       const userData = buildUserData();
-      userData.kycSteps = [
-        buildStep(KycStepName.PERSONAL_DATA, ReviewStatus.COMPLETED),
-      ];
+      userData.kycSteps = [buildStep(KycStepName.PERSONAL_DATA, ReviewStatus.COMPLETED)];
 
       const result = UserDtoMapper.mapUser(userData);
 
@@ -162,9 +160,7 @@ describe('UserDtoMapper', () => {
 
     it('canEditName is false while PersonalData is in review', () => {
       const userData = buildUserData();
-      userData.kycSteps = [
-        buildStep(KycStepName.PERSONAL_DATA, ReviewStatus.MANUAL_REVIEW),
-      ];
+      userData.kycSteps = [buildStep(KycStepName.PERSONAL_DATA, ReviewStatus.MANUAL_REVIEW)];
 
       const result = UserDtoMapper.mapUser(userData);
 
@@ -180,9 +176,7 @@ describe('UserDtoMapper', () => {
     });
 
     it('all edit flags collapse to false on KYC-terminated accounts', () => {
-      const result = UserDtoMapper.mapUser(
-        buildUserData({ kycLevel: KycLevel.REJECTED }),
-      );
+      const result = UserDtoMapper.mapUser(buildUserData({ kycLevel: KycLevel.REJECTED }));
 
       expect(result.capabilities.canEditMail).toBe(false);
       expect(result.capabilities.canEditPhone).toBe(false);

--- a/src/subdomains/generic/user/models/user/dto/__tests__/user-dto.mapper.spec.ts
+++ b/src/subdomains/generic/user/models/user/dto/__tests__/user-dto.mapper.spec.ts
@@ -1,8 +1,14 @@
+import { ConfigService } from 'src/config/config';
 import { Country } from 'src/shared/models/country/country.entity';
+import { createDefaultFiat } from 'src/shared/models/fiat/__mocks__/fiat.entity.mock';
+import { Language } from 'src/shared/models/language/language.entity';
+import { KycStep } from 'src/subdomains/generic/kyc/entities/kyc-step.entity';
+import { KycStepName } from 'src/subdomains/generic/kyc/enums/kyc-step-name.enum';
+import { ReviewStatus } from 'src/subdomains/generic/kyc/enums/review-status.enum';
 import { Organization } from '../../../organization/organization.entity';
 import { AccountType } from '../../../user-data/account-type.enum';
 import { UserData } from '../../../user-data/user-data.entity';
-import { UserDataStatus } from '../../../user-data/user-data.enum';
+import { KycLevel, UserDataStatus } from '../../../user-data/user-data.enum';
 import { UserDtoMapper } from '../user-dto.mapper';
 
 describe('UserDtoMapper', () => {
@@ -92,6 +98,94 @@ describe('UserDtoMapper', () => {
       const result = UserDtoMapper.mapProfile(userData);
 
       expect(result.address).toBeUndefined();
+    });
+  });
+
+  // Capability flags surfaced for client-side UI gating, replacing the
+  // settings/support widgets' status interpretation. See realunit-app
+  // `docs/api-authority-plan.md` (Wave 3).
+  describe('mapUser: capabilities', () => {
+    beforeAll(() => {
+      new ConfigService();
+    });
+
+    const buildLanguage = (): Language => {
+      const lang = new Language();
+      lang.symbol = 'EN';
+      lang.name = 'English';
+      lang.foreignName = 'English';
+      lang.enable = true;
+      return lang;
+    };
+
+    const buildStep = (name: KycStepName, status: ReviewStatus): KycStep => {
+      const step = new KycStep();
+      step.name = name;
+      step.status = status;
+      step.sequenceNumber = 0;
+      return step;
+    };
+
+    const buildUserData = (overrides: Partial<UserData> = {}): UserData => {
+      const userData = new UserData();
+      userData.id = 1;
+      userData.kycHash = 'h';
+      userData.status = UserDataStatus.ACTIVE;
+      userData.accountType = AccountType.PERSONAL;
+      userData.mail = 'john@example.com';
+      userData.kycLevel = KycLevel.LEVEL_20;
+      userData.language = buildLanguage();
+      userData.currency = createDefaultFiat();
+      userData.users = [];
+      userData.kycSteps = [];
+      return Object.assign(userData, overrides);
+    };
+
+    it('canEditName is true when no PersonalData step has been reviewed yet', () => {
+      const result = UserDtoMapper.mapUser(buildUserData());
+
+      expect(result.capabilities.canEditName).toBe(true);
+      expect(result.capabilities.canEditAddress).toBe(true);
+    });
+
+    it('canEditName is false once PersonalData is completed', () => {
+      const userData = buildUserData();
+      userData.kycSteps = [
+        buildStep(KycStepName.PERSONAL_DATA, ReviewStatus.COMPLETED),
+      ];
+
+      const result = UserDtoMapper.mapUser(userData);
+
+      expect(result.capabilities.canEditName).toBe(false);
+      expect(result.capabilities.canEditAddress).toBe(false);
+    });
+
+    it('canEditName is false while PersonalData is in review', () => {
+      const userData = buildUserData();
+      userData.kycSteps = [
+        buildStep(KycStepName.PERSONAL_DATA, ReviewStatus.MANUAL_REVIEW),
+      ];
+
+      const result = UserDtoMapper.mapUser(userData);
+
+      expect(result.capabilities.canEditName).toBe(false);
+    });
+
+    it('supportAvailable mirrors whether the user has a mail set', () => {
+      const withMail = UserDtoMapper.mapUser(buildUserData());
+      const withoutMail = UserDtoMapper.mapUser(buildUserData({ mail: undefined }));
+
+      expect(withMail.capabilities.supportAvailable).toBe(true);
+      expect(withoutMail.capabilities.supportAvailable).toBe(false);
+    });
+
+    it('all edit flags collapse to false on KYC-terminated accounts', () => {
+      const result = UserDtoMapper.mapUser(
+        buildUserData({ kycLevel: KycLevel.REJECTED }),
+      );
+
+      expect(result.capabilities.canEditMail).toBe(false);
+      expect(result.capabilities.canEditPhone).toBe(false);
     });
   });
 });

--- a/src/subdomains/generic/user/models/user/dto/user-dto.mapper.ts
+++ b/src/subdomains/generic/user/models/user/dto/user-dto.mapper.ts
@@ -7,10 +7,18 @@ import { FiatDtoMapper } from 'src/shared/models/fiat/dto/fiat-dto.mapper';
 import { LanguageDtoMapper } from 'src/shared/models/language/dto/language-dto.mapper';
 import { ApiKeyService } from 'src/shared/services/api-key.service';
 import { Util } from 'src/shared/utils/util';
+import { KycStepName } from 'src/subdomains/generic/kyc/enums/kyc-step-name.enum';
 import { UserData } from '../../user-data/user-data.entity';
 import { User } from '../user.entity';
 import { UserProfileDto } from './user-profile.dto';
-import { PhoneCallStatusMapper, ReferralDto, UserAddressDto, UserV2Dto, VolumesDto } from './user-v2.dto';
+import {
+  PhoneCallStatusMapper,
+  ReferralDto,
+  UserAddressDto,
+  UserCapabilitiesDto,
+  UserV2Dto,
+  VolumesDto,
+} from './user-v2.dto';
 
 export class UserDtoMapper {
   static mapUser(userData: UserData, activeUserId?: number): UserV2Dto {
@@ -32,6 +40,7 @@ export class UserDtoMapper {
         phoneCallStatus: userData.phoneCallStatus ? PhoneCallStatusMapper[userData.phoneCallStatus] : undefined,
         preferredPhoneTimes: userData.phoneCallTimesObject,
       },
+      capabilities: UserDtoMapper.computeCapabilities(userData),
       volumes: this.mapVolumes(userData),
       addresses: userData.users
         .filter((u) => !u.isBlockedOrDeleted && !u.wallet.usesDummyAddresses)
@@ -63,6 +72,24 @@ export class UserDtoMapper {
     };
 
     return Object.assign(new UserAddressDto(), dto);
+  }
+
+  // Per-action capabilities. Mirrors the gating the realunit-app cubits
+  // were re-implementing locally (settings-edit visibility, support-link
+  // visibility) — surfacing them here lets the app render UI affordances
+  // without iterating step status.
+  private static computeCapabilities(userData: UserData): UserCapabilitiesDto {
+    const personalDataLocked = userData
+      .getStepsWith(KycStepName.PERSONAL_DATA)
+      .some((s) => s.isCompleted || s.isInReview);
+    const hasVerifiedMail = !!userData.mail;
+    return {
+      canEditName: !personalDataLocked,
+      canEditMail: !userData.isKycTerminated,
+      canEditPhone: !userData.isKycTerminated,
+      canEditAddress: !personalDataLocked,
+      supportAvailable: hasVerifiedMail,
+    };
   }
 
   private static mapVolumes(user: UserData | User): VolumesDto {

--- a/src/subdomains/generic/user/models/user/dto/user-v2.dto.ts
+++ b/src/subdomains/generic/user/models/user/dto/user-v2.dto.ts
@@ -138,6 +138,35 @@ export class UserPaymentLinkDto {
   active: boolean;
 }
 
+export class UserCapabilitiesDto {
+  @ApiProperty({
+    description:
+      'Whether the user may edit their first/last name. False when the personal-data step is in any review or completed state.',
+  })
+  canEditName: boolean;
+
+  @ApiProperty({
+    description: 'Whether the user may edit their primary email address.',
+  })
+  canEditMail: boolean;
+
+  @ApiProperty({
+    description: 'Whether the user may edit their phone number.',
+  })
+  canEditPhone: boolean;
+
+  @ApiProperty({
+    description: 'Whether the user may edit their postal address.',
+  })
+  canEditAddress: boolean;
+
+  @ApiProperty({
+    description:
+      'Whether the support / ticket flow is currently available for this user (requires a verified email).',
+  })
+  supportAvailable: boolean;
+}
+
 export class UserV2Dto {
   @ApiProperty({ description: 'Unique account id' })
   accountId: number;
@@ -162,6 +191,13 @@ export class UserV2Dto {
 
   @ApiProperty({ type: UserKycDto })
   kyc: UserKycDto;
+
+  @ApiProperty({
+    type: UserCapabilitiesDto,
+    description:
+      'Per-action capability flags. Clients render UI affordances (edit buttons, support links, …) from this object instead of inferring them from KYC step status.',
+  })
+  capabilities: UserCapabilitiesDto;
 
   @ApiProperty({ type: VolumesDto })
   volumes: VolumesDto;

--- a/src/subdomains/generic/user/models/user/dto/user-v2.dto.ts
+++ b/src/subdomains/generic/user/models/user/dto/user-v2.dto.ts
@@ -161,8 +161,7 @@ export class UserCapabilitiesDto {
   canEditAddress: boolean;
 
   @ApiProperty({
-    description:
-      'Whether the support / ticket flow is currently available for this user (requires a verified email).',
+    description: 'Whether the support / ticket flow is currently available for this user (requires a verified email).',
   })
   supportAvailable: boolean;
 }

--- a/src/subdomains/supporting/realunit/__tests__/realunit.service.spec.ts
+++ b/src/subdomains/supporting/realunit/__tests__/realunit.service.spec.ts
@@ -423,13 +423,13 @@ describe('RealUnitService', () => {
       registrationDate,
     };
 
-    it('returns COMPLETED without creating a new KycStep when signature matches a completed registration', async () => {
+    it('returns ALREADY_REGISTERED without creating a new KycStep when signature matches a completed registration', async () => {
       const existingStep = buildExistingStep({ signature: matchingSignature, isCompleted: true });
       mockUserWithSteps([existingStep]);
 
       const status = await service.completeRegistrationForWalletAddress(userDataId, dto);
 
-      expect(status).toBe(RealUnitRegistrationStatus.COMPLETED);
+      expect(status).toBe(RealUnitRegistrationStatus.ALREADY_REGISTERED);
       expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
     });
 
@@ -452,7 +452,7 @@ describe('RealUnitService', () => {
         signature: matchingSignature.toLowerCase(),
       });
 
-      expect(status).toBe(RealUnitRegistrationStatus.COMPLETED);
+      expect(status).toBe(RealUnitRegistrationStatus.ALREADY_REGISTERED);
       expect(kycService.createCustomKycStep).not.toHaveBeenCalled();
     });
 

--- a/src/subdomains/supporting/realunit/controllers/realunit.controller.ts
+++ b/src/subdomains/supporting/realunit/controllers/realunit.controller.ts
@@ -543,7 +543,10 @@ export class RealUnitController {
     const response: RealUnitRegistrationResponseDto = {
       status: status,
     };
-    const statusCode = status === RealUnitRegistrationStatus.COMPLETED ? HttpStatus.CREATED : HttpStatus.ACCEPTED;
+    const statusCode =
+      status === RealUnitRegistrationStatus.COMPLETED || status === RealUnitRegistrationStatus.ALREADY_REGISTERED
+        ? HttpStatus.CREATED
+        : HttpStatus.ACCEPTED;
     res.status(statusCode).json(response);
   }
 
@@ -567,7 +570,10 @@ export class RealUnitController {
   ): Promise<void> {
     const status = await this.realunitService.completeRegistrationForWalletAddress(jwt.account, dto);
     const response: RealUnitRegistrationResponseDto = { status };
-    const statusCode = status === RealUnitRegistrationStatus.COMPLETED ? HttpStatus.CREATED : HttpStatus.ACCEPTED;
+    const statusCode =
+      status === RealUnitRegistrationStatus.COMPLETED || status === RealUnitRegistrationStatus.ALREADY_REGISTERED
+        ? HttpStatus.CREATED
+        : HttpStatus.ACCEPTED;
     res.status(statusCode).json(response);
   }
 

--- a/src/subdomains/supporting/realunit/dto/realunit-registration.dto.ts
+++ b/src/subdomains/supporting/realunit/dto/realunit-registration.dto.ts
@@ -27,6 +27,10 @@ export enum RealUnitRegistrationStatus {
   COMPLETED = 'completed',
   PENDING_REVIEW = 'pending_review',
   FORWARDING_FAILED = 'forwarding_failed',
+  // Returned when the wallet is already registered for this user. Clients
+  // treat this as a non-error success state — the merge / re-entry path
+  // depends on this being a structured response, not a thrown 400.
+  ALREADY_REGISTERED = 'already_registered',
 }
 
 export class RealUnitRegistrationResponseDto {

--- a/src/subdomains/supporting/realunit/realunit.service.ts
+++ b/src/subdomains/supporting/realunit/realunit.service.ts
@@ -914,8 +914,12 @@ export class RealUnitService {
     // (e.g. ON_HOLD, OUTDATED) reachable here. Only COMPLETED is a terminal success; every
     // other reachable status falls through to FORWARDING_FAILED, which surfaces the same retry
     // path the client would have seen on the original call.
+    // Surface ALREADY_REGISTERED (not COMPLETED) on the idempotent path so
+    // clients can distinguish "registration just completed in this call"
+    // from "registration was already in place". The wallet-app uses this
+    // to skip the post-registration onboarding screens on retry.
     const status = step.isCompleted
-      ? RealUnitRegistrationStatus.COMPLETED
+      ? RealUnitRegistrationStatus.ALREADY_REGISTERED
       : RealUnitRegistrationStatus.FORWARDING_FAILED;
 
     this.logger.info(


### PR DESCRIPTION
## Summary

Wave 3 of the realunit-app API-as-Decision-Authority plan ([`DFXswiss/realunit-app:docs/api-authority-plan.md`](https://github.com/DFXswiss/realunit-app/blob/develop/docs/api-authority-plan.md)). Two changes that let the realunit-app stop interpreting backend state into UI affordances.

## What changes

### `UserV2Dto.capabilities`

New `UserCapabilitiesDto` field on the `/v2/user` response. Surfaces per-action flags the realunit-app cubits were re-deriving locally from KYC step status:

- `canEditName` / `canEditAddress`: `false` once `PersonalData` is in any review or completed state (data is locked to keep client and KYC attestation aligned).
- `canEditMail` / `canEditPhone`: `false` only on KYC-terminated accounts.
- `supportAvailable`: requires a verified mail.

`UserDtoMapper.computeCapabilities` mirrors the rules the realunit-app cubits encode today (`settings_user_data_page.dart:239`, `settings_edit_name_cubit.dart:22`, `settings_contact_page.dart:54-67`).

### `RealUnitRegistrationStatus.ALREADY_REGISTERED`

New enum value. Since #3731 the idempotent path (same wallet + same EIP-712 signature) already returns a success status instead of throwing — it returned `COMPLETED`. This PR refines that return value to a dedicated `ALREADY_REGISTERED`, so the realunit-app can distinguish "registration just completed in this call" from "registration was already in place" and skip the post-registration onboarding screens on retry.

This is a change to an existing return value, not a purely additive one: the idempotent completed-retry path now returns `ALREADY_REGISTERED` where it previously returned `COMPLETED`. The HTTP status is unchanged — `completeRegistration` / `completeRegistrationForWalletAddress` map both `COMPLETED` and `ALREADY_REGISTERED` to `201`, so clients that branch on the status code see no change; the distinction is carried by the `status` body field.

The signature-mismatch behaviour from #3731 is preserved — same wallet + different signature still throws `400`; same wallet + same signature is the idempotent `ALREADY_REGISTERED` path.

## What is intentionally NOT in this PR

- **`requiredWorkflow` on `SellPaymentInfoDto`** was considered (audit V9) but BitBox vs software-wallet selection is unavoidably a client-side device fact — the API can't substitute for the client knowing what hardware it has. Will be addressed differently in a future iteration (e.g. by exposing `supportedSignMethods` rather than a single workflow choice).

## Backwards compatibility

- `capabilities` is purely additive — old clients ignore the new field and continue to derive editability locally.
- `ALREADY_REGISTERED` is a new enum value, but on the idempotent completed-retry path it **replaces** the `COMPLETED` value returned since #3731. A client that explicitly checks for `COMPLETED` on that path will now see `ALREADY_REGISTERED`; clients that switch on the `status` field with a fallback treat the unknown value like `FORWARDING_FAILED` (no worse than a generic non-error fallback). The HTTP status stays `201`, so status-code-based clients are unaffected. The companion realunit-app PR consumes the new value.

## Tests

- `user-dto.mapper.spec.ts` adds a `mapUser: capabilities` block covering all five flags across happy path, PersonalData-locked, KYC-terminated, and no-mail fixtures.
- `realunit.service.spec.ts` asserts the idempotent path returns `ALREADY_REGISTERED`.

## Local verification

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — **943 / 943 passing** (938 baseline + 5 new tests)

## Test plan (manual, DEV)

- [ ] `GET /v2/user` for a clean Level-20 user → `capabilities.canEditName=true`.
- [ ] `GET /v2/user` for a user with PersonalData in `ManualReview` → `capabilities.canEditName=false`.
- [ ] `GET /v2/user` for a no-mail user → `capabilities.supportAvailable=false`.
- [ ] `POST /v1/realunit/register/wallet` for an already-registered wallet (same signature) → `201 { "status": "already_registered" }` (returned `201 { "status": "completed" }` before this PR).

## Companion app PR

Will open immediately on the realunit-app side to consume `capabilities` + `ALREADY_REGISTERED`.