### PR TITLE
ci: dispatch handbook rebuild on RealUnit mail changes

### DIFF
--- a/.github/workflows/notify-handbook-on-mail-change.yaml
+++ b/.github/workflows/notify-handbook-on-mail-change.yaml
@@ -1,0 +1,76 @@
+name: Notify RealUnit handbook on mail change
+
+# Pings DFXswiss/realunit-app (Handbook CI/CD) whenever the RealUnit mail
+# templates, the German i18n strings used by those templates, or the
+# preview-generator script itself change on develop.
+#
+# The realunit-app handbook image embeds an HTML preview of every customer
+# mail. Those previews are generated at handbook-build-time from THIS repo
+# (single source of truth) — see DFXswiss/api/scripts/generate-realunit-previews.js
+# and the consumer step in DFXswiss/realunit-app/.github/workflows/handbook.yaml
+# ("Generate RealUnit mail previews from api repo").
+#
+# Without this dispatch, a change to a mail template here would only land in
+# the handbook the next time someone pushed an unrelated commit to the
+# realunit-app repo — i.e. the handbook would drift behind production mail
+# content silently. With the dispatch, the handbook DEV+PRD deploy is
+# triggered immediately after the develop push that changed the mail.
+#
+# Path filter mirrors exactly what the generator script reads (verified via
+# `grep -E "readFileSync|require" scripts/generate-realunit-previews.js`):
+#   - mail-realunit.json  → RealUnit-specific i18n strings
+#   - mail.json           → DFX defaults, used as fallback for missing keys
+#   - realunit.hbs        → the Handlebars template itself
+#   - generate-realunit-previews.js → wiring (also covers index/wrapping)
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'src/shared/i18n/de/mail-realunit.json'
+      - 'src/shared/i18n/de/mail.json'
+      - 'src/subdomains/supporting/notification/templates/realunit.hbs'
+      - 'scripts/generate-realunit-previews.js'
+      - '.github/workflows/notify-handbook-on-mail-change.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize so a burst of mail-template commits collapses into a single
+# handbook rebuild rather than queuing up N parallel deploys (each one would
+# rebuild the same handbook image and race on Docker Hub :beta).
+concurrency:
+  group: notify-handbook-mails
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Send repository_dispatch to realunit-app
+    runs-on: ubuntu-latest
+    steps:
+      # peter-evans/repository-dispatch is the standard wrapper used across
+      # the org for cross-repo dispatches. Pinned to a major tag so a
+      # behaviour change in a future major is opt-in.
+      - name: Trigger handbook rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          # PAT (classic, scope: repo) for DFXswiss/realunit-app. Stored as a
+          # repository secret in DFXswiss/api so this workflow can dispatch
+          # into the realunit-app repo (the default GITHUB_TOKEN of THIS
+          # workflow is scoped to THIS repo and cannot trigger workflows in
+          # another repo, even within the same org).
+          token: ${{ secrets.HANDBOOK_DISPATCH_TOKEN }}
+          repository: DFXswiss/realunit-app
+          event-type: mails-updated
+          # Small payload that ends up in the receiver's
+          # github.event.client_payload — useful for tracing back which commit
+          # caused a rebuild when triaging a regression.
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "source_sha": "${{ github.sha }}",
+              "source_ref": "${{ github.ref }}",
+              "source_actor": "${{ github.actor }}",
+              "source_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/notify-handbook-on-mail-change.yaml
+++ b/.github/workflows/notify-handbook-on-mail-change.yaml
@@ -66,11 +66,23 @@ jobs:
           # Small payload that ends up in the receiver's
           # github.event.client_payload — useful for tracing back which commit
           # caused a rebuild when triaging a regression.
+          #
+          # Each value is wrapped in `toJSON(...)` (which emits a fully
+          # JSON-escaped string *including* the surrounding double-quotes),
+          # rather than the simpler "${{ ... }}" interpolation. Most of these
+          # fields are safe by construction today (github.actor is a GitHub
+          # username, refs/sha are constrained character sets), but
+          # github.actor in particular can legally contain '[' / ']' (bot
+          # accounts like `dependabot[bot]`) and refs can include characters
+          # that would need escaping. toJSON() makes the payload robust to
+          # any future GitHub-side widening of those character sets, at zero
+          # cost. Note: NO surrounding quotes around `${{ toJSON(...) }}` —
+          # toJSON already supplies them.
           client-payload: |
             {
-              "source_repo": "${{ github.repository }}",
-              "source_sha": "${{ github.sha }}",
-              "source_ref": "${{ github.ref }}",
-              "source_actor": "${{ github.actor }}",
-              "source_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "source_repo": ${{ toJSON(github.repository) }},
+              "source_sha": ${{ toJSON(github.sha) }},
+              "source_ref": ${{ toJSON(github.ref) }},
+              "source_actor": ${{ toJSON(github.actor) }},
+              "source_run_url": ${{ toJSON(format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id)) }}
             }

--- a/scripts/generate-realunit-previews.js
+++ b/scripts/generate-realunit-previews.js
@@ -4,6 +4,24 @@
  * Uses RealUnit translations with fallback to DFX defaults (same as production).
  * Usage: node scripts/generate-realunit-previews.js
  * Output: scripts/email-previews/realunit/
+ *
+ * CROSS-REPO COUPLING — read before adding a language/locale
+ * ----------------------------------------------------------
+ * This script is also invoked from the DFXswiss/realunit-app handbook build
+ * (.github/workflows/handbook.yaml → step "Generate RealUnit mail previews
+ * from api repo"). Whenever you add a NEW locale here (e.g. a French
+ * mail-realunit-fr.json + a French generator-output directory), you MUST
+ * also widen the `paths:` filter in this repo's
+ * .github/workflows/notify-handbook-on-mail-change.yaml — otherwise a
+ * commit that only touches the new locale will not fire the
+ * repository_dispatch and the handbook will silently fall behind. The
+ * filter currently lists the German files explicitly by path; it does not
+ * use a wildcard, because we want every locale add to be a deliberate edit
+ * to both files in the same PR.
+ *
+ * The realunit-app side ALSO has a hard-coded mail-count check
+ * (EXPECTED_HTML_COUNT) — adding/removing a mail here without bumping
+ * that count over there will fail the handbook build. That is intentional.
  */
 
 const fs = require('fs');


### PR DESCRIPTION
## Summary

Neuer Workflow `notify-handbook-on-mail-change.yaml`: bei Push auf `develop` mit Änderungen an einem der Mail-relevanten Files (`mail-realunit.json`, `mail.json`, `realunit.hbs`, `generate-realunit-previews.js`) sendet ein `repository_dispatch` `mails-updated` an `DFXswiss/realunit-app` → triggert dort den Handbook-Deploy DEV→PRD.

Plus Doc-Block-Kommentar im Generator-Script, der Cross-Repo-Coupling explizit macht (Locale-Extension Pflicht-Update am Pfad-Filter).

Gegenstück: **https://github.com/DFXswiss/realunit-app/pull/537**

## Änderungen

- `.github/workflows/notify-handbook-on-mail-change.yaml` (neu) — `repository_dispatch` via `peter-evans/repository-dispatch@v3`; `client-payload` Felder via `toJSON()` wrapped; `concurrency: notify-handbook-mails` kollabiert Bursts
- `scripts/generate-realunit-previews.js` — Docblock mit CROSS-REPO-COUPLING-Hinweis (Locale-Extension → Pfad-Filter aktualisieren, `EXPECTED_HTML_COUNT` im realunit-app workflow erhöhen)

## Path-Filter

Genau die Files die das Generator-Script via `readFileSync`/`require` liest:
- `src/shared/i18n/de/mail-realunit.json` — RealUnit Translations
- `src/shared/i18n/de/mail.json` — DFX-Fallback (Script liest beide!)
- `src/subdomains/supporting/notification/templates/realunit.hbs` — Handlebars-Template
- `scripts/generate-realunit-previews.js` — Generator selbst

## Secrets-Setup

**Du musst in DFXswiss/api als Repository-Secret anlegen:**

| Secret-Name | Type | Scope |
|---|---|---|
| `HANDBOOK_DISPATCH_TOKEN` | Classic PAT | `repo` scope auf `DFXswiss/realunit-app` (für `repository_dispatch`) |

Im realunit-app Repo ist **kein** Secret nötig (api ist public, default `GITHUB_TOKEN` reicht für den checkout).

## Test plan

- [ ] Push einer No-Op-Änderung an z.B. `mail-realunit.json` auf develop nach Merge → workflow-Run sichtbar
- [ ] realunit-app Actions: `Handbook CI/CD` Run via `repository_dispatch` sichtbar, baut + deployt DEV→PRD