### PR TITLE
Remove BTC purchase mechanism on Scrypt

### DIFF
--- a/migration/1779381590531-RouteScryptEurViaUsdt.js
+++ b/migration/1779381590531-RouteScryptEurViaUsdt.js
@@ -1,0 +1,59 @@
+// Stop buying BTC directly on Scrypt. Convert incoming EUR on Scrypt to USDT instead
+// and route USDT to Binance for further BTC acquisition (same pattern as CHF / Rule 312).
+//
+// Reverts the routing introduced by migration 1774100000000-AddScryptSellIfDeficitAction.js:
+// 1. Re-points Rule 313 (Scrypt/EUR redundancy) from Action 261 back to Action 233
+//    (Scrypt sell USDT) — already in use by Rule 312 (CHF) and known good.
+// 2. Removes Action 261 (Scrypt sell-if-deficit BTC), which is no longer referenced.
+//
+// Verified on 2026-05-21: no other action references 261 via onSuccessId/onFailId.
+// Rule 314 (Scrypt/BTC withdraw) is kept as cleanup path for any residual BTC on Scrypt.
+module.exports = class RouteScryptEurViaUsdt1779381590531 {
+  name = 'RouteScryptEurViaUsdt1779381590531';
+
+  async up(queryRunner) {
+    // Skip if rule 313 or action 233 don't exist in this environment
+    const [rule] = await queryRunner.query(`SELECT "id" FROM "dbo"."liquidity_management_rule" WHERE "id" = 313`);
+    if (!rule) return;
+
+    const [fallbackAction] = await queryRunner.query(
+      `SELECT "id" FROM "dbo"."liquidity_management_action" WHERE "id" = 233`,
+    );
+    if (!fallbackAction) return;
+
+    // 1. Point Rule 313 (Scrypt/EUR redundancy) at the USDT sell action
+    await queryRunner.query(`
+            UPDATE "dbo"."liquidity_management_rule"
+            SET "redundancyStartActionId" = 233
+            WHERE "id" = 313
+        `);
+
+    // 2. Remove the now-unreferenced sell-if-deficit BTC action
+    await queryRunner.query(`
+            DELETE FROM "dbo"."liquidity_management_action"
+            WHERE "id" = 261 AND "system" = 'Scrypt' AND "command" = 'sell-if-deficit'
+        `);
+  }
+
+  async down(queryRunner) {
+    // Restore the state from migration 1774100000000-AddScryptSellIfDeficitAction.js:
+    // re-insert Action 261 (Scrypt sell-if-deficit BTC) and re-point Rule 313 at it.
+    const [fallbackAction] = await queryRunner.query(
+      `SELECT "id" FROM "dbo"."liquidity_management_action" WHERE "id" = 233`,
+    );
+    if (!fallbackAction) return;
+
+    await queryRunner.query(`
+            SET IDENTITY_INSERT "dbo"."liquidity_management_action" ON;
+            INSERT INTO "dbo"."liquidity_management_action" ("id", "system", "command", "tag", "params", "onSuccessId", "onFailId")
+            VALUES (261, 'Scrypt', 'sell-if-deficit', 'SCRYPT BTC', '{"tradeAsset":"BTC","checkAssetId":113}', NULL, 233);
+            SET IDENTITY_INSERT "dbo"."liquidity_management_action" OFF;
+        `);
+
+    await queryRunner.query(`
+            UPDATE "dbo"."liquidity_management_rule"
+            SET "redundancyStartActionId" = 261
+            WHERE "id" = 313
+        `);
+  }
+};

--- a/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
+++ b/src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Blockchain } from 'src/integration/blockchain/shared/enums/blockchain.enum';
 import { ScryptOrderInfo, ScryptOrderSide, ScryptTransactionStatus } from 'src/integration/exchange/dto/scrypt.dto';
 import { TradeChangedException } from 'src/integration/exchange/exceptions/trade-changed.exception';
@@ -8,28 +8,20 @@ import { Asset } from 'src/shared/models/asset/asset.entity';
 import { AssetService } from 'src/shared/models/asset/asset.service';
 import { DfxLogger } from 'src/shared/services/dfx-logger';
 import { Util } from 'src/shared/utils/util';
-import { BuyCryptoService } from 'src/subdomains/core/buy-crypto/process/services/buy-crypto.service';
 import { DexService } from 'src/subdomains/supporting/dex/services/dex.service';
-import {
-  PriceCurrency,
-  PriceValidity,
-  PricingService,
-} from 'src/subdomains/supporting/pricing/services/pricing.service';
+import { PriceValidity, PricingService } from 'src/subdomains/supporting/pricing/services/pricing.service';
 import { LiquidityManagementOrder } from '../../entities/liquidity-management-order.entity';
 import { LiquidityManagementSystem } from '../../enums';
 import { OrderFailedException } from '../../exceptions/order-failed.exception';
 import { OrderNotProcessableException } from '../../exceptions/order-not-processable.exception';
 import { Command, CorrelationId } from '../../interfaces';
-import { LiquidityBalanceRepository } from '../../repositories/liquidity-balance.repository';
 import { LiquidityManagementOrderRepository } from '../../repositories/liquidity-management-order.repository';
-import { LiquidityManagementRuleRepository } from '../../repositories/liquidity-management-rule.repository';
 import { LiquidityActionAdapter } from './base/liquidity-action.adapter';
 
 export enum ScryptAdapterCommands {
   WITHDRAW = 'withdraw',
   SELL = 'sell',
   BUY = 'buy',
-  SELL_IF_DEFICIT = 'sell-if-deficit',
 }
 
 @Injectable()
@@ -44,16 +36,12 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     private readonly orderRepo: LiquidityManagementOrderRepository,
     private readonly pricingService: PricingService,
     private readonly assetService: AssetService,
-    private readonly ruleRepo: LiquidityManagementRuleRepository,
-    private readonly balanceRepo: LiquidityBalanceRepository,
-    @Inject(forwardRef(() => BuyCryptoService)) private readonly buyCryptoService: BuyCryptoService,
   ) {
     super(LiquidityManagementSystem.SCRYPT);
 
     this.commands.set(ScryptAdapterCommands.WITHDRAW, this.withdraw.bind(this));
     this.commands.set(ScryptAdapterCommands.SELL, this.sell.bind(this));
     this.commands.set(ScryptAdapterCommands.BUY, this.buy.bind(this));
-    this.commands.set(ScryptAdapterCommands.SELL_IF_DEFICIT, this.sellIfDeficit.bind(this));
   }
 
   async checkCompletion(order: LiquidityManagementOrder): Promise<boolean> {
@@ -66,9 +54,6 @@ export class ScryptAdapter extends LiquidityActionAdapter {
 
       case ScryptAdapterCommands.BUY:
         return this.checkBuyCompletion(order);
-
-      case ScryptAdapterCommands.SELL_IF_DEFICIT:
-        return this.checkSellCompletion(order);
 
       default:
         return false;
@@ -83,9 +68,6 @@ export class ScryptAdapter extends LiquidityActionAdapter {
       case ScryptAdapterCommands.SELL:
       case ScryptAdapterCommands.BUY:
         return this.validateTradeParams(params);
-
-      case ScryptAdapterCommands.SELL_IF_DEFICIT:
-        return this.validateSellIfDeficitParams(params);
 
       default:
         throw new Error(`Command ${command} not supported by ScryptAdapter`);
@@ -128,6 +110,14 @@ export class ScryptAdapter extends LiquidityActionAdapter {
   private async sell(order: LiquidityManagementOrder): Promise<CorrelationId> {
     const { tradeAsset, maxPriceDeviation } = this.parseTradeParams(order.action.paramMap);
 
+    // Structural guard: Scrypt BTC/EUR (and other Scrypt BTC pairs) have materially worse spreads
+    // than Scrypt USDT pairs. BTC acquisition on Scrypt is no longer supported — route via Binance USDT.
+    if (tradeAsset === 'BTC') {
+      throw new OrderNotProcessableException(
+        'Scrypt: buying BTC is no longer supported (tradeAsset=BTC). Route via Binance USDT instead.',
+      );
+    }
+
     const targetAsset = order.pipeline.rule.targetAsset;
     const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
@@ -151,6 +141,15 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     const { tradeAsset, maxPriceDeviation } = this.parseTradeParams(order.action.paramMap);
 
     const targetAssetEntity = order.pipeline.rule.targetAsset;
+
+    // Structural guard: Scrypt BTC pairs have materially worse spreads than USDT pairs.
+    // BTC acquisition on Scrypt is no longer supported — route via Binance USDT instead.
+    if (targetAssetEntity.dexName === 'BTC') {
+      throw new OrderNotProcessableException(
+        'Scrypt: buying BTC is no longer supported (targetAsset=BTC). Route via Binance USDT instead.',
+      );
+    }
+
     const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
 
     const price = await this.getAndCheckTradePrice(tradeAssetEntity, targetAssetEntity, maxPriceDeviation);
@@ -182,57 +181,6 @@ export class ScryptAdapter extends LiquidityActionAdapter {
 
       throw e;
     }
-  }
-
-  private async sellIfDeficit(order: LiquidityManagementOrder): Promise<CorrelationId> {
-    const { tradeAsset, checkAssetId, maxPriceDeviation } = this.parseSellIfDeficitParams(order.action.paramMap);
-
-    // Check if the referenced asset has a deficit or pending liquidity demand
-    const checkRule = await this.ruleRepo.findOneBy({ targetAsset: { id: checkAssetId } });
-    if (!checkRule) {
-      throw new OrderNotProcessableException(`No rule found for asset ${checkAssetId}`);
-    }
-
-    const checkAsset = checkRule.targetAsset;
-    const checkBalance = await this.balanceRepo.findOneBy({ asset: { id: checkAssetId } });
-
-    // Convert pending demand from CHF to check asset
-    const pendingDemandChf = await this.buyCryptoService.getPendingLiquidityDemandChf(checkAssetId);
-    const chfPrice = await this.pricingService.getPrice(PriceCurrency.CHF, checkAsset, PriceValidity.VALID_ONLY);
-    const pendingDemand = chfPrice.convert(pendingDemandChf, 8);
-
-    const effectiveBalance = (checkBalance?.amount ?? 0) - pendingDemand;
-    const hasDeficit = effectiveBalance < (checkRule.minimal ?? 0);
-
-    if (!hasDeficit) {
-      throw new OrderNotProcessableException(
-        `No deficit for asset ${checkAssetId} (balance: ${checkBalance?.amount}, pending: ${pendingDemand}, effective: ${effectiveBalance}, minimal: ${checkRule.minimal})`,
-      );
-    }
-
-    // Calculate how much of the trade asset is needed to reach optimal (accounting for pending demand)
-    const deficitAmount = (checkRule.optimal ?? 0) - effectiveBalance;
-    if (deficitAmount <= 0) {
-      throw new OrderNotProcessableException(`No deficit to optimal for asset ${checkAssetId}`);
-    }
-
-    const targetAsset = order.pipeline.rule.targetAsset;
-    const tradeAssetEntity = await this.assetService.getAssetByUniqueName(`Scrypt/${tradeAsset}`);
-
-    const price = await this.getAndCheckTradePrice(targetAsset, tradeAssetEntity, maxPriceDeviation);
-    const availableBalance = await this.scryptService.getAvailableBalance(targetAsset.dexName);
-
-    // price = targetAsset per tradeAsset (e.g., EUR per BTC)
-    const sellAmount = Util.floor(deficitAmount * price, 6);
-    const amount = Util.floor(Math.min(sellAmount, order.maxAmount, availableBalance), 6);
-
-    if (amount <= 0) {
-      throw new OrderNotProcessableException(
-        `Scrypt: insufficient amount for sell-if-deficit (needed: ${sellAmount}, available: ${availableBalance})`,
-      );
-    }
-
-    return this.executeSell(order, amount, targetAsset.dexName, tradeAsset);
   }
 
   // --- COMPLETION CHECKS --- //
@@ -387,30 +335,6 @@ export class ScryptAdapter extends LiquidityActionAdapter {
     }
 
     return { tradeAsset, maxPriceDeviation };
-  }
-
-  private validateSellIfDeficitParams(params: Record<string, unknown>): boolean {
-    try {
-      this.parseSellIfDeficitParams(params);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private parseSellIfDeficitParams(params: Record<string, unknown>): {
-    tradeAsset: string;
-    checkAssetId: number;
-    maxPriceDeviation?: number;
-  } {
-    const { tradeAsset, maxPriceDeviation } = this.parseTradeParams(params);
-    const checkAssetId = params.checkAssetId as number | undefined;
-
-    if (!checkAssetId) {
-      throw new Error('Params provided to ScryptAdapter sell-if-deficit command are missing checkAssetId.');
-    }
-
-    return { tradeAsset, checkAssetId, maxPriceDeviation };
   }
 
   // --- HELPER METHODS --- //


### PR DESCRIPTION
## Why

On 2026-05-21, buy_crypto **#123090** routed a 570'000 EUR -> BTC trade onto Scrypt because Binance had insufficient BTC (Rule 192) and the Binance USDT refill pipeline (Rule 210) is `Inactive`. We paid 66'487 EUR/BTC on Scrypt vs. Kraken VWAP @ 13:44 UTC of 66'218 EUR/BTC -- a **+0.41% premium**, ~2'257 EUR more than a hypothetical Kraken-VWAP fill.

In our 6-month history Scrypt BTC/EUR averages a ~0.6% spread over reference, while Scrypt USDT/EUR is ~0.13%. We should not be buying BTC on Scrypt when a cheaper route exists.

The previous attempt ([PR #3740](https://github.com/DFXswiss/api/pull/3740)) was DB-only -- a future LM rule misconfiguration could re-introduce the same incident. This PR enforces the policy **structurally in code** so it cannot happen again.

Closes #3739

## What

### Code (`src/subdomains/core/liquidity-management/adapters/actions/scrypt.adapter.ts`)

- Remove the `sell-if-deficit` command from `ScryptAdapter` (enum entry, command registration, completion check, param validation, the `sellIfDeficit` method, and its param helpers)
- Remove now-unused constructor dependencies and imports (`LiquidityManagementRuleRepository`, `LiquidityBalanceRepository`, `BuyCryptoService`, `PriceCurrency`, `forwardRef`, `Inject`)
- Add a structural guard in `sell()` that throws `OrderNotProcessableException` when `tradeAsset === 'BTC'` -- fails fast before any balance/price logic
- Add a structural guard in `buy()` that throws `OrderNotProcessableException` when `targetAssetEntity.dexName === 'BTC'` -- same fail-fast semantics

These guards make it impossible for any LM rule misconfiguration to acquire BTC via Scrypt.

### Migration (`migration/1779381590531-RouteScryptEurViaUsdt.js`)

- `up()`: re-point Rule 313 (Scrypt/EUR redundancy) from Action 261 to Action 233 (Scrypt sell USDT, same action already used by Rule 312 for CHF); then delete Action 261 (Scrypt sell-if-deficit BTC)
- `down()`: re-insert Action 261 with original params via `IDENTITY_INSERT` and re-point Rule 313 back to 261
- Rule 314 (Scrypt/BTC withdraw) is kept as cleanup path for any residual BTC sitting on Scrypt

## Prerequisite (out of scope, blocks safe deploy)

**Rule 210 (Binance/USDT)** is `Inactive` as of 2026-05-21 -- this is exactly why the 2026-05-21 trade fell back to Scrypt in the first place. It **must be re-activated before deploying this PR**, otherwise large BTC buy_crypto orders will pile up on `MissingLiquidity` once the Scrypt BTC path is cut. Verify with:

```sql
SELECT id, status, [minimal], optimal FROM liquidity_management_rule WHERE id = 210;
```

## Acceptance criteria

- [x] New migration committed in `migration/` with a timestamp > `1775745823000` (1779381590531)
- [x] Migration's `up()` reroutes Rule 313 to Action 233 and deletes Action 261
- [x] Migration's `down()` restores the previous state
- [x] Code-level structural guards in `sell()` and `buy()` prevent BTC acquisition via Scrypt
- [x] `sell-if-deficit` command fully removed from `ScryptAdapter`
- [x] Lint, format, build green locally
- [ ] Verification queries below produce expected results on DEV
- [x] Draft PR opened against `develop` on `DFXswiss/api`
- [x] Linked to #3739

## Verification queries

### Before merge

```sql
-- Confirm action 261 has no incoming references
SELECT id, system, command, onSuccessId, onFailId
FROM liquidity_management_action
WHERE onSuccessId = 261 OR onFailId = 261;
-- Expected: [] empty

-- Confirm Rule 313 currently points at 261
SELECT id, context, [maximal], redundancyStartActionId
FROM liquidity_management_rule WHERE id = 313;
-- Expected: redundancyStartActionId = 261
```

### After deploy

```sql
-- Rule 313 now points at 233
SELECT id, redundancyStartActionId FROM liquidity_management_rule WHERE id = 313;
-- Expected: 233

-- Action 261 is gone
SELECT id FROM liquidity_management_action WHERE id = 261;
-- Expected: [] empty

-- No new Scrypt BTC/EUR trades after migration timestamp
SELECT TOP 5 id, created, symbol, cost, [order]
FROM exchange_tx
WHERE exchange = 'Scrypt' AND symbol = 'BTC/EUR' AND created > '<deploy-date>'
ORDER BY id DESC;
-- Expected: [] empty (any rows mean fallback wasn't fully cut)
```

### End-to-end smoke test on DEV

1. Deposit 1'000 EUR to the DEV Scrypt EUR account
2. Watch `liquidity_management_pipeline` -- confirm new pipeline targets Rule 313 with action 233 (not 261)
3. Confirm `exchange_tx` shows a `USDT/EUR` Scrypt trade, not `BTC/EUR`
4. Confirm Rule 315 (Scrypt/USDT redundancy) then triggers Action 231 to withdraw USDT to Tron/Binance