### PR TITLE
feat(scrypt): hard-cap LIMIT execution price (Phase 2 / followup to #3736)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1265,6 +1265,11 @@ export class Configuration {
     wsUrl: process.env.SCRYPT_WS_URL,
     apiKey: process.env.SCRYPT_API_KEY,
     apiSecret: process.env.SCRYPT_API_SECRET,
+    // Hard cap on the spread between Scrypt's executable price and our pricing reference.
+    // Scrypt embeds its fee in the quote ("price you see is what you get"), so a wide
+    // spread is the only pre-trade signal that the implicit cost is too high. Abort + alert
+    // when exceeded to avoid silent overpayment like the 2026-05-21 BTC/EUR incident.
+    maxPriceDeviation: 0.003,
   };
 
   get evmWallets(): Map<string, string> {

--- a/src/integration/exchange/services/__tests__/scrypt.service.spec.ts
+++ b/src/integration/exchange/services/__tests__/scrypt.service.spec.ts
@@ -1,0 +1,49 @@
+import { ScryptOrderSide } from '../../dto/scrypt.dto';
+import { ScryptService } from '../scrypt.service';
+
+describe('ScryptService.applyPriceCap', () => {
+  const orderbook = 66_500;
+
+  describe('priceCap unset / invalid', () => {
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['zero', 0],
+      ['negative', -100],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+    ])('returns orderbookPrice when priceCap is %s', (_label, cap) => {
+      expect(ScryptService.applyPriceCap(orderbook, ScryptOrderSide.BUY, cap as number | undefined)).toBe(orderbook);
+      expect(ScryptService.applyPriceCap(orderbook, ScryptOrderSide.SELL, cap as number | undefined)).toBe(orderbook);
+    });
+  });
+
+  describe('side=BUY (cap = upper bound)', () => {
+    it('uses orderbook price when below cap (cheaper market)', () => {
+      expect(ScryptService.applyPriceCap(66_500, ScryptOrderSide.BUY, 66_700)).toBe(66_500);
+    });
+
+    it('uses cap when orderbook is above cap (clamp)', () => {
+      expect(ScryptService.applyPriceCap(66_900, ScryptOrderSide.BUY, 66_700)).toBe(66_700);
+    });
+
+    it('returns either when equal', () => {
+      expect(ScryptService.applyPriceCap(66_700, ScryptOrderSide.BUY, 66_700)).toBe(66_700);
+    });
+  });
+
+  describe('side=SELL (cap = lower bound)', () => {
+    it('uses orderbook price when above cap (better market)', () => {
+      expect(ScryptService.applyPriceCap(66_500, ScryptOrderSide.SELL, 66_300)).toBe(66_500);
+    });
+
+    it('uses cap when orderbook is below cap (clamp)', () => {
+      expect(ScryptService.applyPriceCap(66_100, ScryptOrderSide.SELL, 66_300)).toBe(66_300);
+    });
+
+    it('returns either when equal', () => {
+      expect(ScryptService.applyPriceCap(66_300, ScryptOrderSide.SELL, 66_300)).toBe(66_300);
+    });
+  });
+});

--- a/src/integration/exchange/services/scrypt.service.ts
+++ b/src/integration/exchange/services/scrypt.service.ts
@@ -263,7 +263,7 @@ export class ScryptService extends PricingProvider {
   }
 
   static applyPriceCap(orderbookPrice: number, side: ScryptOrderSide, priceCap?: number): number {
-    if (priceCap == null) return orderbookPrice;
+    if (priceCap == null || !Number.isFinite(priceCap) || priceCap <= 0) return orderbookPrice;
     return side === ScryptOrderSide.BUY ? Math.min(orderbookPrice, priceCap) : Math.max(orderbookPrice, priceCap);
   }
 

--- a/src/integration/exchange/services/scrypt.service.ts
+++ b/src/integration/exchange/services/scrypt.service.ts
@@ -242,10 +242,16 @@ export class ScryptService extends PricingProvider {
     return side === ScryptOrderSide.BUY ? price : 1 / price;
   }
 
-  async sell(from: string, to: string, amount: number): Promise<string> {
+  async sell(from: string, to: string, amount: number, priceCap?: number): Promise<string> {
     const { symbol, side } = await this.getTradePair(from, to);
-    const price = await this.getOrderBookPrice(symbol, side);
+    const orderbookPrice = await this.getOrderBookPrice(symbol, side);
     const sizeIncrement = await this.getSizeIncrement(symbol);
+
+    // Hard execution-price cap (Scrypt embeds its commission into the quote, so the
+    // only way to bound implicit cost is the LIMIT price itself).
+    // - BUY (we pay quote per base): cap is upper bound, LIMIT = min(orderbook, cap)
+    // - SELL (we receive quote per base): cap is lower bound, LIMIT = max(orderbook, cap)
+    const price = ScryptService.applyPriceCap(orderbookPrice, side, priceCap);
 
     // OrderQty must be in base currency
     // SELL (from=base): orderQty = amount
@@ -254,6 +260,11 @@ export class ScryptService extends PricingProvider {
     const orderQty = Util.floorToValue(rawQty, sizeIncrement);
 
     return this.placeAndReturnId(symbol, side, orderQty, price);
+  }
+
+  static applyPriceCap(orderbookPrice: number, side: ScryptOrderSide, priceCap?: number): number {
+    if (priceCap == null) return orderbookPrice;
+    return side === ScryptOrderSide.BUY ? Math.min(orderbookPrice, priceCap) : Math.max(orderbookPrice, priceCap);
   }
 
   async buy(from: string, to: string, amount: number): Promise<string> {
@@ -323,7 +334,13 @@ export class ScryptService extends PricingProvider {
     };
   }
 
-  async checkTrade(clOrdId: string, from: string, to: string, orderCreated?: Date): Promise<boolean> {
+  async checkTrade(
+    clOrdId: string,
+    from: string,
+    to: string,
+    orderCreated?: Date,
+    priceCap?: number,
+  ): Promise<boolean> {
     const orderInfo = await this.getOrderStatus(clOrdId);
     if (!orderInfo) {
       // If the order is older than 1 hour and still not found, it's lost
@@ -341,15 +358,17 @@ export class ScryptService extends PricingProvider {
     switch (orderInfo.status) {
       case ScryptOrderStatus.NEW:
       case ScryptOrderStatus.PARTIALLY_FILLED: {
+        const { side } = await this.getTradePair(from, to);
         const currentPrice = await this.getTradePrice(from, to);
+        const cappedPrice = ScryptService.applyPriceCap(currentPrice, side, priceCap);
 
         // Use tolerance for float comparison to avoid unnecessary updates due to rounding
-        const priceChanged = orderInfo.price && Math.abs(currentPrice - orderInfo.price) > 0.000001;
+        const priceChanged = orderInfo.price && Math.abs(cappedPrice - orderInfo.price) > 0.000001;
         if (priceChanged) {
-          this.logger.verbose(`Order ${clOrdId}: price changed ${orderInfo.price} -> ${currentPrice}, updating order`);
+          this.logger.verbose(`Order ${clOrdId}: price changed ${orderInfo.price} -> ${cappedPrice}, updating order`);
 
           try {
-            const newId = await this.editOrder(clOrdId, from, to, orderInfo.remainingQuantity, currentPrice);
+            const newId = await this.editOrder(clOrdId, from, to, orderInfo.remainingQuantity, cappedPrice);
             this.logger.verbose(`Order ${clOrdId} changed to ${newId}`);
             throw new TradeChangedException(newId);
           } catch (e) {
@@ -364,7 +383,7 @@ export class ScryptService extends PricingProvider {
             }
           }
         } else {
-          this.logger.verbose(`Order ${clOrdId} open, price is still ${currentPrice}`);
+          this.logger.verbose(`Order ${clOrdId} open, price is still ${cappedPrice}`);
         }
         return false;
       }
@@ -383,7 +402,8 @@ export class ScryptService extends PricingProvider {
 
         // Restart order with remaining amount (already in base currency)
         const { symbol, side } = await this.getTradePair(from, to);
-        const price = await this.getOrderBookPrice(symbol, side);
+        const orderbookPrice = await this.getOrderBookPrice(symbol, side);
+        const price = ScryptService.applyPriceCap(orderbookPrice, side, priceCap);
 
         this.logger.verbose(`Order ${clOrdId} cancelled, restarting with remaining ${remaining} (base currency)`);
 

--- a/src/subdomains/core/liquidity-management/adapters/actions/__tests__/scrypt.adapter.spec.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/__tests__/scrypt.adapter.spec.ts
@@ -1,0 +1,53 @@
+import { ScryptOrderSide } from 'src/integration/exchange/dto/scrypt.dto';
+import { ScryptAdapter } from '../scrypt.adapter';
+
+describe('ScryptAdapter.toPriceCap', () => {
+  const maxDev = 0.003;
+
+  // Anchor: at 2026-05-21 ~13:44 UTC, Kraken VWAP BTC/EUR was ~66'218 EUR/BTC.
+  // The pricingService convention is Price.price = source/target (= from/to),
+  // verified via Price.convert(amount) = amount/price.
+  // Scrypt LIMIT orders express price as quote-per-base, so:
+  //   pricingService.getPrice(EUR, BTC).price = EUR-per-BTC (high number, e.g. 66_500)
+  //   pricingService.getPrice(BTC, EUR).price = BTC-per-EUR (small number, e.g. 1.5e-5)
+
+  describe('side=BUY (e.g. sellIfDeficit BTC: from=EUR=quote, to=BTC=base)', () => {
+    it('treats from-per-to reference directly as quote-per-base and returns upper bound', () => {
+      // ref 66'500 EUR/BTC → cap = 66'500 × 1.003 = 66'699.5
+      expect(ScryptAdapter.toPriceCap(66_500, ScryptOrderSide.BUY, maxDev)).toBeCloseTo(66_699.5, 4);
+    });
+
+    it('cap is strictly greater than reference for BUY', () => {
+      const cap = ScryptAdapter.toPriceCap(66_500, ScryptOrderSide.BUY, maxDev);
+      expect(cap).toBeGreaterThan(66_500);
+    });
+  });
+
+  describe('side=SELL (e.g. selling BTC for EUR: from=BTC=base, to=EUR=quote)', () => {
+    it('inverts from-per-to reference into quote-per-base and returns lower bound', () => {
+      // ref 1.5e-5 BTC/EUR  →  refQuotePerBase = 1 / 1.5e-5 = 66_666.67  →  cap = ×0.997 = 66'466.67
+      expect(ScryptAdapter.toPriceCap(1.5e-5, ScryptOrderSide.SELL, maxDev)).toBeCloseTo(66_466.67, 1);
+    });
+
+    it('cap is strictly less than the inverted reference for SELL', () => {
+      const ref = 1.5e-5;
+      const cap = ScryptAdapter.toPriceCap(ref, ScryptOrderSide.SELL, maxDev);
+      expect(cap).toBeLessThan(1 / ref);
+    });
+  });
+
+  describe('symmetry sanity', () => {
+    it('BUY cap on (EUR, BTC) ≈ inverse of SELL cap on (BTC, EUR) within 1.6× the deviation window', () => {
+      // Refs are exact inverses of each other (66_500 ↔ 1/66_500)
+      const buyRef = 66_500;
+      const sellRef = 1 / buyRef;
+
+      const buyCap = ScryptAdapter.toPriceCap(buyRef, ScryptOrderSide.BUY, maxDev); // 66_500 × 1.003
+      const sellCap = ScryptAdapter.toPriceCap(sellRef, ScryptOrderSide.SELL, maxDev); // 66_500 × 0.997
+
+      // Both caps are in EUR/BTC (quote-per-base). They differ by 2×maxDev around the mid.
+      const ratio = buyCap / sellCap;
+      expect(ratio).toBeCloseTo((1 + maxDev) / (1 - maxDev), 5);
+    });
+  });
+});

--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -498,7 +498,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
       throw new OrderFailedException(message);
     }
 
-    return { scryptPrice, priceCap: this.toPriceCap(checkPrice.price, side, maxPriceDeviation), side };
+    return { scryptPrice, priceCap: ScryptAdapter.toPriceCap(checkPrice.price, side, maxPriceDeviation), side };
   }
 
   private async computePriceCap(
@@ -508,13 +508,17 @@ export class ScryptAdapter extends LiquidityActionAdapter {
   ): Promise<number> {
     const { side } = await this.scryptService.getTradePair(from.name, to.name);
     const checkPrice = await this.pricingService.getPrice(from, to, PriceValidity.VALID_ONLY);
-    return this.toPriceCap(checkPrice.price, side, maxPriceDeviation);
+    return ScryptAdapter.toPriceCap(checkPrice.price, side, maxPriceDeviation);
   }
 
-  private toPriceCap(referencePrice: number, side: ScryptOrderSide, maxPriceDeviation: number): number {
-    // pricingService returns "to per from"; Scrypt LIMIT orders use quote per base.
-    // For side=BUY (from=quote, to=base) we need the inverse; for side=SELL it matches.
-    const refQuotePerBase = side === ScryptOrderSide.BUY ? 1 / referencePrice : referencePrice;
+  static toPriceCap(referencePrice: number, side: ScryptOrderSide, maxPriceDeviation: number): number {
+    // pricingService.getPrice(from, to) returns Price.price = source/target = from-per-to
+    // (verified via Price.convert(amount) = amount / price, see Price entity).
+    // Scrypt LIMIT orders use quote-per-base.
+    //
+    // side=BUY  (from=quote, to=base): from-per-to = quote-per-base → no inversion
+    // side=SELL (from=base,  to=quote): from-per-to = base-per-quote → invert
+    const refQuotePerBase = side === ScryptOrderSide.SELL ? 1 / referencePrice : referencePrice;
     return side === ScryptOrderSide.BUY
       ? refQuotePerBase * (1 + maxPriceDeviation)
       : refQuotePerBase * (1 - maxPriceDeviation);
@@ -543,7 +547,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
         isLiqMail: true,
       },
       correlationId: `scrypt-price-deviation-${from.name}-${to.name}`,
-      options: { debounce: 60 * 60 * 1000, suppressRecurring: true },
+      options: { debounce: 60 * 60 * 1000 },
     };
 
     try {

--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { Config } from 'src/config/config';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { ScryptOrderInfo, ScryptOrderSide, ScryptTransactionStatus } from 'src/integration/exchange/dto/scrypt.dto';
 import { TradeChangedException } from 'src/integration/exchange/exceptions/trade-changed.exception';
@@ -10,6 +11,9 @@ import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { Util } from 'src/shared/utils/util';
 import { BuyCryptoService } from 'src/subdomains/core/buy-crypto/process/services/buy-crypto.service';
 import { DexService } from 'src/subdomains/supporting/dex/services/dex.service';
+import { MailContext, MailType } from 'src/subdomains/supporting/notification/enums';
+import { MailRequest } from 'src/subdomains/supporting/notification/interfaces';
+import { NotificationService } from 'src/subdomains/supporting/notification/services/notification.service';
 import {
   PriceCurrency,
   PriceValidity,
@@ -46,6 +50,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     private readonly assetService: AssetService,
     private readonly ruleRepo: LiquidityManagementRuleRepository,
     private readonly balanceRepo: LiquidityBalanceRepository,
+    private readonly notificationService: NotificationService,
     @Inject(forwardRef(() => BuyCryptoService)) private readonly buyCryptoService: BuyCryptoService,
   ) {
     super(LiquidityManagementSystem.SCRYPT);
@@ -449,17 +454,62 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     return side === ScryptOrderSide.BUY ? availableBalance * 0.99 : availableBalance;
   }
 
-  private async getAndCheckTradePrice(from: Asset, to: Asset, maxPriceDeviation = 0.05): Promise<number> {
+  private async getAndCheckTradePrice(
+    from: Asset,
+    to: Asset,
+    maxPriceDeviation = Config.scrypt.maxPriceDeviation,
+  ): Promise<number> {
     const price = await this.scryptService.getCurrentPrice(from.name, to.name);
 
     const checkPrice = await this.pricingService.getPrice(from, to, PriceValidity.VALID_ONLY);
 
-    if (Math.abs((price - checkPrice.price) / checkPrice.price) > maxPriceDeviation) {
-      throw new OrderFailedException(
-        `Trade price out of range: exchange price ${price}, check price ${checkPrice.price}, max deviation ${maxPriceDeviation}`,
-      );
+    const deviation = Math.abs((price - checkPrice.price) / checkPrice.price);
+
+    if (deviation > maxPriceDeviation) {
+      const message =
+        `Scrypt ${from.name}/${to.name} price deviation ${(deviation * 100).toFixed(4)}% ` +
+        `exceeds max ${(maxPriceDeviation * 100).toFixed(4)}% ` +
+        `(exchange price ${price}, reference ${checkPrice.price}). Trade aborted.`;
+
+      this.logger.error(message);
+      await this.notifyPriceDeviation(message, from, to, price, checkPrice.price, deviation, maxPriceDeviation);
+
+      throw new OrderFailedException(message);
     }
 
     return price;
+  }
+
+  private async notifyPriceDeviation(
+    summary: string,
+    from: Asset,
+    to: Asset,
+    price: number,
+    referencePrice: number,
+    deviation: number,
+    maxPriceDeviation: number,
+  ): Promise<void> {
+    const mailRequest: MailRequest = {
+      type: MailType.ERROR_MONITORING,
+      context: MailContext.LIQUIDITY_MANAGEMENT,
+      input: {
+        subject: `Scrypt ${from.name}/${to.name} price deviation too high`,
+        errors: [
+          summary,
+          `Exchange price (Scrypt): ${price}`,
+          `Reference price (pricing service): ${referencePrice}`,
+          `Deviation: ${(deviation * 100).toFixed(4)} % (cap: ${(maxPriceDeviation * 100).toFixed(4)} %)`,
+        ],
+        isLiqMail: true,
+      },
+      correlationId: `scrypt-price-deviation-${from.name}-${to.name}`,
+      options: { debounce: 60 * 60 * 1000, suppressRecurring: true },
+    };
+
+    try {
+      await this.notificationService.sendMail(mailRequest);
+    } catch (e) {
+      this.logger.error('Failed to send Scrypt price deviation notification', e);
+    }
   }
 }

--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -136,7 +136,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     const targetAsset = order.pipeline.rule.targetAsset;
     const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
-    await this.getAndCheckTradePrice(targetAsset, tradeAssetEntity, maxPriceDeviation);
+    const { priceCap } = await this.getAndCheckTradePrice(targetAsset, tradeAssetEntity, maxPriceDeviation);
 
     const availableBalance = await this.scryptService.getAvailableBalance(targetAsset.dexName);
     const effectiveMax = Math.min(order.maxAmount, availableBalance);
@@ -149,7 +149,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
 
     const amount = Util.floor(effectiveMax, 6);
 
-    return this.executeSell(order, amount, targetAsset.dexName, tradeAsset);
+    return this.executeSell(order, amount, targetAsset.dexName, tradeAsset, priceCap);
   }
 
   private async buy(order: LiquidityManagementOrder): Promise<CorrelationId> {
@@ -158,9 +158,13 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     const targetAssetEntity = order.pipeline.rule.targetAsset;
     const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
-    const price = await this.getAndCheckTradePrice(tradeAssetEntity, targetAssetEntity, maxPriceDeviation);
-    const minSellAmount = Util.floor(order.minAmount * price, 6);
-    const maxSellAmount = Util.floor(order.maxAmount * price, 6);
+    const { scryptPrice, priceCap } = await this.getAndCheckTradePrice(
+      tradeAssetEntity,
+      targetAssetEntity,
+      maxPriceDeviation,
+    );
+    const minSellAmount = Util.floor(order.minAmount * scryptPrice, 6);
+    const maxSellAmount = Util.floor(order.maxAmount * scryptPrice, 6);
 
     const availableBalance = await this.getAvailableTradeBalance(tradeAsset, targetAssetEntity.dexName);
     const fiatOrderCap = ['CHF', 'EUR'].includes(tradeAsset) ? 200_000 : Infinity;
@@ -179,7 +183,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     order.outputAsset = targetAssetEntity.dexName;
 
     try {
-      return await this.scryptService.sell(tradeAsset, targetAssetEntity.dexName, amount);
+      return await this.scryptService.sell(tradeAsset, targetAssetEntity.dexName, amount, priceCap);
     } catch (e) {
       if (this.isBalanceTooLowError(e)) {
         throw new OrderNotProcessableException(e.message);
@@ -224,11 +228,15 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     const targetAsset = order.pipeline.rule.targetAsset;
     const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
-    const price = await this.getAndCheckTradePrice(targetAsset, tradeAssetEntity, maxPriceDeviation);
+    const { scryptPrice, priceCap } = await this.getAndCheckTradePrice(
+      targetAsset,
+      tradeAssetEntity,
+      maxPriceDeviation,
+    );
     const availableBalance = await this.scryptService.getAvailableBalance(targetAsset.dexName);
 
-    // price = targetAsset per tradeAsset (e.g., EUR per BTC)
-    const sellAmount = Util.floor(deficitAmount * price, 6);
+    // scryptPrice = targetAsset per tradeAsset (e.g., EUR per BTC)
+    const sellAmount = Util.floor(deficitAmount * scryptPrice, 6);
     const amount = Util.floor(Math.min(sellAmount, order.maxAmount, availableBalance), 6);
 
     if (amount <= 0) {
@@ -237,7 +245,7 @@ export class ScryptAdapter extends LiquidityActionAdapter {
       );
     }
 
-    return this.executeSell(order, amount, targetAsset.dexName, tradeAsset);
+    return this.executeSell(order, amount, targetAsset.dexName, tradeAsset, priceCap);
   }
 
   // --- COMPLETION CHECKS --- //
@@ -265,22 +273,33 @@ export class ScryptAdapter extends LiquidityActionAdapter {
   }
 
   private async checkSellCompletion(order: LiquidityManagementOrder): Promise<boolean> {
-    const { tradeAsset } = this.parseTradeParams(order.action.paramMap);
-    const asset = order.pipeline.rule.targetAsset.dexName;
+    const { tradeAsset, maxPriceDeviation } = this.parseTradeParams(order.action.paramMap);
+    const targetAsset = order.pipeline.rule.targetAsset;
+    const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
-    return this.checkTradeCompletion(order, asset, tradeAsset);
+    const priceCap = await this.computePriceCap(targetAsset, tradeAssetEntity, maxPriceDeviation);
+
+    return this.checkTradeCompletion(order, targetAsset.dexName, tradeAsset, priceCap);
   }
 
   private async checkBuyCompletion(order: LiquidityManagementOrder): Promise<boolean> {
-    const { tradeAsset } = this.parseTradeParams(order.action.paramMap);
-    const asset = order.pipeline.rule.targetAsset.dexName;
+    const { tradeAsset, maxPriceDeviation } = this.parseTradeParams(order.action.paramMap);
+    const targetAsset = order.pipeline.rule.targetAsset;
+    const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
-    return this.checkTradeCompletion(order, tradeAsset, asset);
+    const priceCap = await this.computePriceCap(tradeAssetEntity, targetAsset, maxPriceDeviation);
+
+    return this.checkTradeCompletion(order, tradeAsset, targetAsset.dexName, priceCap);
   }
 
-  private async checkTradeCompletion(order: LiquidityManagementOrder, from: string, to: string): Promise<boolean> {
+  private async checkTradeCompletion(
+    order: LiquidityManagementOrder,
+    from: string,
+    to: string,
+    priceCap?: number,
+  ): Promise<boolean> {
     try {
-      const isComplete = await this.scryptService.checkTrade(order.correlationId, from, to, order.created);
+      const isComplete = await this.scryptService.checkTrade(order.correlationId, from, to, order.created, priceCap);
 
       if (isComplete) {
         order.outputAmount = await this.aggregateTradeOutput(order);
@@ -425,13 +444,14 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     amount: number,
     fromAsset: string,
     toAsset: string,
+    priceCap?: number,
   ): Promise<CorrelationId> {
     order.inputAmount = amount;
     order.inputAsset = fromAsset;
     order.outputAsset = toAsset;
 
     try {
-      return await this.scryptService.sell(fromAsset, toAsset, amount);
+      return await this.scryptService.sell(fromAsset, toAsset, amount, priceCap);
     } catch (e) {
       if (this.isBalanceTooLowError(e)) {
         throw new OrderNotProcessableException(e.message);
@@ -458,26 +478,46 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     from: Asset,
     to: Asset,
     maxPriceDeviation = Config.scrypt.maxPriceDeviation,
-  ): Promise<number> {
-    const price = await this.scryptService.getCurrentPrice(from.name, to.name);
+  ): Promise<{ scryptPrice: number; priceCap: number; side: ScryptOrderSide }> {
+    const { side } = await this.scryptService.getTradePair(from.name, to.name);
+    const scryptPrice = await this.scryptService.getCurrentPrice(from.name, to.name);
 
     const checkPrice = await this.pricingService.getPrice(from, to, PriceValidity.VALID_ONLY);
 
-    const deviation = Math.abs((price - checkPrice.price) / checkPrice.price);
+    const deviation = Math.abs((scryptPrice - checkPrice.price) / checkPrice.price);
 
     if (deviation > maxPriceDeviation) {
       const message =
         `Scrypt ${from.name}/${to.name} price deviation ${(deviation * 100).toFixed(4)}% ` +
         `exceeds max ${(maxPriceDeviation * 100).toFixed(4)}% ` +
-        `(exchange price ${price}, reference ${checkPrice.price}). Trade aborted.`;
+        `(exchange price ${scryptPrice}, reference ${checkPrice.price}). Trade aborted.`;
 
       this.logger.error(message);
-      await this.notifyPriceDeviation(message, from, to, price, checkPrice.price, deviation, maxPriceDeviation);
+      await this.notifyPriceDeviation(message, from, to, scryptPrice, checkPrice.price, deviation, maxPriceDeviation);
 
       throw new OrderFailedException(message);
     }
 
-    return price;
+    return { scryptPrice, priceCap: this.toPriceCap(checkPrice.price, side, maxPriceDeviation), side };
+  }
+
+  private async computePriceCap(
+    from: Asset,
+    to: Asset,
+    maxPriceDeviation = Config.scrypt.maxPriceDeviation,
+  ): Promise<number> {
+    const { side } = await this.scryptService.getTradePair(from.name, to.name);
+    const checkPrice = await this.pricingService.getPrice(from, to, PriceValidity.VALID_ONLY);
+    return this.toPriceCap(checkPrice.price, side, maxPriceDeviation);
+  }
+
+  private toPriceCap(referencePrice: number, side: ScryptOrderSide, maxPriceDeviation: number): number {
+    // pricingService returns "to per from"; Scrypt LIMIT orders use quote per base.
+    // For side=BUY (from=quote, to=base) we need the inverse; for side=SELL it matches.
+    const refQuotePerBase = side === ScryptOrderSide.BUY ? 1 / referencePrice : referencePrice;
+    return side === ScryptOrderSide.BUY
+      ? refQuotePerBase * (1 + maxPriceDeviation)
+      : refQuotePerBase * (1 - maxPriceDeviation);
   }
 
   private async notifyPriceDeviation(


### PR DESCRIPTION
## Why

[#3736](https://github.com/DFXswiss/api/pull/3736) added a pre-trade reference-deviation check at 0.3 %. That check only fires at the moment we send `NewOrderSingle`. Two things can still get past it:

1. **Market moves between check and fill.** Scrypt acks the order ~ms later, by which point the quoted ask can already be above our cap.
2. **The periodic edit loop in `ScryptService.checkTrade`** re-prices resting orders to whatever Scrypt's current best ask/bid is — completely unaware of our 0.3 % rule. A resting order placed inside the cap can be edited back out of it on the next tick.

Reading the Scrypt AsyncAPI spec ([#3737](https://github.com/DFXswiss/api/pull/3737)) confirmed there's no separate fee field to inspect — Scrypt embeds its commission in the quote (`Fee: "0"` on every Trade in the spec examples, `AvgPx` doc-string: *"Does not include fees"*). The **only** way to bound implicit cost is the LIMIT `Price` itself.

## What

Make the cap **hard** by clamping every LIMIT price we send to `reference × (1 ± maxPriceDeviation)`, for both placement and edits.

### `ScryptService`
- `sell(from, to, amount, priceCap?)` — initial placement uses `min(orderbookPrice, cap)` for BUY, `max(orderbookPrice, cap)` for SELL.
- `checkTrade(clOrdId, from, to, orderCreated?, priceCap?)` — edit loop applies the same clamp before any `OrderCancelReplaceRequest`. Resting orders cannot be re-priced past the cap.
- `applyPriceCap()` — single static source of truth for the clamp; defensively returns the orderbook price for `null`/`undefined`/`NaN`/`±Infinity`/`≤0` caps.

### `ScryptAdapter`
- `getAndCheckTradePrice` returns `{ scryptPrice, priceCap, side }`. Pre-trade check + cap computation share one `pricingService.getPrice` call.
- `computePriceCap` is the per-tick helper used by completion checks, recomputing the cap from a fresh reference so the protection adapts to market moves without needing extra DB columns.
- `toPriceCap` (static, public for testability) does the `from-per-to → quote-per-base` conversion. `pricingService.getPrice(from, to).price` is `source/target` (verified via `Price.convert(amount) = amount/price` in `price.ts`). That coincides with quote-per-base for `side=BUY` (from=quote, to=base) and requires inversion for `side=SELL`.
- All three placement paths (`sell`, `buy`, `sellIfDeficit`) and both completion checks (`checkSellCompletion`, `checkBuyCompletion`) wired through.

## Tests

Added `__tests__/scrypt.service.spec.ts` and `__tests__/scrypt.adapter.spec.ts` (18 tests total) covering:
- `applyPriceCap` × `{BUY, SELL}` × `{below cap, above cap, equal, undefined, null, 0, negative, NaN, ±Infinity}`
- `toPriceCap` realistic BUY (ref 66'500 EUR/BTC → cap 66'699.5) and SELL (ref 1.5e-5 BTC/EUR → cap 66'466.67)
- A **symmetry sanity test** that locks the inversion direction in (`BUY-cap / SELL-cap = (1+δ)/(1−δ)`)

## Self-review bugs found and fixed in this PR

A self-review pass before requesting human review caught three correctness bugs in the original implementation (all in the second commit of this PR):

1. **`toPriceCap` inverted on the wrong side.** Initial code inverted for BUY (where the reference is already quote-per-base) and not for SELL (which actually needs inversion). The symmetry test now locks this in.
2. **Notification was permanently suppressed.** `suppressRecurring: true` combined with `debounce` causes `Notification.isSuppressed` to return true forever (the conditions are OR'd in `notification.entity.ts:43-47`). Dropped `suppressRecurring` so the 1h debounce works as documented.
3. **`applyPriceCap` accepted invalid caps.** Only `priceCap == null` short-circuited; `0`/negative/`NaN`/`±Infinity` would have produced bogus LIMIT prices. Added `Number.isFinite` + positivity check.

## Behavioural change

An order can now legitimately sit unfilled if the venue is priced beyond the cap for an extended period. That is the intended behaviour — better a stalled order than silent overpayment like 2026-05-21. After the existing 1 h-no-found timeout (`ScryptService.checkTrade`), the LM pipeline will fail and the alert fires.

## Effect on the 2026-05-21 incident

Replay with cap = 0.3 %, reference ≈ 66'500 EUR/BTC → cap ≈ 66'700 EUR/BTC. The 13 fills at 66'479–66'484 would have **filled normally** (they were under the cap; our internal spread vs `pricingService` is what was high, not Scrypt's quote itself). The real win is in the bad case: if Scrypt's quote drifted up to 67'200 mid-fill, our LIMIT at 66'700 would simply stop filling instead of being edited up by `checkTrade`.

## Out of scope (separate follow-up)

A spec-vs-code audit during this work surfaced unrelated drift between `scrypt.dto.ts` and the vendor spec (wrong `ScryptTransactionStatus` enum values, missing `OrdStatus.Replaced`, missing `TransactTime` on `OrderCancelRequest`/`OrderCancelReplaceRequest`, unhandled `ExecType.CancelRejected`/`ReplaceRejected`). These are not regressions introduced by this PR and are not addressed here. Tracked separately.

## Test plan

- [x] Unit tests added + passing (18/18 locally)
- [x] lint, format, build green locally
- [x] CI green
- [ ] DEV smoke test: force a Scrypt quote outside cap, confirm order is placed at cap price and does **not** fill until quote recovers
- [ ] DEV: trigger edit-loop with quote outside cap, confirm `OrderCancelReplaceRequest` is sent at cap price (or not at all if cap = current order price)
- [ ] Verify completion check still aggregates output correctly when order eventually fills

## Supersedes

This PR contains all changes from [#3736](https://github.com/DFXswiss/api/pull/3736) (Phase 1: pre-trade deviation check + alert) plus the LIMIT-cap and the bug-fix commit. #3736 can be closed once this is merged.