### PR TITLE
Route Scrypt EUR via USDT instead of BTC

### DIFF
--- a/migration/1779381590531-RouteScryptEurViaUsdt.js
+++ b/migration/1779381590531-RouteScryptEurViaUsdt.js
@@ -1,0 +1,59 @@
+// Stop buying BTC directly on Scrypt. Convert incoming EUR on Scrypt to USDT instead
+// and route USDT to Binance for further BTC acquisition (same pattern as CHF / Rule 312).
+//
+// Reverts the routing introduced by migration 1774100000000-AddScryptSellIfDeficitAction.js:
+// 1. Re-points Rule 313 (Scrypt/EUR redundancy) from Action 261 back to Action 233
+//    (Scrypt sell USDT) — already in use by Rule 312 (CHF) and known good.
+// 2. Removes Action 261 (Scrypt sell-if-deficit BTC), which is no longer referenced.
+//
+// Verified on 2026-05-21: no other action references 261 via onSuccessId/onFailId.
+// Rule 314 (Scrypt/BTC withdraw) is kept as cleanup path for any residual BTC on Scrypt.
+module.exports = class RouteScryptEurViaUsdt1779381590531 {
+  name = 'RouteScryptEurViaUsdt1779381590531';
+
+  async up(queryRunner) {
+    // Skip if rule 313 or action 233 don't exist in this environment
+    const [rule] = await queryRunner.query(`SELECT "id" FROM "dbo"."liquidity_management_rule" WHERE "id" = 313`);
+    if (!rule) return;
+
+    const [fallbackAction] = await queryRunner.query(
+      `SELECT "id" FROM "dbo"."liquidity_management_action" WHERE "id" = 233`,
+    );
+    if (!fallbackAction) return;
+
+    // 1. Point Rule 313 (Scrypt/EUR redundancy) at the USDT sell action
+    await queryRunner.query(`
+            UPDATE "dbo"."liquidity_management_rule"
+            SET "redundancyStartActionId" = 233
+            WHERE "id" = 313
+        `);
+
+    // 2. Remove the now-unreferenced sell-if-deficit BTC action
+    await queryRunner.query(`
+            DELETE FROM "dbo"."liquidity_management_action"
+            WHERE "id" = 261 AND "system" = 'Scrypt' AND "command" = 'sell-if-deficit'
+        `);
+  }
+
+  async down(queryRunner) {
+    // Restore the state from migration 1774100000000-AddScryptSellIfDeficitAction.js:
+    // re-insert Action 261 (Scrypt sell-if-deficit BTC) and re-point Rule 313 at it.
+    const [fallbackAction] = await queryRunner.query(
+      `SELECT "id" FROM "dbo"."liquidity_management_action" WHERE "id" = 233`,
+    );
+    if (!fallbackAction) return;
+
+    await queryRunner.query(`
+            SET IDENTITY_INSERT "dbo"."liquidity_management_action" ON;
+            INSERT INTO "dbo"."liquidity_management_action" ("id", "system", "command", "tag", "params", "onSuccessId", "onFailId")
+            VALUES (261, 'Scrypt', 'sell-if-deficit', 'SCRYPT BTC', '{"tradeAsset":"BTC","checkAssetId":113}', NULL, 233);
+            SET IDENTITY_INSERT "dbo"."liquidity_management_action" OFF;
+        `);
+
+    await queryRunner.query(`
+            UPDATE "dbo"."liquidity_management_rule"
+            SET "redundancyStartActionId" = 261
+            WHERE "id" = 313
+        `);
+  }
+};


### PR DESCRIPTION
## Why

On 2026-05-21, buy_crypto **#123090** routed a 570'000 EUR → BTC trade to **Scrypt BTC/EUR** at 66'487 EUR/BTC vs. Kraken VWAP @ 13:44 UTC of 66'218 EUR/BTC — a **+0.41 %** premium (~2'257 EUR more than a Kraken-VWAP fill, ~1'530 EUR more than an actual Kraken trade incl. fees). The fallback chain landed on Scrypt because Binance had insufficient BTC (Rule 192) and the Binance USDT refill (Rule 210) is `Inactive`.

Scrypt's BTC/EUR pricing is structurally worse than its USDT pairs (~0.6 % spread vs ~0.13 % on 6-month history). The USDT route already exists end-to-end for CHF (Rule 312 → Action 233 → Rule 315 → Binance).

Closes #3739

## What

New TypeORM migration `migration/1779381590531-RouteScryptEurViaUsdt.js`:

- `up()`:
  1. `UPDATE liquidity_management_rule SET redundancyStartActionId = 233 WHERE id = 313` — re-points Scrypt/EUR redundancy at the existing `Scrypt sell USDT` action (same one Rule 312 / CHF already uses).
  2. `DELETE FROM liquidity_management_action WHERE id = 261 AND system = 'Scrypt' AND command = 'sell-if-deficit'` — removes the now-unreferenced action.
- `down()`: faithful inverse of `1774100000000-AddScryptSellIfDeficitAction.js` — re-inserts Action 261 (with `IDENTITY_INSERT` so the id is preserved, important because Rule 313's `redundancyStartActionId` references it by id) and re-points Rule 313 back to 261.

Verified before merge (per issue): `SELECT id FROM liquidity_management_action WHERE onSuccessId=261 OR onFailId=261` returns `[]`. Rule 314 (Scrypt/BTC withdraw) and Action 262 are intentionally retained as cleanup path for any residual BTC on Scrypt.

## Deploy prerequisite (out of scope for this PR)

Per the issue, Rule 210 (Binance/USDT refill) must be `Active` **before** this migration deploys, otherwise large BTC buys will pile up on `MissingLiquidity`. Verify with:

```sql
SELECT id, status, [minimal], optimal FROM liquidity_management_rule WHERE id = 210;
```

## Acceptance criteria

- [x] New migration committed in `migration/` with timestamp > `1775745823000` (`1779381590531`)
- [x] `up()` reroutes Rule 313 to Action 233 and deletes Action 261
- [x] `down()` restores the previous state (re-inserts Action 261 + re-points Rule 313 → 261)
- [x] Lint, format:check, build green locally
- [ ] Verification queries produce expected results in DEV (post-deploy)
- [x] Draft PR opened against `develop` on `DFXswiss/api`
- [x] Linked back to #3739

## Verification queries (post-deploy)

```sql
-- Rule 313 now points at 233
SELECT id, redundancyStartActionId FROM liquidity_management_rule WHERE id = 313;
-- Expected: 233

-- Action 261 is gone
SELECT id FROM liquidity_management_action WHERE id = 261;
-- Expected: [] empty

-- No new Scrypt BTC/EUR trades after deploy
SELECT TOP 5 id, created, symbol, cost, [order]
FROM exchange_tx
WHERE exchange = 'Scrypt' AND symbol = 'BTC/EUR' AND created > '<deploy-date>'
ORDER BY id DESC;
-- Expected: [] empty
```