### PR TITLE
fix: circular JSON in buyCrypto update response

### DIFF
--- a/src/subdomains/core/buy-crypto/process/services/buy-crypto.service.ts
+++ b/src/subdomains/core/buy-crypto/process/services/buy-crypto.service.ts
@@ -414,7 +414,21 @@ export class BuyCryptoService implements OnModuleInit {
       await this.updateCryptoRouteVolume([cryptoRouteIdBefore, entity.cryptoRoute?.id]);
     if (dto.usedRef || dto.amountInEur) await this.updateRefVolume([usedRefBefore, entity.usedRef]);
 
-    return entity;
+    // reload without userData.kycSteps/users: TypeORM sets the inverse back-reference on those
+    // collections, producing a circular graph that breaks JSON serialization of the response
+    return this.buyCryptoRepo.findOne({
+      where: { id },
+      relations: {
+        buy: true,
+        cryptoRoute: true,
+        cryptoInput: true,
+        bankTx: true,
+        checkoutTx: true,
+        transaction: { user: { wallet: true }, userData: true },
+        chargebackOutput: true,
+        bankData: true,
+      },
+    });
   }
 
   private async changeRoute(entity: BuyCrypto, route: Buy | Swap) {


### PR DESCRIPTION
## Problem

`PUT /v1/buyCrypto/:id` (und `PUT /v1/buyCrypto/:id/amlCheck`) liefern auf PRD HTTP 500:

```
TypeError: Converting circular structure to JSON
  --> starting at object with constructor 'UserData'
  |   property 'kycSteps' -> object with constructor 'Array'
  |   index 7 -> object with constructor 'KycStep'
  --- property 'userData' closes the circle
```

## Ursache

`BuyCryptoController.update` gibt die rohe `BuyCrypto`-Entity zurück. `buyCryptoService.update()` lädt sie mit `transaction.userData.kycSteps`. TypeORM setzt beim Laden die Rückreferenz `KycStep.userData` auf den Parent → zyklischer Objektgraph → `JSON.stringify` in `res.json()` wirft.

`manualPassAmlCheck` delegiert an `update()` und ist damit identisch betroffen.

Die `kycSteps`-Relation kam per #3139 ("fix missing relation triggerVideoIdent") rein — **unabhängig** von der PostgreSQL-Migration. Es gibt keinen globalen `ClassSerializerInterceptor`, der Zyklen abfangen würde.

## Fix

`kycSteps` wird für die interne Update-Logik gebraucht, kann also nicht weggelassen werden. Daher lädt `update()` die Entity am Ende für die Response neu — ohne die zyklischen `userData`-Collections (`kycSteps`, `users`). Die Response-Felder bleiben sonst identisch.

## Test plan

- [ ] `PUT /v1/buyCrypto/{id}` für einen BuyCrypto, dessen `userData` KYC-Steps hat → 200 statt 500
- [ ] `PUT /v1/buyCrypto/{id}/amlCheck` → 200, AML-Logik unverändert
- [ ] Response enthält weiterhin buy/cryptoRoute/transaction/bankData etc.