### PR TITLE
feat(realunit): API request/response tracing (DEV + PRD)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -80,8 +80,8 @@ async function bootstrap() {
   app.use('*', json({ type: 'application/json', limit: '20mb' }));
   app.use('/v1/node/*/rpc', text({ type: 'text/plain' }));
 
-  // DEV-only full request/response tracing for the RealUnit internal test phase
-  if (Config.environment === Environment.DEV) {
+  // Full request/response tracing for the RealUnit internal test phase (DEV + PRD)
+  if ([Environment.DEV, Environment.PRD].includes(Config.environment)) {
     app.use(apiTraceMiddleware());
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { getVerifiedIp } from './shared/utils/ip.util';
 import { AppModule } from './app.module';
 import { Config, Environment } from './config/config';
 import { ApiExceptionFilter } from './shared/filters/exception.filter';
+import { apiTraceMiddleware } from './shared/middlewares/api-trace.middleware';
 import { DfxLogger } from './shared/services/dfx-logger';
 import { AccountChangedWebhookDto } from './subdomains/generic/user/services/webhook/dto/account-changed-webhook.dto';
 import {
@@ -78,6 +79,11 @@ async function bootstrap() {
   app.use('/v1/tatum/addressWebhook', raw({ type: 'application/json', limit: '10mb' }));
   app.use('*', json({ type: 'application/json', limit: '20mb' }));
   app.use('/v1/node/*/rpc', text({ type: 'text/plain' }));
+
+  // DEV-only full request/response tracing for the RealUnit internal test phase
+  if (Config.environment === Environment.DEV) {
+    app.use(apiTraceMiddleware());
+  }
 
   app.useWebSocketAdapter(new WsAdapter(app));
 

--- a/src/shared/middlewares/api-trace.middleware.ts
+++ b/src/shared/middlewares/api-trace.middleware.ts
@@ -1,0 +1,83 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { DfxLogger } from '../services/dfx-logger';
+
+const logger = new DfxLogger('RealUnitTrace');
+
+const CLIENT_HEADER = 'x-client';
+const REALUNIT_CLIENT = /realunit-app/i;
+const REALUNIT_PATH = /^\/v\d+\/realunit\//i;
+
+// Keys whose values are masked: auth header, JWT/access tokens, signatures, credentials.
+// Anchored so public fields like `tokenInfo` / `tokenAddress` are NOT redacted.
+const SECRET_KEY = /(^authorization$|token$|signature$|password|secret|mnemonic|privatekey)/i;
+const MAX_STRING = 512;
+const REDACTED = '***';
+
+function redact(value: unknown, key?: string): unknown {
+  if (key && SECRET_KEY.test(key) && value != null && value !== '') return REDACTED;
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING ? `<… ${value.length} chars …>` : value;
+  }
+  if (Array.isArray(value)) return value.map((entry) => redact(entry));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redact(v, k)]));
+  }
+  return value;
+}
+
+function format(value: unknown): string {
+  if (value === undefined || value === null) return '(empty)';
+  if (typeof value === 'object' && Object.keys(value as object).length === 0) return '(empty)';
+  try {
+    return JSON.stringify(redact(value), null, 2);
+  } catch {
+    return '(unserializable)';
+  }
+}
+
+/**
+ * DEV-only request/response tracer for the RealUnit internal test phase.
+ *
+ * Emits one log block per call originating from the realunit-app — detected
+ * either via the `X-Client: realunit-app` header or a `/v{n}/realunit/*` path
+ * (the latter also covers app builds shipped before the header existed).
+ * Secrets are masked; KYC/PII bodies are kept intact by design.
+ */
+export function apiTraceMiddleware(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const client = req.headers[CLIENT_HEADER];
+    const clientStr = Array.isArray(client) ? client[0] : (client ?? '');
+
+    const isRealUnit = REALUNIT_CLIENT.test(clientStr) || REALUNIT_PATH.test(req.originalUrl);
+    if (!isRealUnit) return next();
+
+    const start = Date.now();
+    let responseBody: unknown;
+
+    const originalJson = res.json.bind(res);
+    res.json = (body: any) => {
+      responseBody = body;
+      return originalJson(body);
+    };
+
+    const originalSend = res.send.bind(res);
+    res.send = (body: any) => {
+      if (responseBody === undefined) responseBody = body;
+      return originalSend(body);
+    };
+
+    res.on('finish', () => {
+      const durationMs = Date.now() - start;
+      const block = [
+        `${req.method} ${req.originalUrl} → ${res.statusCode} (${durationMs}ms)  ` +
+          `client=${clientStr || '(none)'} ip=${req.realIp}`,
+        `  req.headers: ${format(req.headers)}`,
+        `  req.body:    ${format(req.body)}`,
+        `  res.body:    ${format(responseBody)}`,
+      ].join('\n');
+      logger.info(block);
+    });
+
+    next();
+  };
+}

--- a/src/shared/middlewares/api-trace.middleware.ts
+++ b/src/shared/middlewares/api-trace.middleware.ts
@@ -36,12 +36,14 @@ function format(value: unknown): string {
 }
 
 /**
- * DEV-only request/response tracer for the RealUnit internal test phase.
+ * Full request/response tracer for the RealUnit internal test phase.
+ * Enabled on DEV and PRD — see the environment gate in `main.ts`.
  *
  * Emits one log block per call originating from the realunit-app — detected
  * either via the `X-Client: realunit-app` header or a `/v{n}/realunit/*` path
  * (the latter also covers app builds shipped before the header existed).
- * Secrets are masked; KYC/PII bodies are kept intact by design.
+ * Secrets are masked; KYC/PII bodies are kept intact by design — on PRD this
+ * means real customer data is written to the container logs.
  */
 export function apiTraceMiddleware(): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
## Summary
- Adds an Express middleware (`src/shared/middlewares/api-trace.middleware.ts`) that logs full request/response detail for the RealUnit internal test phase.
- Scoped to calls from the realunit-app: detected via `X-Client: realunit-app` header **or** a `/v{n}/realunit/*` path.
- **Active on DEV and PRD** — gated in `main.ts`.
- Secrets masked (auth header, JWT/access tokens, signatures, credentials); long strings truncated. KYC/PII bodies kept intact by design — on PRD this writes real customer data to the container logs.
- Output goes to stdout → visible via `docker logs`.

## Context
Internal test phase of the RealUnit wallet starts in the next days; this gives central, immediate visibility into every app↔API call. Internal testers use the mainnet build, so tracing runs on PRD as well as DEV. The realunit-app side (sending the `X-Client` header) ships in a separate PR: DFXswiss/realunit-app#520.

## Test plan
- [ ] DEV/PRD deploy, `docker logs -f` the dfx-api container
- [ ] Trigger a `/v1/realunit/*` call → one `[RealUnitTrace]` block with method, URL, status, duration, bodies
- [ ] Verify `Authorization` / `signature` / `accessToken` show as `***`
- [ ] Verify non-RealUnit traffic is NOT logged